### PR TITLE
ci(release-drafter): revert branches to only main

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,8 +5,6 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - main
-      - v[0-9]+
-      - v[0-9]+.[0-9]+
   # pull_request event is required only for autolabeler
   pull_request:
     # Only following types are handled by the action, but one can default to all as well


### PR DESCRIPTION
Fix to avoid combining fixes from different branches into same release notes.