### PR TITLE
fix(pvc): set fsGroup to ensure mounts writable

### DIFF
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -242,10 +242,17 @@ func NewPodForCR(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, imageTags *I
 			volumes = append(volumes, eventTemplateVolume)
 		}
 	}
+
+	// Ensure PV mounts are writable
+	fsGroup := int64(0)
+	sc := &corev1.PodSecurityContext{
+		FSGroup: &fsGroup,
+	}
 	return &corev1.PodSpec{
 		ServiceAccountName: cr.Name,
 		Volumes:            volumes,
 		Containers:         containers,
+		SecurityContext:    sc,
 	}
 }
 

--- a/internal/controllers/cryostat_controller_test.go
+++ b/internal/controllers/cryostat_controller_test.go
@@ -1033,6 +1033,7 @@ func (t *cryostatTestInput) checkDeployment() {
 		"kind": "cryostat",
 	}))
 	Expect(template.Spec.Volumes).To(Equal(test.NewVolumes(t.minimal, tls)))
+	Expect(template.Spec.SecurityContext).To(Equal(test.NewPodSecurityContext()))
 
 	// Check that the networking environment variables are set correctly
 	coreContainer := template.Spec.Containers[0]

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -1132,6 +1132,13 @@ func NewVolumesWithTemplates() []corev1.Volume {
 		})
 }
 
+func NewPodSecurityContext() *corev1.PodSecurityContext {
+	fsGroup := int64(0)
+	return &corev1.PodSecurityContext{
+		FSGroup: &fsGroup,
+	}
+}
+
 func NewNetworkConfigurationList() operatorv1beta1.NetworkConfigurationList {
 	coreSVC := resource_definitions.NewExporterService(NewCryostat())
 	coreIng := NewNetworkConfiguration(coreSVC.Name, coreSVC.Spec.Ports[0].Port)


### PR DESCRIPTION
This sets a SecurityContext for the Cryostat Pod, where `fsGroup` is set to `0`. This means that the files and directories in the mounted persistent volume are owned and writable by the root group, which the Cryostat container is always executing as [1].

With this fix applied on the problematic cluster:
```
$ ls -l /opt/cryostat.d/
total 192
drwxrwsr-x. 2 root  root   4096 Aug 31 21:26 clientlib.d
drwxrwsr-x. 4 root  root   4096 Aug 31 21:26 conf.d
drwxrwsr-x. 2 root  root   4096 Aug 31 21:26 recordings.d
drwxrwsr-x. 2 root  root   4096 Aug 31 21:26 templates.d
-rwxrwxr-x. 1 root  root    472 Jul  9 19:52 truststore-setup.sh
-rw-rw-r--. 1 jboss root 170412 Aug 31 21:26 truststore.p12
-rw-rw-r--. 1 jboss root     33 Jul  9 19:53 truststore.pass
```

Fixes #243 

[1] https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podsecuritycontext-v1-core