### PR TITLE
fix(grafana): use loopback alias for Grafana health check

### DIFF
--- a/internal/controllers/common/resource_definitions/certificates.go
+++ b/internal/controllers/common/resource_definitions/certificates.go
@@ -143,6 +143,7 @@ func NewGrafanaCert(cr *operatorv1beta1.Cryostat) *certv1.Certificate {
 				cr.Name,
 				fmt.Sprintf("%s-grafana.%s.svc", cr.Name, cr.Namespace),
 				fmt.Sprintf("%s-grafana.%s.svc.cluster.local", cr.Name, cr.Namespace),
+				healthCheckHostname,
 			},
 			SecretName: cr.Name + "-grafana-tls",
 			IssuerRef: certMeta.ObjectReference{

--- a/internal/controllers/cryostat_controller.go
+++ b/internal/controllers/cryostat_controller.go
@@ -925,8 +925,6 @@ func requeueIfIngressNotReady(log logr.Logger, err error) (reconcile.Result, err
 func getNetworkConfig(controller *operatorv1beta1.Cryostat, svc *corev1.Service) (*operatorv1beta1.NetworkConfiguration, error) {
 	if svc.Name == controller.Name {
 		return controller.Spec.NetworkOptions.CoreConfig, nil
-	} else if svc.Name == controller.Name+"-command" {
-		return controller.Spec.NetworkOptions.CommandConfig, nil
 	} else if svc.Name == controller.Name+"-grafana" {
 		return controller.Spec.NetworkOptions.GrafanaConfig, nil
 	} else {

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -1069,13 +1069,13 @@ func NewCoreEnvironmentVariables(minimal bool, tls bool, externalTLS bool, opens
 			envs = append(envs,
 				corev1.EnvVar{
 					Name:  "GRAFANA_DASHBOARD_URL",
-					Value: "https://127.0.0.1:3000",
+					Value: "https://cryostat-health.local:3000",
 				})
 		} else {
 			envs = append(envs,
 				corev1.EnvVar{
 					Name:  "GRAFANA_DASHBOARD_URL",
-					Value: "http://127.0.0.1:3000",
+					Value: "http://cryostat-health.local:3000",
 				})
 		}
 	}

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -967,9 +967,6 @@ func NewCorePorts() []corev1.ContainerPort {
 			ContainerPort: 8181,
 		},
 		{
-			ContainerPort: 9090,
-		},
-		{
 			ContainerPort: 9091,
 		},
 	}
@@ -1058,14 +1055,27 @@ func NewCoreEnvironmentVariables(minimal bool, tls bool, externalTLS bool, opens
 		if externalTLS {
 			envs = append(envs,
 				corev1.EnvVar{
-					Name:  "GRAFANA_DASHBOARD_URL",
+					Name:  "GRAFANA_DASHBOARD_EXT_URL",
 					Value: "https://cryostat-grafana.example.com",
 				})
 		} else {
 			envs = append(envs,
 				corev1.EnvVar{
-					Name:  "GRAFANA_DASHBOARD_URL",
+					Name:  "GRAFANA_DASHBOARD_EXT_URL",
 					Value: "http://cryostat-grafana.example.com",
+				})
+		}
+		if tls {
+			envs = append(envs,
+				corev1.EnvVar{
+					Name:  "GRAFANA_DASHBOARD_URL",
+					Value: "https://127.0.0.1:3000",
+				})
+		} else {
+			envs = append(envs,
+				corev1.EnvVar{
+					Name:  "GRAFANA_DASHBOARD_URL",
+					Value: "http://127.0.0.1:3000",
 				})
 		}
 	}
@@ -1536,15 +1546,11 @@ func NewNetworkConfigurationList(tls bool) operatorv1beta1.NetworkConfigurationL
 	coreSVC := resource_definitions.NewCoreService(NewCryostat())
 	coreIng := NewNetworkConfiguration(coreSVC.Name, coreSVC.Spec.Ports[0].Port, tls)
 
-	commandSVC := resource_definitions.NewCommandChannelService(NewCryostat())
-	commandIng := NewNetworkConfiguration(commandSVC.Name, commandSVC.Spec.Ports[0].Port, tls)
-
 	grafanaSVC := resource_definitions.NewGrafanaService(NewCryostat())
 	grafanaIng := NewNetworkConfiguration(grafanaSVC.Name, grafanaSVC.Spec.Ports[0].Port, tls)
 
 	return operatorv1beta1.NetworkConfigurationList{
 		CoreConfig:    &coreIng,
-		CommandConfig: &commandIng,
 		GrafanaConfig: &grafanaIng,
 	}
 }


### PR DESCRIPTION
This PR adds a [HostAlias](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/) for `127.0.0.1` to a `cryostat-health.local` hostname. We add this hostname as a SAN to our self-signed certificate issued by cert-manager. This is preferred over adding the loopback address directly, since our custom hostname is unlikely to be resolvable outside of our pod.

Fixes: #351, #357 

Previous approach using `127.0.0.1` directly:
~~Currently failing due to lack of loopback address as a Subject Alternative Name:~~
```
INFO: (10.217.0.1:44504): GET /health 200 16ms
Mar 07, 2022 10:25:15 PM io.cryostat.core.log.Logger warn
WARNING: Exception thrown
java.io.IOException: javax.net.ssl.SSLHandshakeException: Failed to create SSL connection
	at io.cryostat.net.web.http.generic.HealthGetHandler.lambda$checkUri$0(HealthGetHandler.java:164)
	at io.vertx.ext.web.client.impl.HttpContext.handleFailure(HttpContext.java:309)
	at io.vertx.ext.web.client.impl.HttpContext.execute(HttpContext.java:303)
	at io.vertx.ext.web.client.impl.HttpContext.next(HttpContext.java:275)
	at io.vertx.ext.web.client.impl.predicate.PredicateInterceptor.handle(PredicateInterceptor.java:70)
	at io.vertx.ext.web.client.impl.predicate.PredicateInterceptor.handle(PredicateInterceptor.java:32)
	at io.vertx.ext.web.client.impl.HttpContext.next(HttpContext.java:272)
	at io.vertx.ext.web.client.impl.HttpContext.fire(HttpContext.java:282)
	at io.vertx.ext.web.client.impl.HttpContext.fail(HttpContext.java:262)
	at io.vertx.ext.web.client.impl.HttpContext.lambda$handleSendRequest$7(HttpContext.java:422)
	at io.vertx.core.impl.FutureImpl.tryFail(FutureImpl.java:195)
	at io.vertx.ext.web.client.impl.HttpContext.lambda$handleSendRequest$15(HttpContext.java:518)
	at io.vertx.core.http.impl.HttpClientRequestBase.handleException(HttpClientRequestBase.java:133)
	at io.vertx.core.http.impl.HttpClientRequestImpl.handleException(HttpClientRequestImpl.java:371)
	at io.vertx.core.http.impl.HttpClientRequestImpl.lambda$null$6(HttpClientRequestImpl.java:473)
	at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:366)
	at io.vertx.core.impl.EventLoopContext.execute(EventLoopContext.java:43)
	at io.vertx.core.impl.ContextImpl.executeFromIO(ContextImpl.java:229)
	at io.vertx.core.impl.ContextImpl.executeFromIO(ContextImpl.java:221)
	at io.vertx.core.http.impl.HttpClientRequestImpl.lambda$connect$7(HttpClientRequestImpl.java:472)
	at io.vertx.core.http.impl.HttpClientImpl.lambda$getConnectionForRequest$4(HttpClientImpl.java:1048)
	at io.vertx.core.http.impl.ConnectionManager.lambda$getConnection$7(ConnectionManager.java:159)
	at io.vertx.core.http.impl.pool.Pool.connectFailed(Pool.java:397)
	at io.vertx.core.http.impl.pool.Pool.access$600(Pool.java:89)
	at io.vertx.core.http.impl.pool.Pool$Holder.lambda$connect$0(Pool.java:129)
	at io.vertx.core.impl.FutureImpl.tryFail(FutureImpl.java:195)
	at io.vertx.core.http.impl.HttpChannelConnector.connectFailed(HttpChannelConnector.java:255)
	at io.vertx.core.http.impl.HttpChannelConnector.lambda$doConnect$0(HttpChannelConnector.java:164)
	at io.vertx.core.net.impl.ChannelProvider.lambda$connect$1(ChannelProvider.java:78)
	at io.vertx.core.net.impl.ChannelProvider$1.userEventTriggered(ChannelProvider.java:117)
	at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:346)
	at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:332)
	at io.netty.channel.AbstractChannelHandlerContext.fireUserEventTriggered(AbstractChannelHandlerContext.java:324)
	at io.netty.handler.ssl.SslHandler.handleUnwrapThrowable(SslHandler.java:1260)
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1241)
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1285)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:507)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:446)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:276)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:719)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:655)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:581)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:493)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: javax.net.ssl.SSLHandshakeException: Failed to create SSL connection
	at io.vertx.core.net.impl.ChannelProvider$1.userEventTriggered(ChannelProvider.java:115)
	... 25 more
Caused by: javax.net.ssl.SSLHandshakeException: No subject alternative names matching IP address 127.0.0.1 found
	at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:131)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:349)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:292)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:287)
	at java.base/sun.security.ssl.CertificateMessage$T12CertificateConsumer.checkServerCerts(CertificateMessage.java:654)
	at java.base/sun.security.ssl.CertificateMessage$T12CertificateConsumer.onCertificate(CertificateMessage.java:473)
	at java.base/sun.security.ssl.CertificateMessage$T12CertificateConsumer.consume(CertificateMessage.java:369)
	at java.base/sun.security.ssl.SSLHandshake.consume(SSLHandshake.java:392)
	at java.base/sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:443)
	at java.base/sun.security.ssl.SSLEngineImpl$DelegatedTask$DelegatedAction.run(SSLEngineImpl.java:1074)
	at java.base/sun.security.ssl.SSLEngineImpl$DelegatedTask$DelegatedAction.run(SSLEngineImpl.java:1061)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/sun.security.ssl.SSLEngineImpl$DelegatedTask.run(SSLEngineImpl.java:1008)
	at io.netty.handler.ssl.SslHandler.runDelegatedTasks(SslHandler.java:1549)
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1395)
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1236)
	... 20 more
Caused by: java.security.cert.CertificateException: No subject alternative names matching IP address 127.0.0.1 found
	at java.base/sun.security.util.HostnameChecker.matchIP(HostnameChecker.java:165)
	at java.base/sun.security.util.HostnameChecker.match(HostnameChecker.java:101)
	at java.base/sun.security.ssl.X509TrustManagerImpl.checkIdentity(X509TrustManagerImpl.java:455)
	at java.base/sun.security.ssl.X509TrustManagerImpl.checkIdentity(X509TrustManagerImpl.java:429)
	at java.base/sun.security.ssl.X509TrustManagerImpl.checkTrusted(X509TrustManagerImpl.java:283)
	at java.base/sun.security.ssl.X509TrustManagerImpl.checkServerTrusted(X509TrustManagerImpl.java:141)
	at java.base/sun.security.ssl.CertificateMessage$T12CertificateConsumer.checkServerCerts(CertificateMessage.java:632)
	... 31 more
```

~~While we could easily add the loopback address as a SAN to the certificate generated by cert-manager, this may not be ideal from a security perspective.~~