### PR TITLE
Generate Kustomize patch for image tag vars 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ undeploy:
 .PHONY: manifests
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
-	printf "CORE_IMG=%s\nDATASOURCE_IMG=%s\nGRAFANA_IMG=%s\n" "$(CORE_IMG)" "$(DATASOURCE_IMG)" "$(GRAFANA_IMG)" > config/manager/imagetags.env
+	envsubst < hack/image_tag_patch.yaml.in > config/default/image_tag_patch.yaml
 
 # Run go fmt against code
 .PHONY: fmt

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ simply, `make create_cryostat_cr`.
 
 The container images used by the operator for the core application,
 jfr-datasource, and the Grafana dashboard can be overridden by setting the
-`CORE_IMG`, `DATASOURCE_IMG`, and `GRAFANA_IMG` environment variables,
-respectively, in the operator deployment.
+`RELATED_IMAGE_CORE`, `RELATED_IMAGE_DATASOURCE`, and `RELATED_IMAGE_GRAFANA`
+environment variables, respectively, in the operator deployment.
 
 ## Security
 

--- a/bundle/manifests/cryostat-operator-manager-env_v1_configmap.yaml
+++ b/bundle/manifests/cryostat-operator-manager-env_v1_configmap.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-data:
-  CORE_IMG: quay.io/cryostat/cryostat:1.0.0-BETA6
-  DATASOURCE_IMG: quay.io/cryostat/jfr-datasource:1.0.0-BETA6
-  GRAFANA_IMG: quay.io/cryostat/cryostat-grafana-dashboard:1.0.0-BETA3
-kind: ConfigMap
-metadata:
-  name: cryostat-operator-manager-env

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -271,13 +271,16 @@ spec:
                 command:
                 - /manager
                 env:
+                - name: RELATED_IMAGE_CORE
+                  value: quay.io/cryostat/cryostat:1.0.0-BETA6
+                - name: RELATED_IMAGE_DATASOURCE
+                  value: quay.io/cryostat/jfr-datasource:1.0.0-BETA6
+                - name: RELATED_IMAGE_GRAFANA
+                  value: quay.io/cryostat/cryostat-grafana-dashboard:1.0.0-BETA3
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                envFrom:
-                - configMapRef:
-                    name: cryostat-operator-manager-env
                 image: quay.io/cryostat/cryostat-operator:1.0.0-beta5
                 livenessProbe:
                   httpGet:

--- a/config/default/image_tag_patch.yaml
+++ b/config/default/image_tag_patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: RELATED_IMAGE_CORE
+          value: "quay.io/cryostat/cryostat:1.0.0-BETA6"
+        - name: RELATED_IMAGE_DATASOURCE
+          value: "quay.io/cryostat/jfr-datasource:1.0.0-BETA6"
+        - name: RELATED_IMAGE_GRAFANA
+          value: "quay.io/cryostat/cryostat-grafana-dashboard:1.0.0-BETA3"

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -25,6 +25,7 @@ bases:
 #- ../prometheus
 
 patchesStrategicMerge:
+- image_tag_patch.yaml
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.

--- a/config/manager/imagetags.env
+++ b/config/manager/imagetags.env
@@ -1,3 +1,0 @@
-CORE_IMG=quay.io/cryostat/cryostat:1.0.0-BETA6
-DATASOURCE_IMG=quay.io/cryostat/jfr-datasource:1.0.0-BETA6
-GRAFANA_IMG=quay.io/cryostat/cryostat-grafana-dashboard:1.0.0-BETA3

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,9 +8,6 @@ configMapGenerator:
 - files:
   - controller_manager_config.yaml
   name: manager-config
-- envs:
-  - imagetags.env
-  name: manager-env
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,7 +44,4 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        envFrom:
-        - configMapRef:
-            name: manager-env
       terminationGracePeriodSeconds: 10

--- a/controllers/cryostat_controller.go
+++ b/controllers/cryostat_controller.go
@@ -82,13 +82,13 @@ type CryostatReconciler struct {
 const cryostatFinalizer = "operator.cryostat.io/cryostat.finalizer"
 
 // Environment variable to override the core application image
-const coreImageTagEnv = "CORE_IMG"
+const coreImageTagEnv = "RELATED_IMAGE_CORE"
 
 // Environment variable to override the JFR datasource image
-const datasourceImageTagEnv = "DATASOURCE_IMG"
+const datasourceImageTagEnv = "RELATED_IMAGE_DATASOURCE"
 
 // Environment variable to override the Grafana dashboard image
-const grafanaImageTagEnv = "GRAFANA_IMG"
+const grafanaImageTagEnv = "RELATED_IMAGE_GRAFANA"
 
 // +kubebuilder:rbac:namespace=system,groups="",resources=pods;services;services/finalizers;endpoints;persistentvolumeclaims;events;configmaps;secrets,verbs=*
 // +kubebuilder:rbac:namespace=system,groups=route.openshift.io,resources=routes;routes/custom-host,verbs=*

--- a/hack/image_tag_patch.yaml.in
+++ b/hack/image_tag_patch.yaml.in
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: RELATED_IMAGE_CORE
+          value: "${CORE_IMG}"
+        - name: RELATED_IMAGE_DATASOURCE
+          value: "${DATASOURCE_IMG}"
+        - name: RELATED_IMAGE_GRAFANA
+          value: "${GRAFANA_IMG}"

--- a/test/reconciler.go
+++ b/test/reconciler.go
@@ -111,13 +111,13 @@ func newTestOSUtils(config *TestReconcilerConfig) *testOSUtils {
 		envs["DISABLE_SERVICE_TLS"] = strconv.FormatBool(*config.DisableTLS)
 	}
 	if config.CoreImageTag != nil {
-		envs["CORE_IMG"] = *config.CoreImageTag
+		envs["RELATED_IMAGE_CORE"] = *config.CoreImageTag
 	}
 	if config.DatasourceImageTag != nil {
-		envs["DATASOURCE_IMG"] = *config.DatasourceImageTag
+		envs["RELATED_IMAGE_DATASOURCE"] = *config.DatasourceImageTag
 	}
 	if config.GrafanaImageTag != nil {
-		envs["GRAFANA_IMG"] = *config.GrafanaImageTag
+		envs["RELATED_IMAGE_GRAFANA"] = *config.GrafanaImageTag
 	}
 	return &testOSUtils{envs}
 }


### PR DESCRIPTION
Builds with OSBS attempt to pin image tags to specific digests. In order to find the images used by our operator, they have to be defined in a predetermined location in the CSV [1]. In our case, this means our environment variables need to be renamed and can no longer refer to a config map for their values.

Unfortunately, Kustomize doesn't appear to have a nice way to handle this scenario. I ended up placing a template patch in our `hack` directory and using `envsubst` to fill in the image tags with the values from our Makefile. The resulting patch goes into the `config/default` Kustomize directory, which then gets picked up by the `deploy` and `bundle` targets. I'm not sure whether we should add `envsubst` to the list of dependencies in the README, or if it's considered a common enough shell utility.

[1] https://osbs.readthedocs.io/en/latest/users.html#pullspec-locations