### PR TITLE
build(csv): add initialization-resource annotation

### DIFF
--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -62,6 +62,18 @@ metadata:
     containerImage: quay.io/cryostat/cryostat-operator:2.1.0-dev
     createdAt: "2021-04-30 00:00:00"
     description: JVM monitoring and profiling tool
+    operatorframework.io/initialization-resource: |-
+      {
+        "apiVersion": "operator.cryostat.io/v1beta1",
+        "kind": "Cryostat",
+        "metadata": {
+          "name": "cryostat-sample"
+        },
+        "spec": {
+          "enableCertManager": true,
+          "minimal": false
+        }
+      }
     operators.operatorframework.io/builder: operator-sdk-v1.4.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: github.com/cryostatio/cryostat-operator

--- a/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
@@ -53,6 +53,18 @@ metadata:
     containerImage: quay.io/cryostat/cryostat-operator:2.1.0-dev
     createdAt: "2021-04-30 00:00:00"
     description: JVM monitoring and profiling tool
+    operatorframework.io/initialization-resource: |-
+      {
+        "apiVersion": "operator.cryostat.io/v1beta1",
+        "kind": "Cryostat",
+        "metadata": {
+          "name": "cryostat-sample"
+        },
+        "spec": {
+          "enableCertManager": true,
+          "minimal": false
+        }
+      }
     operators.operatorframework.io/builder: operator-sdk-v1.5.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: github.com/cryostatio/cryostat-operator


### PR DESCRIPTION
This adds an annotation to our CSV that prompts the user to create a Cryostat CR after they install the operator. Unfortunately, there doesn't seem to be any Operator SDK integration to generate this for us, so we'll have to update it manually. The sample CR I included only sets `minimal` which is required, and `enableCertManager` which we want to explicitly set to true.

Visiting the Installed Operator after using `deploy_bundle`:
![Screenshot 2021-09-17 at 15-40-08 cryostat-operator v2 1 0-dev · Details · Red Hat OpenShift Container Platform](https://user-images.githubusercontent.com/4326090/133845571-356e551a-8996-476f-89d5-618c17206541.png)

After uninstalling the operator and reinstalling from the CatalogSource. A similar workflow to installing from OperatorHub:
![Screenshot 2021-09-17 at 15-41-26 Installing Operator · Red Hat OpenShift Container Platform](https://user-images.githubusercontent.com/4326090/133845744-af94cd3e-788d-44f2-ace8-4eb43296cc3d.png)

Test bundle image for convenience: `quay.io/ebaron/cryostat-operator-bundle:init-res`

Fixes #257 