### PR TITLE
fix(deploy): set CRYOSTAT_SSL_PROXIED only for TLS ingress/route

### DIFF
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -309,10 +309,6 @@ func NewCoreContainer(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, imageTa
 	clientlibPath := "/opt/cryostat.d/clientlib.d"
 	envs := []corev1.EnvVar{
 		{
-			Name:  "CRYOSTAT_SSL_PROXIED",
-			Value: "true",
-		},
-		{
 			Name:  "CRYOSTAT_ALLOW_UNTRUSTED_SSL",
 			Value: "true",
 		},
@@ -442,6 +438,13 @@ func NewCoreContainer(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, imageTa
 			Name:  "CRYOSTAT_DISABLE_SSL",
 			Value: "true",
 		})
+		// Set CRYOSTAT_SSL_PROXIED if Ingress/Route use HTTPS
+		if specs.CoreURL != nil && specs.CoreURL.Scheme == "https" {
+			envs = append(envs, corev1.EnvVar{
+				Name:  "CRYOSTAT_SSL_PROXIED",
+				Value: "true",
+			})
+		}
 	} else {
 		// Configure keystore location and password in expected environment variables
 		envs = append(envs, corev1.EnvVar{


### PR DESCRIPTION
This modifies the deployment spec to only set `CRYOSTAT_SSL_PROXIED` when cert-manager is disabled, but the Route/Ingress use TLS. I've added a test for this scenario with Ingress, currently Routes are always created with TLS.

Related to: #293 