### PR TITLE
fix(finalizer): remove finalizers when objects to delete not found

### DIFF
--- a/internal/controllers/cryostat_controller.go
+++ b/internal/controllers/cryostat_controller.go
@@ -64,6 +64,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -571,6 +572,10 @@ func (r *CryostatReconciler) deleteClusterRoleBinding(ctx context.Context, cr *o
 	clusterBinding := resources.NewClusterRoleBindingForCR(cr)
 	err := r.Delete(ctx, clusterBinding)
 	if err != nil {
+		if kerrors.IsNotFound(err) {
+			reqLogger.Info("ClusterRoleBinding not found, proceeding with deletion", "bindingName", clusterBinding.Name)
+			return nil
+		}
 		reqLogger.Error(err, "failed to delete ClusterRoleBinding", "bindingName", clusterBinding.Name)
 		return err
 	}
@@ -639,6 +644,10 @@ func (r *CryostatReconciler) deleteConsoleLink(ctx context.Context, cr *operator
 	link := resources.NewConsoleLink(cr, "")
 	err := r.Client.Delete(ctx, link)
 	if err != nil {
+		if kerrors.IsNotFound(err) {
+			reqLogger.Info("ConsoleLink not found, proceeding with deletion", "linkName", link.Name)
+			return nil
+		}
 		reqLogger.Error(err, "failed to delete ConsoleLink", "linkName", link.Name)
 		return err
 	}


### PR DESCRIPTION
Fixes #245 

To test:
- Run `make deploy remove_cert_manager create_cryostat_cr IMG=<test_image>`. This results in a Cryostat CR with a finalizer applied to it, but unable to proceed due to cert-manager missing.
- Delete the Cryostat CR `make destroy_cryostat_cr`. Deletion should proceed without hanging.