### PR TITLE
fix(sa): update existing service account

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,10 +12,6 @@ namePrefix: cryostat-operator-
 #commonLabels:
 #  someName: someValue
 
-bases:
-- ../crd
-- ../rbac
-- ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook
@@ -49,31 +45,9 @@ patchesStrategicMerge:
 #- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
-vars:
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: CERTIFICATE_NAME
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#- name: SERVICE_NAMESPACE # namespace of the service
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: SERVICE_NAME
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../crd
+- ../rbac
+- ../manager


### PR DESCRIPTION
To test:
1. `make deploy create_cryostat_cr IMG=quay.io/cryostat/cryostat-operator:2.0.0 CORE_IMG=quay.io/cryostat/cryostat:2.0.0`
2. `kubectl patch deploy cryostat-operator-controller-manager -p '{"spec": {"template": {"spec": {"containers": [{"name": "manager", "image": "quay.io/ebaron/cryostat-operator:sa-upgrade-01"}]}}}}'`
3. `kubectl set env deploy cryostat-operator-controller-manager RELATED_IMAGE_CORE="quay.io/cryostat/cryostat:2.1.0-SNAPSHOT"`
4. After a short time, verify the Service Account is updated with the annotation, and that you can log into Cryostat.

Fixes: #382 