### PR TITLE
fix(health): use /health for Cryostat health check

### DIFF
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -473,7 +473,7 @@ func NewCoreContainer(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, imageTa
 	probeHandler := corev1.Handler{
 		HTTPGet: &corev1.HTTPGetAction{
 			Port:   intstr.IntOrString{IntVal: 8181},
-			Path:   "/api/v1/clienturl",
+			Path:   "/health",
 			Scheme: livenessProbeScheme,
 		},
 	}

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -959,7 +959,7 @@ func newCoreProbeHandler(tls bool) corev1.Handler {
 	return corev1.Handler{
 		HTTPGet: &corev1.HTTPGetAction{
 			Port:   intstr.IntOrString{IntVal: 8181},
-			Path:   "/api/v1/clienturl",
+			Path:   "/health",
 			Scheme: protocol,
 		},
 	}


### PR DESCRIPTION
This PR replaces the usage of `/api/v1/clienturl`, which has been removed. This is currently only used as a container health check. It still seemed to work, I'm guessing because the 404 would redirect to Cryostat's landing page. Since there's a proper `/health` endpoint, I've changed the container health check to use this instead.

Fixes #213 