### PR TITLE
ci: sync CI workflows from main

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,46 @@
+categories:
+    - title: 'Features'
+      label: 'feat'
+    - title: 'Fixes'
+      label: 'fix'
+    - title: 'Documentation'
+      label: 'docs'
+    - title: 'Maintenance'
+      labels:
+          - 'chore'
+          - 'ci'
+          - 'cleanup'
+          - 'perf'
+          - 'refactor'
+          - 'style'
+          - 'test'
+
+autolabeler:
+    - label: 'feat'
+      title: '/^feat:/'
+    - label: 'fix'
+      title: '/^fix:/'
+    - label: 'docs'
+      title: '/^docs:/'
+
+    - label: 'chore'
+      title: '/^chore:/'
+    - label: 'ci'
+      title: '/^ci:/'
+    - label: 'cleanup'
+      title: '/^cleanup:/'
+    - label: 'perf'
+      title: '/^perf:/'
+    - label: 'refactor'
+      title: '/^refactor:/'
+    - label: 'style'
+      title: '/^style:/'
+    - label: 'test'
+      title: '/^test:/'
+
+template: |
+    ## Contributors
+    $CONTRIBUTORS
+    ## What's Changed
+    $CHANGES
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,13 +2,22 @@ name: CI build
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - v[0-9]+
+      - v[0-9]+.[0-9]+
+
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - v[0-9]+
+      - v[0-9]+.[0-9]+
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      OPERATOR_IMG: quay.io/cryostat/cryostat-operator
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
@@ -26,3 +35,32 @@ jobs:
       with:
         operator-sdk-version: v1.5.0
     - run: make generate manifests manager test-envtest
+      if: ${{ github.event_name == 'pull_request' }}
+    - run: make oci-build
+      if: ${{ github.event_name == 'push' }}
+    - name: Tag image
+      id: tag-image
+      run: |
+        IMG_TAG="$(make --eval='print-img-ver: ; @echo $(IMAGE_VERSION)' print-img-ver)"
+        if [ "$GITHUB_REF" == "refs/heads/main" ]; then
+          podman tag \
+          ${{ env.OPERATOR_IMG }}:$IMG_TAG \
+          ${{ env.OPERATOR_IMG }}:latest
+          echo "::set-output name=tags::$IMG_TAG latest"
+        else
+          echo "::set-output name=tags::$IMG_TAG"
+        fi
+      if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
+    - name: Push to quay.io
+      id: push-to-quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: cryostat-operator
+        tags: ${{ steps.tag-image.outputs.tags }}
+        registry: quay.io/cryostat
+        username: cryostat+bot
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+      if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
+    - name: Print image URL
+      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+      if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -1,0 +1,33 @@
+name: Dependent Issues
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+  # Schedule a daily check. Used in referencing cross-repository
+  # issues or pull requests
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: z0al/dependent-issues@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # (Optional) Enable checking for dependencies in issues.
+          # Enable by setting the value to "on". Default "off"
+          check_issues: off
+
+          keywords: depends on, blocked by, based on

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,25 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - main
+      - v[0-9]+
+      - v[0-9]+.[0-9]+
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,8 +5,6 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - main
-      - v[0-9]+
-      - v[0-9]+.[0-9]+
   # pull_request event is required only for autolabeler
   pull_request:
     # Only following types are handled by the action, but one can default to all as well

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,17 @@
+name: semantic-pull-request
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v3.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR backports the contents of `.github` from `main` as-is.

Fixes: #223 