### PR TITLE
fix(deploy): mount probe template directory

### DIFF
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -309,6 +309,7 @@ func NewCoreContainer(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, imageTa
 	archivePath := "/opt/cryostat.d/recordings.d"
 	templatesPath := "/opt/cryostat.d/templates.d"
 	clientlibPath := "/opt/cryostat.d/clientlib.d"
+	probesPath := "/opt/cryostat.d/probes.d"
 	envs := []corev1.EnvVar{
 		{
 			Name:  "CRYOSTAT_ALLOW_UNTRUSTED_SSL",
@@ -337,6 +338,10 @@ func NewCoreContainer(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, imageTa
 		{
 			Name:  "CRYOSTAT_CLIENTLIB_PATH",
 			Value: clientlibPath,
+		},
+		{
+			Name:  "CRYOSTAT_PROBE_TEMPLATE_PATH",
+			Value: probesPath,
 		},
 	}
 	if specs.CoreURL != nil {
@@ -417,6 +422,11 @@ func NewCoreContainer(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, imageTa
 			Name:      cr.Name,
 			MountPath: clientlibPath,
 			SubPath:   "clientlib",
+		},
+		{
+			Name:      cr.Name,
+			MountPath: probesPath,
+			SubPath:   "probes",
 		},
 		{
 			Name:      cr.Name,

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -889,6 +889,10 @@ func NewCoreEnvironmentVariables(minimal bool, tls bool, externalTLS bool, opens
 			Name:  "CRYOSTAT_CLIENTLIB_PATH",
 			Value: "/opt/cryostat.d/clientlib.d",
 		},
+		{
+			Name:  "CRYOSTAT_PROBE_TEMPLATE_PATH",
+			Value: "/opt/cryostat.d/probes.d",
+		},
 	}
 
 	if externalTLS {
@@ -1064,6 +1068,12 @@ func NewCoreVolumeMounts(tls bool) []corev1.VolumeMount {
 			ReadOnly:  false,
 			MountPath: "/opt/cryostat.d/clientlib.d",
 			SubPath:   "clientlib",
+		},
+		{
+			Name:      "cryostat",
+			ReadOnly:  false,
+			MountPath: "/opt/cryostat.d/probes.d",
+			SubPath:   "probes",
 		},
 		{
 			Name:      "cryostat",


### PR DESCRIPTION
Adds a subpath volume mount using the PVC for the probe template directory, and sets the `CRYOSTAT_PROBE_TEMPLATE_PATH` variable.

Fixes: #317 