### PR TITLE
chore(images): update image versions to latest development builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 # Current Operator version
-IMAGE_VERSION ?= 1.0.0
+IMAGE_VERSION ?= 2.0.0-dev
 BUNDLE_VERSION ?= $(IMAGE_VERSION)
 DEFAULT_NAMESPACE ?= quay.io/cryostat
 IMAGE_NAMESPACE ?= $(DEFAULT_NAMESPACE)
@@ -28,7 +28,7 @@ CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 # Images used by the operator
 CORE_NAMESPACE ?= $(DEFAULT_NAMESPACE)
 CORE_NAME ?= cryostat
-CORE_VERSION ?= 1.0.0
+CORE_VERSION ?= 2.0.0-SNAPSHOT
 export CORE_IMG ?= $(CORE_NAMESPACE)/$(CORE_NAME):$(CORE_VERSION)
 DATASOURCE_NAMESPACE ?= $(DEFAULT_NAMESPACE)
 DATASOURCE_NAME ?= jfr-datasource

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -5,11 +5,10 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=cryostat-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=stable-1.0
-LABEL operators.operatorframework.io.bundle.channel.default.v1=stable-1.0
-LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.4.0+git
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -64,7 +64,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: github.com/cryostatio/cryostat-operator
     support: Cryostat Community
-  name: cryostat-operator.v1.0.0
+  name: cryostat-operator.v2.0.0-dev
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -268,7 +268,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_CORE
-                  value: quay.io/cryostat/cryostat:1.0.0
+                  value: quay.io/cryostat/cryostat:2.0.0-SNAPSHOT
                 - name: RELATED_IMAGE_DATASOURCE
                   value: quay.io/cryostat/jfr-datasource:1.0.0
                 - name: RELATED_IMAGE_GRAFANA
@@ -277,7 +277,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/cryostat/cryostat-operator:1.0.0
+                image: quay.io/cryostat/cryostat-operator:2.0.0-dev
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -498,4 +498,4 @@ spec:
   maturity: stable
   provider:
     name: The Cryostat Community
-  version: 1.0.0
+  version: 2.0.0-dev

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -4,11 +4,10 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: cryostat-operator
-  operators.operatorframework.io.bundle.channels.v1: stable-1.0
-  operators.operatorframework.io.bundle.channel.default.v1: stable-1.0
-  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.bundle.channels.v1: alpha
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.4.0+git
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/config/default/image_tag_patch.yaml
+++ b/config/default/image_tag_patch.yaml
@@ -10,7 +10,7 @@ spec:
       - name: manager
         env:
         - name: RELATED_IMAGE_CORE
-          value: "quay.io/cryostat/cryostat:1.0.0"
+          value: "quay.io/cryostat/cryostat:2.0.0-SNAPSHOT"
         - name: RELATED_IMAGE_DATASOURCE
           value: "quay.io/cryostat/jfr-datasource:1.0.0"
         - name: RELATED_IMAGE_GRAFANA

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/cryostat/cryostat-operator
-  newTag: 1.0.0
+  newTag: 2.0.0-dev

--- a/internal/controllers/common/resource_definitions/imagetag_generated.go
+++ b/internal/controllers/common/resource_definitions/imagetag_generated.go
@@ -2,7 +2,7 @@
 package resource_definitions
 
 // Default image tag for the core application image
-const DefaultCoreImageTag = "quay.io/cryostat/cryostat:1.0.0"
+const DefaultCoreImageTag = "quay.io/cryostat/cryostat:2.0.0-SNAPSHOT"
 
 // Default image tag for the JFR datasource image
 const DefaultDatasourceImageTag = "quay.io/cryostat/jfr-datasource:1.0.0"


### PR DESCRIPTION
This PR updates the operator image version to `2.0.0-dev`, the `-dev` suffix indicating this version is still under development. Likewise the Cryostat image tag has been updated to `2.0.0-SNAPSHOT`. This ensures the operator's development builds always deploy the latest development build of Cryostat.