### PR TITLE
fix(openshift): force platform/auth on OpenShift

### DIFF
--- a/internal/controllers/cryostat_controller.go
+++ b/internal/controllers/cryostat_controller.go
@@ -322,7 +322,7 @@ func (r *CryostatReconciler) Reconcile(ctx context.Context, request ctrl.Request
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	deployment := resources.NewDeploymentForCR(instance, serviceSpecs, imageTags, tlsConfig, *fsGroup)
+	deployment := resources.NewDeploymentForCR(instance, serviceSpecs, imageTags, tlsConfig, *fsGroup, r.IsOpenShift)
 	podTemplate := deployment.Spec.Template.DeepCopy()
 	if err := controllerutil.SetControllerReference(instance, deployment, r.Scheme); err != nil {
 		return reconcile.Result{}, err

--- a/internal/controllers/cryostat_controller_test.go
+++ b/internal/controllers/cryostat_controller_test.go
@@ -1210,7 +1210,7 @@ func (t *cryostatTestInput) checkDeployment() {
 
 	// Check that the networking environment variables are set correctly
 	coreContainer := template.Spec.Containers[0]
-	checkCoreContainer(&coreContainer, t.minimal, t.TLS, t.EnvCoreImageTag)
+	checkCoreContainer(&coreContainer, t.minimal, t.TLS, t.EnvCoreImageTag, t.controller.IsOpenShift)
 
 	if !t.minimal {
 		// Check that Grafana is configured properly, depending on the environment
@@ -1240,7 +1240,7 @@ func (t *cryostatTestInput) checkDeploymentHasTemplates() {
 	Expect(volumeMounts).To(Equal(expectedVolumeMounts))
 }
 
-func checkCoreContainer(container *corev1.Container, minimal bool, tls bool, tag *string) {
+func checkCoreContainer(container *corev1.Container, minimal bool, tls bool, tag *string, openshift bool) {
 	Expect(container.Name).To(Equal("cryostat"))
 	if tag == nil {
 		Expect(container.Image).To(HavePrefix("quay.io/cryostat/cryostat:"))
@@ -1248,7 +1248,7 @@ func checkCoreContainer(container *corev1.Container, minimal bool, tls bool, tag
 		Expect(container.Image).To(Equal(*tag))
 	}
 	Expect(container.Ports).To(ConsistOf(test.NewCorePorts()))
-	Expect(container.Env).To(ConsistOf(test.NewCoreEnvironmentVariables(minimal, tls)))
+	Expect(container.Env).To(ConsistOf(test.NewCoreEnvironmentVariables(minimal, tls, openshift)))
 	Expect(container.EnvFrom).To(ConsistOf(test.NewCoreEnvFromSource(tls)))
 	Expect(container.VolumeMounts).To(ConsistOf(test.NewCoreVolumeMounts(tls)))
 	Expect(container.LivenessProbe).To(Equal(test.NewCoreLivenessProbe(tls)))

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -718,7 +718,7 @@ func NewDatasourcePorts() []corev1.ContainerPort {
 	}
 }
 
-func NewCoreEnvironmentVariables(minimal bool, tls bool) []corev1.EnvVar {
+func NewCoreEnvironmentVariables(minimal bool, tls bool, openshift bool) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{
 			Name:  "CRYOSTAT_SSL_PROXIED",
@@ -791,6 +791,17 @@ func NewCoreEnvironmentVariables(minimal bool, tls bool) []corev1.EnvVar {
 			Name:  "KEYSTORE_PATH",
 			Value: "/var/run/secrets/operator.cryostat.io/cryostat-tls/keystore.p12",
 		})
+	}
+	if openshift {
+		envs = append(envs,
+			corev1.EnvVar{
+				Name:  "CRYOSTAT_PLATFORM",
+				Value: "io.cryostat.platform.internal.OpenShiftPlatformStrategy",
+			},
+			corev1.EnvVar{
+				Name:  "CRYOSTAT_AUTH_MANAGER",
+				Value: "io.cryostat.net.OpenShiftAuthManager",
+			})
 	}
 	return envs
 }


### PR DESCRIPTION
This PR adds the `CRYOSTAT_PLATFORM` and `CRYOSTAT_AUTH_MANAGER` environment variables when running on OpenShift. This also changes the OpenShift detection mechanism to not use the caching client to hopefully avoid situations like #210, but I have not encountered it again since filing.

Fixes #273, #210 