### PR TITLE
docs(ingress): Remove unneeded ingress timeouts

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -120,8 +120,6 @@ spec:
     coreConfig:
       annotations:
         nginx.ingress.kubernetes.io/backend-protocol : HTTPS
-        nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-        nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
       ingressSpec:
         tls:
         - {}
@@ -139,8 +137,6 @@ spec:
     commandConfig:
       annotations:
         nginx.ingress.kubernetes.io/backend-protocol : HTTPS
-        nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-        nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
       ingressSpec:
         tls:
         - {}
@@ -158,8 +154,6 @@ spec:
     grafanaConfig:
       annotations:
         nginx.ingress.kubernetes.io/backend-protocol : HTTPS
-        nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-        nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
       ingressSpec:
         tls:
         - {}


### PR DESCRIPTION
Related #757

This reverts commit e524857960ffdfe44eaa360e9fd215d14b968953.

Now that the server keepalive pings in https://github.com/cryostatio/cryostat/pull/792 is merged, we can remove the extra ingress annotations to extend the idle timeout.