### PR TITLE
fix(openshift): correct annotation for topology view

### DIFF
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -133,7 +133,7 @@ func NewDeploymentForCR(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, image
 				"app.kubernetes.io/name": "cryostat",
 			},
 			Annotations: map[string]string{
-				"app.openshift.io/connects-to": "cryostat-operator",
+				"app.openshift.io/connects-to": "cryostat-operator-controller-manager",
 			},
 		},
 		Spec: appsv1.DeploymentSpec{

--- a/internal/controllers/cryostat_controller_test.go
+++ b/internal/controllers/cryostat_controller_test.go
@@ -1187,7 +1187,7 @@ func (t *cryostatTestInput) checkDeployment() {
 	Expect(deployment.Name).To(Equal("cryostat"))
 	Expect(deployment.Namespace).To(Equal("default"))
 	Expect(deployment.Annotations).To(Equal(map[string]string{
-		"app.openshift.io/connects-to": "cryostat-operator",
+		"app.openshift.io/connects-to": "cryostat-operator-controller-manager",
 	}))
 	Expect(deployment.Labels).To(Equal(map[string]string{
 		"app":                    "cryostat",


### PR DESCRIPTION
Fixes #228 

![Screenshot 2021-09-17 at 15-12-55 Topology · Red Hat OpenShift Container Platform](https://user-images.githubusercontent.com/4326090/133841828-b25a2a17-b8f7-4100-9f79-d5d7d5de7a97.png)
