### PR TITLE
feat(tls): emit event when cert-manager is missing

### DIFF
--- a/internal/controllers/cryostat_controller.go
+++ b/internal/controllers/cryostat_controller.go
@@ -45,6 +45,7 @@ import (
 	"github.com/go-logr/logr"
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -60,6 +61,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -71,9 +73,11 @@ import (
 // CryostatReconciler reconciles a Cryostat object
 type CryostatReconciler struct {
 	client.Client
-	Log         logr.Logger
-	Scheme      *runtime.Scheme
-	IsOpenShift bool
+	Log           logr.Logger
+	Scheme        *runtime.Scheme
+	IsOpenShift   bool
+	EventRecorder record.EventRecorder
+	RESTMapper    meta.RESTMapper
 	common.ReconcilerTLS
 }
 

--- a/internal/main.go
+++ b/internal/main.go
@@ -108,10 +108,12 @@ func main() {
 	}
 
 	if err = (&controllers.CryostatReconciler{
-		Client:      mgr.GetClient(),
-		Log:         ctrl.Log.WithName("controllers").WithName("Cryostat"),
-		Scheme:      mgr.GetScheme(),
-		IsOpenShift: openShift,
+		Client:        mgr.GetClient(),
+		Log:           ctrl.Log.WithName("controllers").WithName("Cryostat"),
+		Scheme:        mgr.GetScheme(),
+		IsOpenShift:   openShift,
+		EventRecorder: mgr.GetEventRecorderFor("cryostat-controller"),
+		RESTMapper:    mgr.GetRESTMapper(),
 		ReconcilerTLS: common.NewReconcilerTLS(&common.ReconcilerTLSConfig{
 			Client: mgr.GetClient(),
 		}),

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -48,9 +48,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 )
@@ -69,6 +71,19 @@ func NewTestScheme() *runtime.Scheme {
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	return s
+}
+
+func NewTESTRESTMapper() meta.RESTMapper {
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{
+		certv1.SchemeGroupVersion,
+	})
+	// Add cert-manager Issuer GVK
+	mapper.Add(schema.GroupVersionKind{
+		Group:   certv1.SchemeGroupVersion.Group,
+		Version: certv1.SchemeGroupVersion.Version,
+		Kind:    certv1.IssuerKind,
+	}, meta.RESTScopeNamespace)
+	return mapper
 }
 
 func NewCryostat() *operatorv1beta1.Cryostat {


### PR DESCRIPTION
This PR adds a check for the cert-manager API using the manager's RESTMapper. This is similar to how we check if the cluster is OpenShift. If cert-manager isn't disabled in the Cryostat CR and cert-manager is unavailable, the operator will emit a Warning event to communicate the problem to the user.

Viewing the Cryostat CR's events in the OpenShift Console:
![Screenshot 2021-09-01 at 15-51-25 Red Hat OpenShift Container Platform](https://user-images.githubusercontent.com/4326090/131735549-7ca36453-68b0-4b50-8dff-cefc8971751b.png)

Unfortunately, there's no visual indicator in the Details tab, but if the user sees nothing is happening and visits the Events tab, they'll see the cause.

Similarly, the Events show up when using `kubectl describe`:
```
$ kubectl describe cryostat cryostat-sample 
Name:         cryostat-sample
Namespace:    cryostat-operator-system
Labels:       <none>
Annotations:  <none>
API Version:  operator.cryostat.io/v1beta1
Kind:         Cryostat
Metadata:
  Creation Timestamp:  2021-09-01T19:48:46Z
  Finalizers:
    operator.cryostat.io/cryostat.finalizer
  Generation:  2
[...snip...]
Spec:
  Enable Cert Manager:  true
  Minimal:              false
  Storage Options:
    Pvc:
      Spec:
        Resources:
Events:
  Type     Reason                  Age                  From                 Message
  ----     ------                  ----                 ----                 -------
  Warning  CertManagerUnavailable  4s (x15 over 2m59s)  cryostat-controller  cert-manager is not detected in the cluster, please install cert-manager or disable it by setting "enableCertManager" in this Cryostat custom resource to false
```

Fixes #239 