### PR TITLE
fix(templates): templates should be mounted if TLS disabled

### DIFF
--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -922,8 +922,8 @@ func NewGrafanaVolumeMounts(tls bool) []corev1.VolumeMount {
 	return mounts
 }
 
-func NewVolumeMountsWithTemplates() []corev1.VolumeMount {
-	return append(NewCoreVolumeMounts(true),
+func NewVolumeMountsWithTemplates(tls bool) []corev1.VolumeMount {
+	return append(NewCoreVolumeMounts(tls),
 		corev1.VolumeMount{
 			Name:      "template-templateCM1",
 			ReadOnly:  true,
@@ -1038,9 +1038,9 @@ func NewVolumesWithSecrets() []corev1.Volume {
 	})
 }
 
-func NewVolumesWithTemplates() []corev1.Volume {
+func NewVolumesWithTemplates(tls bool) []corev1.Volume {
 	mode := int32(0440)
-	return append(NewVolumes(false, true),
+	return append(NewVolumes(false, tls),
 		corev1.Volume{
 			Name: "template-templateCM1",
 			VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
Just a case of nesting this code in a branch it shouldn't be in. I added a test case to ensure this works when TLS is disabled as well.

To test manually:
1. `make deploy IMG=<test_img> create_cryostat_cr`
2. Create a config map with a template file `kubectl create configmap my-template --from-file=custom.jfc`
3. `kubectl edit cryostat cryostat-sample`, change `spec.enableCertManager` to false and add the template to `spec.eventTemplates` [1]
4. Cryostat should not have a CA cert mounted, but the custom event template should be present.

Fixes #240 

[1] https://github.com/cryostatio/cryostat-operator/blob/main/docs/config.md#custom-event-templates