### PR TITLE
fix(jdp): disable JDP autodiscovery

### DIFF
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -448,6 +448,10 @@ func NewCoreContainer(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, imageTa
 			Name:  "CRYOSTAT_PROBE_TEMPLATE_PATH",
 			Value: probesPath,
 		},
+		{
+			Name:  "CRYOSTAT_ENABLE_JDP_BROADCAST",
+			Value: "false",
+		},
 	}
 	if specs.CoreURL != nil {
 		coreEnvs := []corev1.EnvVar{

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -985,6 +985,10 @@ func NewCoreEnvironmentVariables(minimal bool, tls bool, externalTLS bool, opens
 			Value: "/opt/cryostat.d/probes.d",
 		},
 		{
+			Name:  "CRYOSTAT_ENABLE_JDP_BROADCAST",
+			Value: "false",
+		},
+		{
 			Name:  "CRYOSTAT_MAX_WS_CONNECTIONS",
 			Value: "2",
 		},


### PR DESCRIPTION
Set the new `CRYOSTAT_ENABLE_JDP_BROADCAST` environment variable to false, since we don't need JDP on Kubernetes/OpenShift and to avoid network multicast issues.

Fixes: #255
Related to: https://github.com/cryostatio/cryostat/issues/803