### PR TITLE
ci(quay): push CI builds to Quay

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,4 +50,3 @@ jobs:
     - name: Print image URL
       run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
       if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
-

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,8 +29,8 @@ jobs:
     - name: Get image tag
       id: image-tag
       run: |
-        IMG="$(make --eval='print-img: ; @echo $(IMG)' print-img)"
-        echo "::set-output name=img-tag::$IMG"
+        IMG_TAG="$(make --eval='print-img-ver: ; @echo $(IMAGE_VERSION)' print-img-ver)"
+        echo "::set-output name=tag::$IMG_TAG"
       if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
     - name: Push to quay.io
       id: push-to-quay
@@ -38,7 +38,7 @@ jobs:
       with:
         image: cryostat-operator
         tags: >
-          ${{ steps.image-tag.outputs.image-tag }}
+          ${{ steps.image-tag.outputs.tag }}
           latest
         registry: quay.io/cryostat
         username: cryostat+bot

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
       id: push-to-quay
       uses: redhat-actions/push-to-registry@v2
       with:
-        image: cryostat
+        image: cryostat-operator
         tags: >
           ${{ steps.image-tag.outputs.image-tag }}
           latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,3 +26,25 @@ jobs:
       with:
         operator-sdk-version: v1.5.0
     - run: make oci-build
+    - name: Get image tag
+      id: image-tag
+      run: |
+        IMG="$(make --eval='print-img: ; @echo $(IMG)' print-img)"
+        echo "::set-output name=img-tag::$IMG"
+      if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
+    - name: Push to quay.io
+      id: push-to-quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: cryostat
+        tags: >
+          ${{ steps.image-tag.outputs.image-tag }}
+          latest
+        registry: quay.io/cryostat
+        username: cryostat+bot
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+      if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
+    - name: Print image URL
+      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+      if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      OPERATOR_IMG: quay.io/cryostat/cryostat-operator
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
@@ -26,11 +28,12 @@ jobs:
       with:
         operator-sdk-version: v1.5.0
     - run: make oci-build
-    - name: Get image tag
-      id: image-tag
+    - name: Tag image
+      id: tag-image
       run: |
         IMG_TAG="$(make --eval='print-img-ver: ; @echo $(IMAGE_VERSION)' print-img-ver)"
         echo "::set-output name=tag::$IMG_TAG"
+        podman tag ${{ env.OPERATOR_IMG }}:$IMG_TAG ${{ env.OPERATOR_IMG }}:latest
       if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
     - name: Push to quay.io
       id: push-to-quay
@@ -38,7 +41,7 @@ jobs:
       with:
         image: cryostat-operator
         tags: >
-          ${{ steps.image-tag.outputs.tag }}
+          ${{ steps.tag-image.outputs.tag }}
           latest
         registry: quay.io/cryostat
         username: cryostat+bot

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,4 +25,4 @@ jobs:
     - uses: jpkrohling/setup-operator-sdk@v1.1.0
       with:
         operator-sdk-version: v1.5.0
-    - run: make generate manifests manager test-envtest
+    - run: make oci-build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,10 @@ jobs:
     - uses: jpkrohling/setup-operator-sdk@v1.1.0
       with:
         operator-sdk-version: v1.5.0
+    - run: make generate manifests manager test-envtest
+      if: ${{ github.event_name == 'pull_request' }}
     - run: make oci-build
+      if: ${{ github.event_name == 'push' }}
     - name: Tag image
       id: tag-image
       run: |


### PR DESCRIPTION
This PR adds a Github workflow to push CI builds to Quay when PRs are merged. This is fairly similar to the implementation in the Cryostat repo, but the method for figuring out the image tag is different. This one is using Make's `--eval` argument to invoke a rule to print the `IMAGE_VERSION` Makefile variable.

The build targets for both PRs and pushes have been changed to `oci-build`, which is the same as before but also builds a container image. This slows down the job a bit, but we can maybe look into caching intermediate container layers. Another possibility is we split up the build step into different PR and push steps, where only the later does the container build.

Some example jobs using my fork and Quay repository:
PR: https://github.com/ebaron/cryostat-operator/actions/runs/1056438894
Push: https://github.com/ebaron/cryostat-operator/actions/runs/1056500603

Relates to: #214 