### PR TITLE
chore(resources): update AUTH_MANAGER env var value for moved package

### DIFF
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -547,7 +547,7 @@ func NewCoreContainer(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, imageTa
 			},
 			{
 				Name:  "CRYOSTAT_AUTH_MANAGER",
-				Value: "io.cryostat.net.OpenShiftAuthManager",
+				Value: "io.cryostat.net.openshift.OpenShiftAuthManager",
 			},
 			{
 				Name:  "CRYOSTAT_OAUTH_CLIENT_ID",

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -1143,7 +1143,7 @@ func NewCoreEnvironmentVariables(minimal bool, tls bool, externalTLS bool, opens
 			},
 			corev1.EnvVar{
 				Name:  "CRYOSTAT_AUTH_MANAGER",
-				Value: "io.cryostat.net.OpenShiftAuthManager",
+				Value: "io.cryostat.net.openshift.OpenShiftAuthManager",
 			},
 			corev1.EnvVar{
 				Name:  "CRYOSTAT_OAUTH_CLIENT_ID",


### PR DESCRIPTION
Depends on https://github.com/cryostatio/cryostat/pull/884

The `OpenShiftAuthManager` has been moved into a subpackage, so this just updates the env var that selects the auth manager impl to point to the new location/corrected fully-qualified class name.