### PR TITLE
ci(quay): apply latest tag only in main 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,17 +35,21 @@ jobs:
       id: tag-image
       run: |
         IMG_TAG="$(make --eval='print-img-ver: ; @echo $(IMAGE_VERSION)' print-img-ver)"
-        echo "::set-output name=tag::$IMG_TAG"
-        podman tag ${{ env.OPERATOR_IMG }}:$IMG_TAG ${{ env.OPERATOR_IMG }}:latest
+        if [ "$GITHUB_REF" == "refs/heads/main" ]; then
+          podman tag \
+          ${{ env.OPERATOR_IMG }}:$IMG_TAG \
+          ${{ env.OPERATOR_IMG }}:latest
+          echo "::set-output name=tags::$IMG_TAG latest"
+        else
+          echo "::set-output name=tags::$IMG_TAG"
+        fi
       if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
     - name: Push to quay.io
       id: push-to-quay
       uses: redhat-actions/push-to-registry@v2
       with:
         image: cryostat-operator
-        tags: >
-          ${{ steps.tag-image.outputs.tag }}
-          latest
+        tags: ${{ steps.tag-image.outputs.tags }}
         registry: quay.io/cryostat
         username: cryostat+bot
         password: ${{ secrets.REGISTRY_PASSWORD }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,16 @@ name: CI build
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - v[0-9]+
+      - v[0-9]+.[0-9]+
+
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - v[0-9]+
+      - v[0-9]+.[0-9]+
 
 jobs:
   build:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,8 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - main
+      - v[0-9]+
+      - v[0-9]+.[0-9]+
   # pull_request event is required only for autolabeler
   pull_request:
     # Only following types are handled by the action, but one can default to all as well


### PR DESCRIPTION
This follows the same approach taken in https://github.com/cryostatio/cryostat/pull/604. There's a conditional where the built images are only tagged and pushed as `latest` if the branch is `main`. I also updated the PR/push events to work with any vX or vX.Y branch. This should make the workflows more backport friendly.

Relates to #223