### PR TITLE
feat(license): add license header checking script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,7 @@ LICENSE_FILE=$(shell pwd)/LICENSE
 add-license: addlicense
 	@echo "Checking/Adding license..."
 	@$(ADDLICENSE) -v -f $(LICENSE_FILE) api internal 2>&1
+	@go list -f '{{.Dir}}' ./... | sed -e "s|^$$(pwd)||" | cut -d/ -f2 | sort | uniq | xargs $(ADDLICENSE) -v -f LICENSE
 	@echo "All good"
 
 # Build the OCI image

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ manifests: controller-gen
 
 # Run go fmt against code
 .PHONY: fmt
-fmt:
+fmt: add-license
 	go fmt ./...
 
 # Run go vet against code
@@ -170,9 +170,9 @@ generate: controller-gen
 LICENSE_FILE=$(shell pwd)/LICENSE
 .PHONY: add-license 
 add-license: addlicense
-	@echo "[RUNNING] Checking/Adding license..."
+	@echo "Checking/Adding license..."
 	@$(ADDLICENSE) -v -f $(LICENSE_FILE) api internal 2>&1
-	@echo "[DONE] All good"
+	@echo "All good"
 
 # Build the OCI image
 .PHONY: oci-build

--- a/Makefile
+++ b/Makefile
@@ -171,8 +171,7 @@ LICENSE_FILE=$(shell pwd)/LICENSE
 .PHONY: add-license 
 add-license: addlicense
 	@echo "Checking/Adding license..."
-	@$(ADDLICENSE) -v -f $(LICENSE_FILE) api internal 2>&1
-	@go list -f '{{.Dir}}' ./... | sed -e "s|^$$(pwd)||" | cut -d/ -f2 | sort | uniq | xargs $(ADDLICENSE) -v -f $(LICENSE_FILE)
+	@go list -f '{{.Dir}}' ./... | sed -e "s|^$$(pwd)||" | cut -d/ -f2 | sort | uniq | xargs $(ADDLICENSE) -v -f $(LICENSE_FILE) 2>&1
 	@echo "All good"
 
 # Build the OCI image

--- a/Makefile
+++ b/Makefile
@@ -171,8 +171,7 @@ LICENSE_FILE=$(shell pwd)/LICENSE
 .PHONY: add-license 
 add-license: addlicense
 	@echo "Checking/Adding license..."
-	@go list -f '{{.Dir}}' ./... | sed -e "s|^$$(pwd)||" | cut -d/ -f2 | uniq | xargs $(ADDLICENSE) -v -f $(LICENSE_FILE) 2>&1
-	@echo "All good"
+	@go list -f '{{.Dir}}' ./... | sed -e "s|^$$(pwd)||" | cut -d/ -f2 | uniq | xargs $(ADDLICENSE) -v -f $(LICENSE_FILE)
 
 # Build the OCI image
 .PHONY: oci-build

--- a/Makefile
+++ b/Makefile
@@ -170,8 +170,9 @@ generate: controller-gen
 LICENSE_FILE=$(shell pwd)/LICENSE
 .PHONY: add-license 
 add-license: addlicense
-	@echo "Checking/Adding license..."
-	@go list -f '{{.Dir}}' ./... | sed -e "s|^$$(pwd)||" | cut -d/ -f2 | uniq | xargs $(ADDLICENSE) -v -f $(LICENSE_FILE)
+	echo "Checking/Adding license..."
+	$(eval GO_PACKAGES  := $(shell go list -f '{{.Dir}}' ./... | sed -e "s|^$$(pwd)||" | cut -d/ -f2 | uniq))
+	$(ADDLICENSE) -v -f $(LICENSE_FILE) ${GO_PACKAGES}
 
 # Build the OCI image
 .PHONY: oci-build

--- a/Makefile
+++ b/Makefile
@@ -167,11 +167,11 @@ generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 # Check and add (if missing) license header
-LICENSE_FILE=$(shell pwd)/LICENSE
+LICENSE_FILE = $(shell pwd)/LICENSE
+GO_PACKAGES := $(shell go list -f '{{.Dir}}' ./... | sed -e "s|^$$(pwd)||" | cut -d/ -f2 | sort -u)
 .PHONY: add-license 
 add-license: addlicense
-	echo "Checking/Adding license..."
-	$(eval GO_PACKAGES  := $(shell go list -f '{{.Dir}}' ./... | sed -e "s|^$$(pwd)||" | cut -d/ -f2 | uniq))
+	@echo "Checking/Adding license..."
 	$(ADDLICENSE) -v -f $(LICENSE_FILE) ${GO_PACKAGES}
 
 # Build the OCI image

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ LICENSE_FILE=$(shell pwd)/LICENSE
 add-license: addlicense
 	@echo "Checking/Adding license..."
 	@$(ADDLICENSE) -v -f $(LICENSE_FILE) api internal 2>&1
