### PR TITLE
ci(release-drafter): generate release notes drafts

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,46 @@
+categories:
+    - title: 'Features'
+      label: 'feat'
+    - title: 'Fixes'
+      label: 'fix'
+    - title: 'Documentation'
+      label: 'docs'
+    - title: 'Maintenance'
+      labels:
+          - 'chore'
+          - 'ci'
+          - 'cleanup'
+          - 'perf'
+          - 'refactor'
+          - 'style'
+          - 'test'
+
+autolabeler:
+    - label: 'feat'
+      title: '/^feat:/'
+    - label: 'fix'
+      title: '/^fix:/'
+    - label: 'docs'
+      title: '/^docs:/'
+
+    - label: 'chore'
+      title: '/^chore:/'
+    - label: 'ci'
+      title: '/^ci:/'
+    - label: 'cleanup'
+      title: '/^cleanup:/'
+    - label: 'perf'
+      title: '/^perf:/'
+    - label: 'refactor'
+      title: '/^refactor:/'
+    - label: 'style'
+      title: '/^style:/'
+    - label: 'test'
+      title: '/^test:/'
+
+template: |
+    ## Contributors
+    $CONTRIBUTORS
+    ## What's Changed
+    $CHANGES
+

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,23 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - main
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Copy the release-drafter configuration from `cryostatio/cryostat` to generate release notes for the operator. The files have been copied as-is.

Relates: #214 