### PR TITLE
Update mounted directories/paths for latest Cryostat upstream

### DIFF
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -225,6 +225,10 @@ func NewPodForCR(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, imageTags *I
 }
 
 func NewCoreContainer(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, imageTag string, tls *TLSConfig) corev1.Container {
+	configPath := "/opt/cryostat.d/conf.d"
+	archivePath := "/opt/cryostat.d/recordings.d"
+	templatesPath := "/opt/cryostat.d/templates.d"
+	clientlibPath := "/opt/cryostat.d/clientlib.d"
 	envs := []corev1.EnvVar{
 		{
 			Name:  "CRYOSTAT_SSL_PROXIED",
@@ -243,8 +247,20 @@ func NewCoreContainer(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, imageTa
 			Value: "9090",
 		},
 		{
+			Name:  "CRYOSTAT_CONFIG_PATH",
+			Value: configPath,
+		},
+		{
+			Name:  "CRYOSTAT_ARCHIVE_PATH",
+			Value: archivePath,
+		},
+		{
 			Name:  "CRYOSTAT_TEMPLATE_PATH",
-			Value: "/templates",
+			Value: templatesPath,
+		},
+		{
+			Name:  "CRYOSTAT_CLIENTLIB_PATH",
+			Value: clientlibPath,
 		},
 	}
 	if specs.CoreURL != nil {
@@ -286,13 +302,28 @@ func NewCoreContainer(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, imageTa
 	mounts := []corev1.VolumeMount{
 		{
 			Name:      cr.Name,
-			MountPath: "flightrecordings",
+			MountPath: configPath,
+			SubPath:   "config",
+		},
+		{
+			Name:      cr.Name,
+			MountPath: archivePath,
 			SubPath:   "flightrecordings",
 		},
 		{
 			Name:      cr.Name,
-			MountPath: "templates",
+			MountPath: templatesPath,
 			SubPath:   "templates",
+		},
+		{
+			Name:      cr.Name,
+			MountPath: clientlibPath,
+			SubPath:   "clientlib",
+		},
+		{
+			Name:      cr.Name,
+			MountPath: "truststore",
+			SubPath:   "truststore",
 		},
 	}
 

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -748,8 +748,20 @@ func NewCoreEnvironmentVariables(minimal bool, tls bool) []corev1.EnvVar {
 			Value: "cryostat-command.example.com",
 		},
 		{
+			Name:  "CRYOSTAT_CONFIG_PATH",
+			Value: "/opt/cryostat.d/conf.d",
+		},
+		{
+			Name:  "CRYOSTAT_ARCHIVE_PATH",
+			Value: "/opt/cryostat.d/recordings.d",
+		},
+		{
 			Name:  "CRYOSTAT_TEMPLATE_PATH",
-			Value: "/templates",
+			Value: "/opt/cryostat.d/templates.d",
+		},
+		{
+			Name:  "CRYOSTAT_CLIENTLIB_PATH",
+			Value: "/opt/cryostat.d/clientlib.d",
 		},
 	}
 	if !minimal {
@@ -848,14 +860,32 @@ func NewCoreVolumeMounts(tls bool) []corev1.VolumeMount {
 		{
 			Name:      "cryostat",
 			ReadOnly:  false,
-			MountPath: "flightrecordings",
+			MountPath: "/opt/cryostat.d/conf.d",
+			SubPath:   "config",
+		},
+		{
+			Name:      "cryostat",
+			ReadOnly:  false,
+			MountPath: "/opt/cryostat.d/recordings.d",
 			SubPath:   "flightrecordings",
 		},
 		{
 			Name:      "cryostat",
 			ReadOnly:  false,
-			MountPath: "templates",
+			MountPath: "/opt/cryostat.d/templates.d",
 			SubPath:   "templates",
+		},
+		{
+			Name:      "cryostat",
+			ReadOnly:  false,
+			MountPath: "/opt/cryostat.d/clientlib.d",
+			SubPath:   "clientlib",
+		},
+		{
+			Name:      "cryostat",
+			ReadOnly:  false,
+			MountPath: "truststore",
+			SubPath:   "truststore",
 		},
 	}
 	if tls {


### PR DESCRIPTION
Fixes #209

Mounted directories and paths changed in latest Cryostat upstream due to additions of persisted credentials and serialized automatic rules