-	@go list -f '{{.Dir}}' ./... | sed -e "s|^$$(pwd)||" | cut -d/ -f2 | sort | uniq | xargs $(ADDLICENSE) -v -f LICENSE
+	@go list -f '{{.Dir}}' ./... | sed -e "s|^$$(pwd)||" | cut -d/ -f2 | sort | uniq | xargs $(ADDLICENSE) -v -f $(LICENSE_FILE)
 	@echo "All good"
 
 # Build the OCI image

--- a/Makefile
+++ b/Makefile
@@ -170,13 +170,9 @@ generate: controller-gen
 LICENSE_FILE=$(shell pwd)/LICENSE
 .PHONY: add-license 
 add-license: addlicense
-	@echo "Checking/Adding license..."
-	@for f in $$(find . -path "./vendor" -prune -o \( -iname '*.go' ! -iname '*.deepcopy.go' \) -type f -print); \
-	do \
-		$(ADDLICENSE) -check -f $(LICENSE_FILE) $${f} &>/dev/null && echo "[OK] $${f}" && continue; \
-		$(ADDLICENSE) -f $(LICENSE_FILE) $${f} &>/dev/null && echo "[Modified] $${f}"; \
-	done
-	@echo "All good"
+	@echo "[RUNNING] Checking/Adding license..."
+	@$(ADDLICENSE) -v -f $(LICENSE_FILE) api internal 2>&1
+	@echo "[DONE] All good"
 
 # Build the OCI image
 .PHONY: oci-build

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ LICENSE_FILE=$(shell pwd)/LICENSE
 .PHONY: add-license 
 add-license: addlicense
 	@echo "Checking/Adding license..."
-	@go list -f '{{.Dir}}' ./... | sed -e "s|^$$(pwd)||" | cut -d/ -f2 | sort | uniq | xargs $(ADDLICENSE) -v -f $(LICENSE_FILE) 2>&1
+	@go list -f '{{.Dir}}' ./... | sed -e "s|^$$(pwd)||" | cut -d/ -f2 | uniq | xargs $(ADDLICENSE) -v -f $(LICENSE_FILE) 2>&1
 	@echo "All good"
 
 # Build the OCI image

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ generate: controller-gen
 
 # Check and add (if missing) license header
 LICENSE_FILE = $(shell pwd)/LICENSE
-GO_PACKAGES := $(shell go list -f '{{.Dir}}' ./... | sed -e "s|^$$(pwd)||" | cut -d/ -f2 | sort -u)
+GO_PACKAGES := $(shell go list -test -f '{{.Dir}}' ./... | sed -e "s|^$$(pwd)||" | cut -d/ -f2 | sort -u)
 .PHONY: add-license 
 add-license: addlicense
 	@echo "Checking/Adding license..."

--- a/api/v1beta1/groupversion_info.go
+++ b/api/v1beta1/groupversion_info.go
@@ -1,18 +1,38 @@
-/*
-Copyright The Cryostat Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright The Cryostat Authors
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or data
+// (collectively the "Software"), free of charge and under any and all copyright
+// rights in the Software, and any and all patent rights owned or freely
+// licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger
+// Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+// one is included with the Software (each a "Larger Work" to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition:
+// The above copyright notice and either this complete permission notice or at
+// a minimum a reference to the UPL must be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 // Package v1beta1 contains API Schema definitions for the operator v1beta1 API group
 // +kubebuilder:object:generate=true

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -1,18 +1,38 @@
-/*
-Copyright The Cryostat Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright The Cryostat Authors
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or data
+// (collectively the "Software"), free of charge and under any and all copyright
+// rights in the Software, and any and all patent rights owned or freely
+// licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger
+// Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+// one is included with the Software (each a "Larger Work" to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition:
+// The above copyright notice and either this complete permission notice or at
+// a minimum a reference to the UPL must be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 package controllers_test
 

--- a/internal/main.go
+++ b/internal/main.go
@@ -1,18 +1,38 @@
-/*
-Copyright The Cryostat Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright The Cryostat Authors
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or data
+// (collectively the "Software"), free of charge and under any and all copyright
+// rights in the Software, and any and all patent rights owned or freely
+// licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger
+// Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+// one is included with the Software (each a "Larger Work" to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition:
+// The above copyright notice and either this complete permission notice or at
+// a minimum a reference to the UPL must be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 package main
 


### PR DESCRIPTION
Resolves #81 

Added a script to check and add license header to source files if needed. Run `make add-license`.

We are using `addlicense v1.0.0` from https://github.com/google/addlicense. 

