### PR TITLE
fix(openshift): ensure ConsoleLink is not duplicated

### DIFF
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -757,18 +757,11 @@ func NewClusterRoleBindingForCR(cr *operatorv1beta1.Cryostat) *rbacv1.ClusterRol
 	}
 }
 
-const ConsoleLinkNSLabel = "operator.cryostat.io/cryostat-consolelink-namespace"
-const ConsoleLinkNameLabel = "operator.cryostat.io/cryostat-consolelink-name"
-
 func NewConsoleLink(cr *operatorv1beta1.Cryostat, url string) *consolev1.ConsoleLink {
-	// Cluster scoped, so use generated name to avoid conflicts. Look up using labels.
+	// Cluster scoped, so use a unique name to avoid conflicts
 	return &consolev1.ConsoleLink{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "cryostat-",
-			Labels: map[string]string{
-				ConsoleLinkNSLabel:   cr.Namespace,
-				ConsoleLinkNameLabel: cr.Name,
-			},
+			Name: clusterUniqueName(cr),
 		},
 		Spec: consolev1.ConsoleLinkSpec{
 			Link: consolev1.Link{

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -1175,3 +1175,21 @@ func NewClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 		},
 	}
 }
+
+func NewConsoleLink() *consolev1.ConsoleLink {
+	return &consolev1.ConsoleLink{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cryostat-9ecd5050500c2566765bc593edfcce12434283e5da32a27476bc4a1569304a02",
+		},
+		Spec: consolev1.ConsoleLinkSpec{
+			Link: consolev1.Link{
+				Text: "Cryostat",
+				Href: "https://cryostat.example.com",
+			},
+			Location: consolev1.NamespaceDashboard,
+			NamespaceDashboard: &consolev1.NamespaceDashboardSpec{
+				Namespaces: []string{"default"},
+			},
+		},
+	}
+}


### PR DESCRIPTION
This PR changes the naming scheme of the ConsoleLink from using `GenerateName` to using a suffix of the SHA256 sum of the associated Cryostat CR's `namespace/name`. This ensures the ConsoleLink name is known and reproducible across reconciles, and eliminates the possibility of two instances being created due to the caching behaviour of the Kubernetes client.

Fixes: #163 