### PR TITLE
fix(ingress): Recommend Ingress timeout as 3600s

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -93,6 +93,8 @@ spec:
     coreConfig:
       annotations:
         nginx.ingress.kubernetes.io/backend-protocol : HTTPS
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+        nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
       ingressSpec:
         tls:
         - {}
@@ -110,6 +112,8 @@ spec:
     commandConfig:
       annotations:
         nginx.ingress.kubernetes.io/backend-protocol : HTTPS
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+        nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
       ingressSpec:
         tls:
         - {}
@@ -127,6 +131,8 @@ spec:
     grafanaConfig:
       annotations:
         nginx.ingress.kubernetes.io/backend-protocol : HTTPS
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+        nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
       ingressSpec:
         tls:
         - {}


### PR DESCRIPTION
Fixes #311 

Since users are responsible for configuring the Ingress configurations, I added the recommended annotations in the readme.