### PR TITLE
fix(api): deprecate FlightRecorder and Recording CRDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,6 @@ kubectl get secret ${CRYOSTAT_NAME}-jmx-auth -o jsonpath='{$.data.CRYOSTAT_RJMX_
 kubectl get secret ${CRYOSTAT_NAME}-jmx-auth -o jsonpath='{$.data.CRYOSTAT_RJMX_PASS}' | base64 -d
 ```
 
-## Kubernetes API
-The operator provides a Kubernetes API to directly create and manage Flight Recordings.
-See [Kubernetes API Overview](docs/api.md) for more details.
-
 # Building
 ## Requirements
 - `go` v1.15

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -81,6 +81,7 @@ metadata:
         }
       }
     operators.operatorframework.io/builder: operator-sdk-v1.4.0+git
+    operators.operatorframework.io/internal-objects: '["flightrecorders.operator.cryostat.io","recordings.operator.cryostat.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: github.com/cryostatio/cryostat-operator
     support: Cryostat Community

--- a/bundle/manifests/operator.cryostat.io_flightrecorders.yaml
+++ b/bundle/manifests/operator.cryostat.io_flightrecorders.yaml
@@ -14,7 +14,9 @@ spec:
     singular: flightrecorder
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - deprecated: true
+    deprecationWarning: operator.cryostat.io/v1beta1 FlightRecorder is deprecated; please use the Cryostat web application or the Cryostat HTTP API to manage recordings
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: FlightRecorder represents a target Pod that is capable of creating JDK Flight Recordings using Cryostat. The Cryostat operator creates FlightRecorder objects when it finds compatible Pods.

--- a/bundle/manifests/operator.cryostat.io_recordings.yaml
+++ b/bundle/manifests/operator.cryostat.io_recordings.yaml
@@ -14,7 +14,9 @@ spec:
     singular: recording
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - deprecated: true
+    deprecationWarning: operator.cryostat.io/v1beta1 Recording is deprecated; please use the Cryostat web application or the Cryostat HTTP API to manage recordings
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: Recording represents a JDK Flight Recording. Create a Recording object to instruct Cryostat to start a new recording for a Pod. An alternative to managing recordings with the Cryostat web application.

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -22,6 +22,21 @@ patchesStrategicMerge:
 #- patches/cainjection_in_flightrecorders.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
+# FIXME Remove once migrated to kubebuilder markers
+patches:
+- path: patches/deprecate_flightrecorders.yaml
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: flightrecorders.operator.cryostat.io
+- path: patches/deprecate_recordings.yaml
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: recordings.operator.cryostat.io
+
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
 - kustomizeconfig.yaml

--- a/config/crd/patches/deprecate_flightrecorders.yaml
+++ b/config/crd/patches/deprecate_flightrecorders.yaml
@@ -1,0 +1,8 @@
+# FIXME this can be done using kubebuilder markers
+# after upgrading Operator SDK to 1.10+
+- op: add
+  path: /spec/versions/0/deprecated
+  value: true
+- op: add
+  path: /spec/versions/0/deprecationWarning
+  value: "operator.cryostat.io/v1beta1 FlightRecorder is deprecated; please use the Cryostat web application or the Cryostat HTTP API to manage recordings"

--- a/config/crd/patches/deprecate_recordings.yaml
+++ b/config/crd/patches/deprecate_recordings.yaml
@@ -1,0 +1,8 @@
+# FIXME this can be done using kubebuilder markers
+# after upgrading Operator SDK to 1.10+
+- op: add
+  path: /spec/versions/0/deprecated
+  value: true
+- op: add
+  path: /spec/versions/0/deprecationWarning
+  value: "operator.cryostat.io/v1beta1 Recording is deprecated; please use the Cryostat web application or the Cryostat HTTP API to manage recordings"

--- a/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
@@ -69,6 +69,7 @@ metadata:
         }
       }
     operators.operatorframework.io/builder: operator-sdk-v1.5.0
+    operators.operatorframework.io/internal-objects: '["flightrecorders.operator.cryostat.io","recordings.operator.cryostat.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: github.com/cryostatio/cryostat-operator
     support: Cryostat Community

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,4 +1,4 @@
-# Kubernetes API Overview
+# (Deprecated) Kubernetes API Overview
 
 This operator provides a Kubernetes API to interact with [Cryostat](https://github.com/cryostatio/cryostat).
 This API comes in the form of the `FlightRecorders` and `Recordings` Custom Resource Definitions, and allows you to create, list, delete, and download recordings from a Kubernetes cluster.


### PR DESCRIPTION
The CRD spec has properties for whether a version is deprecated and a warning string to show the user when they try to use that version. Newer controller-tools versions support these properties using marker comments, but this requires Operator SDK 1.10 and we're still quite a bit behind that (see #287). In the meantime, I've added Kustomize patches to add these properties.

Example:
```
$ kubectl get recording
Warning: operator.cryostat.io/v1beta1 Recording is deprecated; please use the Cryostat web application or the Cryostat HTTP API to manage recordings
No resources found in cryostat-operator-system namespace.
```

I didn't see this have an effect in the UI, so I've added the `operators.operatorframework.io/internal-objects` annotation to our CSV. This results in the FlightRecorder and Recording APIs being hidden from the OpenShift Console's operator UI. The functionality remains available via command line or through the CustomResourceDefinitions page in the OpenShift Console.

Bundle for testing:
```
make deploy_bundle BUNDLE_IMG=quay.io/ebaron/cryostat-operator-bundle:deprecate-api-01
```

Fixes: #349 