### PR TITLE
feat(auth): Add logout permissions to service account

### DIFF
--- a/bundle/manifests/cryostat-operator-cryostat_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/cryostat-operator-cryostat_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -16,3 +16,10 @@ rules:
   - selfsubjectaccessreviews
   verbs:
   - create
+- apiGroups:
+  - oauth.openshift.io
+  resources:
+  - oauthaccesstokens
+  verbs:
+  - list
+  - delete

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -310,6 +310,13 @@ spec:
           - list
           - update
         - apiGroups:
+          - oauth.openshift.io
+          resources:
+          - oauthaccesstokens
+          verbs:
+          - delete
+          - list
+        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - clusterrolebindings

--- a/config/rbac/cryostat_role.yaml
+++ b/config/rbac/cryostat_role.yaml
@@ -17,3 +17,10 @@ rules:
   - selfsubjectaccessreviews
   verbs:
   - create
+- apiGroups:
+  - oauth.openshift.io
+  resources:
+  - oauthaccesstokens
+  verbs:
+  - list
+  - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -37,6 +37,13 @@ rules:
   - list
   - update
 - apiGroups:
+  - oauth.openshift.io
+  resources:
+  - oauthaccesstokens
+  verbs:
+  - delete
+  - list
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings

--- a/internal/controllers/cryostat_controller.go
+++ b/internal/controllers/cryostat_controller.go
@@ -108,6 +108,7 @@ var supGroupRegexp = regexp.MustCompile(`^\d+`)
 // +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=selfsubjectaccessreviews,verbs=create
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups=oauth.openshift.io,resources=oauthaccesstokens,verbs=list;delete
 // +kubebuilder:rbac:namespace=system,groups=route.openshift.io,resources=routes;routes/custom-host,verbs=*
 // +kubebuilder:rbac:namespace=system,groups=apps.openshift.io,resources=deploymentconfigs,verbs=get
 // +kubebuilder:rbac:namespace=system,groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=*


### PR DESCRIPTION
Related https://github.com/cryostatio/cryostat/issues/717

Adds permissions needed for the backend to `list` and `delete` an `oauthaccesstoken`. 

I believe the `oc logout` command in the OpenShift docs corresponds to the cryostat frontend `POST https://oauth-server-namespace-route/logout` request that removes the session cookie stored in the OAuth server. This `/logout` call invalidates the token but does not delete any existing invalid tokens, which is why the backend needs to make a second request to delete the access token.

[OpenShift OAuth logout docs](https://docs.openshift.com/container-platform/4.9/authentication/managing-oauth-access-tokens.html#oauth-delete-tokens_managing-oauth-access-tokens)
[OpenShift OAuth endpoint for deleting access tokens](https://docs.openshift.com/container-platform/4.9/rest_api/oauth_apis/oauthaccesstoken-oauth-openshift-io-v1.html#oauthaccesstoken-oauth-openshift-io-v1)