### PR TITLE
fix(rbac): add permissions to support tree API

### DIFF
--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -384,6 +384,12 @@ spec:
           - update
           - watch
         - apiGroups:
+          - ""
+          resources:
+          - replicationcontrollers
+          verbs:
+          - get
+        - apiGroups:
           - apps
           resources:
           - daemonsets
@@ -392,6 +398,12 @@ spec:
           - statefulsets
           verbs:
           - '*'
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
         - apiGroups:
           - cert-manager.io
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -88,6 +88,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers
+  verbs:
+  - get
+- apiGroups:
   - apps
   resources:
   - daemonsets
@@ -96,6 +102,12 @@ rules:
   - statefulsets
   verbs:
   - '*'
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
 - apiGroups:
   - cert-manager.io
   resources:

--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -708,6 +708,21 @@ func NewRoleForCR(cr *operatorv1beta1.Cryostat) *rbacv1.Role {
 				Resources: []string{"endpoints"},
 			},
 			{
+				Verbs:     []string{"get"},
+				APIGroups: []string{""},
+				Resources: []string{"pods", "replicationcontrollers"},
+			},
+			{
+				Verbs:     []string{"get"},
+				APIGroups: []string{"apps"},
+				Resources: []string{"replicasets", "deployments", "daemonsets", "statefulsets"},
+			},
+			{
+				Verbs:     []string{"get"},
+				APIGroups: []string{"apps.openshift.io"},
+				Resources: []string{"deploymentconfigs"},
+			},
+			{
 				Verbs:     []string{"get", "list"},
 				APIGroups: []string{"route.openshift.io"},
 				Resources: []string{"routes"},

--- a/internal/controllers/cryostat_controller.go
+++ b/internal/controllers/cryostat_controller.go
@@ -91,11 +91,13 @@ const datasourceImageTagEnv = "RELATED_IMAGE_DATASOURCE"
 const grafanaImageTagEnv = "RELATED_IMAGE_GRAFANA"
 
 // +kubebuilder:rbac:namespace=system,groups="",resources=pods;services;services/finalizers;endpoints;persistentvolumeclaims;events;configmaps;secrets;serviceaccounts,verbs=*
+// +kubebuilder:rbac:namespace=system,groups="",resources=replicationcontrollers,verbs=get
 // +kubebuilder:rbac:namespace=system,groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=create;get;list;update;watch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create;get;list;update;watch;delete
 // +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=selfsubjectaccessreviews,verbs=create
 // +kubebuilder:rbac:namespace=system,groups=route.openshift.io,resources=routes;routes/custom-host,verbs=*
+// +kubebuilder:rbac:namespace=system,groups=apps.openshift.io,resources=deploymentconfigs,verbs=get
 // +kubebuilder:rbac:namespace=system,groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=*
 // +kubebuilder:rbac:namespace=system,groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create
 // +kubebuilder:rbac:namespace=system,groups=cert-manager.io,resources=issuers;certificates,verbs=create;get;list;update;watch

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -1127,6 +1127,21 @@ func NewRole() *rbacv1.Role {
 				Resources: []string{"endpoints"},
 			},
 			{
+				Verbs:     []string{"get"},
+				APIGroups: []string{""},
+				Resources: []string{"pods", "replicationcontrollers"},
+			},
+			{
+				Verbs:     []string{"get"},
+				APIGroups: []string{"apps"},
+				Resources: []string{"replicasets", "deployments", "daemonsets", "statefulsets"},
+			},
+			{
+				Verbs:     []string{"get"},
+				APIGroups: []string{"apps.openshift.io"},
+				Resources: []string{"deploymentconfigs"},
+			},
+			{
 				Verbs:     []string{"get", "list"},
 				APIGroups: []string{"route.openshift.io"},
 				Resources: []string{"routes"},


### PR DESCRIPTION
This PR adds additional permissions to the Role bound to Cryostat's Service Account. These extra permissions are needed to support the tree API added in https://github.com/cryostatio/cryostat/pull/492.

Fixes #234