### PR TITLE
feat(deploy): use Always pull policy for development images 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,10 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 # Check whether this is a development or release version
-ifeq (,$(shell echo $(IMAGE_VERSION) | grep -iE '(:latest|SNAPSHOT|dev|BETA[[:digit:]]+)$$'))
-PULL_POLICY ?= IfNotPresent
-else
+ifneq (,$(shell echo $(IMAGE_VERSION) | grep -iE '(:latest|SNAPSHOT|dev|BETA[[:digit:]]+)$$'))
 PULL_POLICY ?= Always
+else
+PULL_POLICY ?= IfNotPresent
 endif
 export PULL_POLICY
 

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,14 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# Check whether this is a development or release version
+ifeq (,$(shell echo $(IMAGE_VERSION) | grep -E '^[0-9]+\.[0-9]+\.[0-9]*$$'))
+PULL_POLICY ?= Always
+else
+PULL_POLICY ?= IfNotPresent
+endif
+export PULL_POLICY
+
 # Run tests with Ginkgo CLI if available
 GINKGO ?= $(shell go env GOPATH)/bin/ginkgo
 GO_TEST ?= go test
@@ -130,6 +138,7 @@ undeploy:
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	envsubst < hack/image_tag_patch.yaml.in > config/default/image_tag_patch.yaml
+	envsubst < hack/image_pull_patch.yaml.in > config/default/image_pull_patch.yaml
 
 # Run go fmt against code
 .PHONY: fmt

--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,10 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 # Check whether this is a development or release version
-ifeq (,$(shell echo $(IMAGE_VERSION) | grep -E '^[0-9]+\.[0-9]+\.[0-9]*$$'))
-PULL_POLICY ?= Always
-else
+ifeq (,$(shell echo $(IMAGE_VERSION) | grep -iE '(:latest|SNAPSHOT|dev|BETA[[:digit:]]+)$$'))
 PULL_POLICY ?= IfNotPresent
+else
+PULL_POLICY ?= Always
 endif
 export PULL_POLICY
 

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -342,6 +342,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 image: quay.io/cryostat/cryostat-operator:2.1.0-dev
+                imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/config/default/image_pull_patch.yaml
+++ b/config/default/image_pull_patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        imagePullPolicy: "Always"

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -26,6 +26,7 @@ bases:
 
 patchesStrategicMerge:
 - image_tag_patch.yaml
+- image_pull_patch.yaml
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.

--- a/hack/image_pull_patch.yaml.in
+++ b/hack/image_pull_patch.yaml.in
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        imagePullPolicy: "${PULL_POLICY}"

--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -894,11 +894,13 @@ func clusterUniqueName(cr *operatorv1beta1.Cryostat) string {
 }
 
 // Matches image tags of the form "major.minor.patch"
-var releaseVerRegexp = regexp.MustCompile(`:\d+\.\d+\.\d+$`)
+var develVerRegexp = regexp.MustCompile(`(?i)(:latest|SNAPSHOT|dev|BETA\d+)$`)
 
 func getPullPolicy(imageTag string) corev1.PullPolicy {
-	if releaseVerRegexp.MatchString(imageTag) {
-		return corev1.PullIfNotPresent
+	// Use Always for tags that have a known development suffix
+	if develVerRegexp.MatchString(imageTag) {
+		return corev1.PullAlways
 	}
-	return corev1.PullAlways
+	// Likely a release, use IfNotPresent
+	return corev1.PullIfNotPresent
 }

--- a/internal/controllers/cryostat_controller_test.go
+++ b/internal/controllers/cryostat_controller_test.go
@@ -436,8 +436,8 @@ var _ = Describe("CryostatController", func() {
 			})
 			Context("for development", func() {
 				BeforeEach(func() {
-					coreImg := "my/core-image:1.0.0-dev"
-					datasourceImg := "my/datasource-image:1.0.0-dev"
+					coreImg := "my/core-image:1.0.0-SNAPSHOT"
+					datasourceImg := "my/datasource-image:1.0.0-BETA25"
 					grafanaImg := "my/grafana-image:1.0.0-dev"
 					t.EnvCoreImageTag = &coreImg
 					t.EnvDatasourceImageTag = &datasourceImg
@@ -471,6 +471,46 @@ var _ = Describe("CryostatController", func() {
 					Expect(containers).To(HaveLen(3))
 					for _, container := range containers {
 						Expect(container.ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
+					}
+				})
+			})
+			Context("by digest", func() {
+				BeforeEach(func() {
+					coreImg := "my/core-image@sha256:99b57e9b8880bc5d4d799b508603628c37c3e6a0d4bdd0988e9dc3ad8e04c495"
+					datasourceImg := "my/datasource-image@sha256:59ded87392077c2371b26e021aade0409855b597383fa78e549eefafab8fc90c"
+					grafanaImg := "my/grafana-image@sha256:e5bc16c2c5b69cd6fd8fdf1381d0a8b6cc9e01d92b9e1bb0a61ed89196563c72"
+					t.EnvCoreImageTag = &coreImg
+					t.EnvDatasourceImageTag = &datasourceImg
+					t.EnvGrafanaImageTag = &grafanaImg
+				})
+				It("should create deployment with the expected tags", func() {
+					t.checkDeployment()
+				})
+				It("should set ImagePullPolicy to IfNotPresent", func() {
+					containers := deploy.Spec.Template.Spec.Containers
+					Expect(containers).To(HaveLen(3))
+					for _, container := range containers {
+						Expect(container.ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
+					}
+				})
+			})
+			Context("with latest", func() {
+				BeforeEach(func() {
+					coreImg := "my/core-image:latest"
+					datasourceImg := "my/datasource-image:latest"
+					grafanaImg := "my/grafana-image:latest"
+					t.EnvCoreImageTag = &coreImg
+					t.EnvDatasourceImageTag = &datasourceImg
+					t.EnvGrafanaImageTag = &grafanaImg
+				})
+				It("should create deployment with the expected tags", func() {
+					t.checkDeployment()
+				})
+				It("should set ImagePullPolicy to Always", func() {
+					containers := deploy.Spec.Template.Spec.Containers
+					Expect(containers).To(HaveLen(3))
+					for _, container := range containers {
+						Expect(container.ImagePullPolicy).To(Equal(corev1.PullAlways))
 					}
 				})
 			})


### PR DESCRIPTION
Uses a regular expression to check image tags for the following suffixes:
* latest
* SNAPSHOT
* dev
* BETA[0-9]+

If any of the above are found the pull policy for that image will be set to `Always`.

For the operator controller deployment, this is done using a Kustomize patch that is updated by the Makefile depending on the regex test. For the operand images, this same check is done in resource_definitions.go when creating the Deployment spec.

Fixes: #254