### PR TITLE
fix(pvc): derive fsGroup from SCC annotation

### DIFF
--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -253,6 +253,14 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - authentication.k8s.io
           resources:
           - tokenreviews

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,14 @@ metadata:
   name: role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews

--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -122,7 +122,7 @@ func NewPersistentVolumeClaimForCR(cr *operatorv1beta1.Cryostat) *corev1.Persist
 }
 
 func NewDeploymentForCR(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, imageTags *ImageTags,
-	tls *TLSConfig) *appsv1.Deployment {
+	tls *TLSConfig, fsGroup int64) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
@@ -152,14 +152,14 @@ func NewDeploymentForCR(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, image
 						"kind": "cryostat",
 					},
 				},
-				Spec: *NewPodForCR(cr, specs, imageTags, tls),
+				Spec: *NewPodForCR(cr, specs, imageTags, tls, fsGroup),
 			},
 		},
 	}
 }
 
 func NewPodForCR(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, imageTags *ImageTags,
-	tls *TLSConfig) *corev1.PodSpec {
+	tls *TLSConfig, fsGroup int64) *corev1.PodSpec {
 	var containers []corev1.Container
 	if cr.Spec.Minimal {
 		containers = []corev1.Container{
@@ -289,7 +289,6 @@ func NewPodForCR(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, imageTags *I
 	}
 
 	// Ensure PV mounts are writable
-	fsGroup := int64(18500)
 	sc := &corev1.PodSecurityContext{
 		FSGroup: &fsGroup,
 	}

--- a/internal/controllers/cryostat_controller_test.go
+++ b/internal/controllers/cryostat_controller_test.go
@@ -102,6 +102,9 @@ var _ = Describe("CryostatController", func() {
 				TLS: true,
 			},
 		}
+		t.objs = []runtime.Object{
+			test.NewNamespace(),
+		}
 	})
 
 	AfterEach(func() {
@@ -111,9 +114,7 @@ var _ = Describe("CryostatController", func() {
 	Describe("reconciling a request in OpenShift", func() {
 		Context("succesfully creates required resources", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostat(),
-				}
+				t.objs = append(t.objs, test.NewCryostat())
 			})
 			It("should create certificates", func() {
 				t.expectCertificates()
@@ -168,9 +169,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("succesfully creates required resources for minimal deployment", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewMinimalCryostat(),
-				}
+				t.objs = append(t.objs, test.NewMinimalCryostat())
 				t.minimal = true
 			})
 			It("should create certificates", func() {
@@ -203,9 +202,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("after cryostat reconciled successfully", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostat(),
-				}
+				t.objs = append(t.objs, test.NewCryostat())
 			})
 			It("should be idempotent", func() {
 				t.expectIdempotence()
@@ -213,9 +210,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("After a minimal cryostat reconciled successfully", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewMinimalCryostat(),
-				}
+				t.objs = append(t.objs, test.NewMinimalCryostat())
 				t.minimal = true
 			})
 			It("should be idempotent", func() {
@@ -232,9 +227,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("Switching from a minimal to a non-minimal deployment", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewMinimalCryostat(),
-				}
+				t.objs = append(t.objs, test.NewMinimalCryostat())
 				t.minimal = true
 			})
 			JustBeforeEach(func() {
@@ -267,9 +260,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("Switching from a non-minimal to a minimal deployment", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostat(),
-				}
+				t.objs = append(t.objs, test.NewCryostat())
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
@@ -302,9 +293,8 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("Cryostat CR has list of certificate secrets", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostatWithSecrets(), newFakeSecret("testCert1"), newFakeSecret("testCert2"),
-				}
+				t.objs = append(t.objs, test.NewCryostatWithSecrets(),
+					newFakeSecret("testCert1"), newFakeSecret("testCert2"))
 			})
 			It("Should add volumes and volumeMounts to deployment", func() {
 				t.reconcileCryostatFully()
@@ -323,9 +313,8 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("Adding a certificate to the TrustedCertSecrets list", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostat(), newFakeSecret("testCert1"), newFakeSecret("testCert2"),
-				}
+				t.objs = append(t.objs, test.NewCryostat(), newFakeSecret("testCert1"),
+					newFakeSecret("testCert2"))
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
@@ -361,10 +350,8 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("Cryostat CR has list of event templates", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostatWithTemplates(), test.NewTemplateConfigMap(),
-					test.NewOtherTemplateConfigMap(),
-				}
+				t.objs = append(t.objs, test.NewCryostatWithTemplates(), test.NewTemplateConfigMap(),
+					test.NewOtherTemplateConfigMap())
 			})
 			It("Should add volumes and volumeMounts to deployment", func() {
 				t.reconcileCryostatFully()
@@ -383,10 +370,8 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("Adding a template to the EventTemplates list", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostat(), test.NewTemplateConfigMap(),
-					test.NewOtherTemplateConfigMap(),
-				}
+				t.objs = append(t.objs, test.NewCryostat(), test.NewTemplateConfigMap(),
+					test.NewOtherTemplateConfigMap())
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
@@ -422,9 +407,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("with custom PVC spec overriding all defaults", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostatWithPVCSpec(),
-				}
+				t.objs = append(t.objs, test.NewCryostatWithPVCSpec())
 			})
 			It("should create the PVC with requested spec", func() {
 				t.expectPVC(test.NewCustomPVC())
@@ -432,9 +415,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("with custom PVC spec overriding some defaults", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostatWithPVCSpecSomeDefault(),
-				}
+				t.objs = append(t.objs, test.NewCryostatWithPVCSpecSomeDefault())
 			})
 			It("should create the PVC with requested spec", func() {
 				t.expectPVC(test.NewCustomPVCSomeDefault())
@@ -442,9 +423,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("with custom PVC config with no spec", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostatWithPVCLabelsOnly(),
-				}
+				t.objs = append(t.objs, test.NewCryostatWithPVCLabelsOnly())
 			})
 			It("should create the PVC with requested label", func() {
 				t.expectPVC(test.NewDefaultPVCWithLabel())
@@ -452,9 +431,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("with overriden image tags", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostat(),
-				}
+				t.objs = append(t.objs, test.NewCryostat())
 				coreImg := "my/core-image:1.0"
 				datasourceImg := "my/datasource-image:1.0"
 				grafanaImg := "my/grafana-image:1.0"
@@ -468,9 +445,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("when deleted", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostat(),
-				}
+				t.objs = append(t.objs, test.NewCryostat())
 			})
 			JustBeforeEach(func() {
 				t.reconcileDeletedCryostat()
@@ -487,9 +462,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("on OpenShift", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostat(),
-				}
+				t.objs = append(t.objs, test.NewCryostat())
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
@@ -507,6 +480,22 @@ var _ = Describe("CryostatController", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(cr.GetFinalizers()).To(ContainElement("operator.cryostat.io/cryostat.finalizer"))
 			})
+			Context("with restricted SCC", func() {
+				BeforeEach(func() {
+					t.objs = []runtime.Object{
+						test.NewCryostat(), test.NewNamespaceWithSCCSupGroups(),
+					}
+				})
+				It("should set fsGroup to value derived from namespace", func() {
+					deploy := &appsv1.Deployment{}
+					err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, deploy)
+					Expect(err).ToNot(HaveOccurred())
+					sc := deploy.Spec.Template.Spec.SecurityContext
+					Expect(sc).ToNot(BeNil())
+					Expect(sc.FSGroup).ToNot(BeNil())
+					Expect(*sc.FSGroup).To(Equal(int64(1000130000)))
+				})
+			})
 			Context("when deleted", func() {
 				JustBeforeEach(func() {
 					t.reconcileDeletedCryostat()
@@ -521,9 +510,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("with cert-manager disabled in CR", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostatCertManagerDisabled(),
-				}
+				t.objs = append(t.objs, test.NewCryostatCertManagerDisabled())
 				t.TLS = false
 			})
 			It("should create deployment and set owner", func() {
@@ -542,9 +529,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("with cert-manager not configured in CR", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostatCertManagerUndefined(),
-				}
+				t.objs = append(t.objs, test.NewCryostatCertManagerUndefined())
 			})
 			It("should create deployment and set owner", func() {
 				t.expectDeployment()
@@ -558,9 +543,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("with DISABLE_SERVICE_TLS=true", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostatCertManagerUndefined(),
-				}
+				t.objs = append(t.objs, test.NewCryostatCertManagerUndefined())
 				disableTLS := true
 				t.EnvDisableTLS = &disableTLS
 				t.TLS = false
@@ -581,9 +564,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("Disable cert-manager after being enabled", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostat(),
-				}
+				t.objs = append(t.objs, test.NewCryostat())
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
@@ -611,9 +592,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("Enable cert-manager after being disabled", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostatCertManagerDisabled(),
-				}
+				t.objs = append(t.objs, test.NewCryostatCertManagerDisabled())
 				t.TLS = false
 			})
 			JustBeforeEach(func() {
@@ -656,9 +635,7 @@ var _ = Describe("CryostatController", func() {
 			})
 			Context("and enabled", func() {
 				BeforeEach(func() {
-					t.objs = []runtime.Object{
-						test.NewCryostat(),
-					}
+					t.objs = append(t.objs, test.NewCryostat())
 				})
 				It("should emit a CertManagerUnavailable Event", func() {
 					req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: "default"}}
@@ -673,9 +650,7 @@ var _ = Describe("CryostatController", func() {
 			})
 			Context("and disabled", func() {
 				BeforeEach(func() {
-					t.objs = []runtime.Object{
-						test.NewCryostatCertManagerDisabled(),
-					}
+					t.objs = append(t.objs, test.NewCryostatCertManagerDisabled())
 					t.TLS = false
 				})
 				It("should not emit a CertManagerUnavailable Event", func() {
@@ -696,9 +671,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("succesfully creates required resources", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostatWithIngress(),
-				}
+				t.objs = append(t.objs, test.NewCryostatWithIngress())
 			})
 			It("should create ingresses", func() {
 				t.expectIngresses()
@@ -710,9 +683,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("no ingress configuration is provided", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostat(),
-				}
+				t.objs = append(t.objs, test.NewCryostat())
 			})
 			It("should not create ingresses or routes", func() {
 				t.reconcileCryostatFully()
@@ -722,9 +693,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("networkConfig for one of the services is nil", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostatWithIngress(),
-				}
+				t.objs = append(t.objs, test.NewCryostatWithIngress())
 			})
 			It("should only create specified ingresses", func() {
 				c := &operatorv1beta1.Cryostat{}
@@ -754,12 +723,9 @@ var _ = Describe("CryostatController", func() {
 				Expect(kerrors.IsNotFound(err)).To(BeTrue())
 			})
 		})
-
 		Context("ingressSpec for one of the services is nil", func() {
 			BeforeEach(func() {
-				t.objs = []runtime.Object{
-					test.NewCryostatWithIngress(),
-				}
+				t.objs = append(t.objs, test.NewCryostatWithIngress())
 			})
 			It("should only create specified ingresses", func() {
 				c := &operatorv1beta1.Cryostat{}

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -45,6 +45,7 @@ import (
 	"github.com/onsi/gomega"
 	consolev1 "github.com/openshift/api/console/v1"
 	routev1 "github.com/openshift/api/route/v1"
+	securityv1 "github.com/openshift/api/security/v1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -1313,6 +1314,22 @@ func NewOtherTemplateConfigMap() *corev1.ConfigMap {
 			"other-template.jfc": "more XML template data",
 		},
 	}
+}
+
+func NewNamespace() *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+	}
+}
+
+func NewNamespaceWithSCCSupGroups() *corev1.Namespace {
+	ns := NewNamespace()
+	ns.Annotations = map[string]string{
+		securityv1.SupplementalGroupsAnnotation: "1000130000/10000",
+	}
+	return ns
 }
 
 func NewConsoleLink() *consolev1.ConsoleLink {


### PR DESCRIPTION
This PR adds some logic for OpenShift to ensure Cryostat runs under the `restricted` SecurityContextConstraint. The range of permitted `fsGroup` values is taken from the `openshift.io/sa.scc.supplemental-groups` annotation on the pod's namespace:
https://docs.openshift.com/container-platform/4.8/authentication/managing-security-context-constraints.html#security-context-constraints-pre-allocated-values_configuring-internal-oauth

I'm still unsure why Cryostat deployed to the `default` namespace isn't subject to SCCs, but this fix appears to make Cryostat work for both `default` and other namespaces.

Fixes #247 