### PR TITLE
chore(version): fix CSV metadata for 2.0.0-dev

### DIFF
--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -57,7 +57,7 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Monitoring, Developer Tools
-    containerImage: quay.io/cryostat/cryostat-operator:1.0.0
+    containerImage: quay.io/cryostat/cryostat-operator:2.0.0-dev
     createdAt: "2021-04-30 00:00:00"
     description: JVM monitoring and profiling tool
     operators.operatorframework.io/builder: operator-sdk-v1.4.0+git

--- a/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
@@ -50,7 +50,7 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Monitoring, Developer Tools
-    containerImage: quay.io/cryostat/cryostat-operator:1.0.0
+    containerImage: quay.io/cryostat/cryostat-operator:2.0.0-dev
     createdAt: "2021-04-30 00:00:00"
     description: JVM monitoring and profiling tool
     operators.operatorframework.io/builder: operator-sdk-v1.5.0
@@ -258,4 +258,4 @@ spec:
   maturity: stable
   provider:
     name: The Cryostat Community
-  version: 1.0.0
+  version: 2.0.0-dev


### PR DESCRIPTION
Fix some spots in the CSV that were missed when bumping the version to 2.0.0-dev.