### PR TITLE
feat(security): create reduced permissions ServiceAccount for Cryostat

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,9 +6,9 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=cryostat-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.4.0+git
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
-LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1

--- a/bundle/manifests/cryostat-operator-cryostat_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/cryostat-operator-cryostat_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: cryostat-operator-cryostat
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - selfsubjectaccessreviews
+  verbs:
+  - create

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -238,6 +238,18 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - selfsubjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
           - console.openshift.io
           resources:
           - consolelinks
@@ -247,6 +259,17 @@ spec:
           - get
           - list
           - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
         serviceAccountName: cryostat-operator-service-account
       deployments:
       - name: cryostat-operator-controller-manager
@@ -330,6 +353,7 @@ spec:
           - persistentvolumeclaims
           - pods
           - secrets
+          - serviceaccounts
           - services
           - services/finalizers
           verbs:
@@ -461,6 +485,18 @@ spec:
           - get
           - patch
           - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
         - apiGroups:
           - route.openshift.io
           resources:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,9 +5,9 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: cryostat-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.4.0+git
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
-  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/config/rbac/cryostat_role.yaml
+++ b/config/rbac/cryostat_role.yaml
@@ -1,0 +1,19 @@
+# Permissions for Cryostat to validate tokens and check permissions
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: cryostat
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - selfsubjectaccessreviews
+  verbs:
+  - create

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -3,6 +3,7 @@ resources:
 - cluster_role_binding.yaml
 - role_binding.yaml
 - service_account.yaml
+- cryostat_role.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
 # Comment the following 4 lines if you want to disable

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,18 @@ metadata:
   name: role
 rules:
 - apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - selfsubjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - console.openshift.io
   resources:
   - consolelinks
@@ -16,6 +28,17 @@ rules:
   - get
   - list
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -34,6 +57,7 @@ rules:
   - persistentvolumeclaims
   - pods
   - secrets
+  - serviceaccounts
   - services
   - services/finalizers
   verbs:
@@ -165,6 +189,18 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - route.openshift.io
   resources:

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -47,6 +47,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1100,6 +1101,77 @@ func NewNetworkConfiguration(svcName string, svcPort int32) operatorv1beta1.Netw
 					},
 				},
 			},
+		},
+	}
+}
+
+func NewServiceAccount() *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cryostat",
+			Namespace: "default",
+		},
+	}
+}
+
+func NewRole() *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cryostat",
+			Namespace: "default",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     []string{"get", "list", "watch"},
+				APIGroups: []string{""},
+				Resources: []string{"endpoints"},
+			},
+			{
+				Verbs:     []string{"get", "list"},
+				APIGroups: []string{"route.openshift.io"},
+				Resources: []string{"routes"},
+			},
+		},
+	}
+}
+
+func NewRoleBinding() *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cryostat",
+			Namespace: "default",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      "cryostat",
+				Namespace: "default",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     "cryostat",
+		},
+	}
+}
+
+func NewClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cryostat-9ecd5050500c2566765bc593edfcce12434283e5da32a27476bc4a1569304a02",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      "cryostat",
+				Namespace: "default",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "cryostat-operator-cryostat",
 		},
 	}
 }


### PR DESCRIPTION
Currently, the operator configures the Cryostat deployment to use the operator's own Service Account. The vast majority of the permissions the operator requires are not needed by Cryostat. This PR creates a separate set of RBAC objects for Cryostat to use.

The operator creates an additional ClusterRole with permissions to create TokenReviews and SelfSubjectAccessReviews.

Each Cryostat CR gets its own:
* ServiceAccount
* Role, with read access to Endpoints and Routes
* RoleBinding to bind the Role to its ServiceAccount
* ClusterRoleBinding to bind the shared ClusterRole to its ServiceAccount

In order to ensure that the cluster-scoped ClusterRoleBinding doesn't suffer a name collision, the operator creates it with the following name: `cryostat-hhhh` where `hhhh` is SHA256 sum of the CR's `namespace/name`. Since this is cluster-scoped, the binding can't be owned by the Cryostat CR and thus can't be garbage collected. Instead, it's deleted using the existing finalizer logic in the Cryostat controller.

Fixes: #221
Depends on: https://github.com/cryostatio/cryostat/pull/599