### PR TITLE
feat(network): update operator-controlled networking objects

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,9 +6,9 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=cryostat-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.4.0+git
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,9 +5,9 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: cryostat-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.4.0+git
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -49,6 +49,7 @@ import (
 	operatorv1beta1 "github.com/cryostatio/cryostat-operator/api/v1beta1"
 	consolev1 "github.com/openshift/api/console/v1"
 	oauthv1 "github.com/openshift/api/oauth/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -85,6 +86,8 @@ type TLSConfig struct {
 	ReportsSecret string
 	// Name of the secret containing the password for the keystore in CryostatSecret
 	KeystorePassSecret string
+	// PEM-encoded X.509 certificate for the Cryostat CA
+	CACert []byte
 }
 
 const (
@@ -900,161 +903,13 @@ func NewJfrDatasourceContainer(cr *operatorv1beta1.Cryostat, imageTag string) co
 	}
 }
 
-func NewCoreService(cr *operatorv1beta1.Cryostat) *corev1.Service {
-	// Check CR for config
-	var config *operatorv1beta1.CoreServiceConfig
-	if cr.Spec.ServiceOptions == nil || cr.Spec.ServiceOptions.CoreConfig == nil {
-		config = &operatorv1beta1.CoreServiceConfig{}
-	} else {
-		config = cr.Spec.ServiceOptions.CoreConfig
-	}
-
-	// Apply common service defaults
-	configureService(&config.ServiceConfig, cr.Name, "cryostat")
-
-	// Apply default HTTP and JMX port if not provided
-	if config.HTTPPort == nil {
-		httpPort := cryostatHTTPContainerPort
-		config.HTTPPort = &httpPort
-	}
-	if config.JMXPort == nil {
-		jmxPort := cryostatJMXContainerPort
-		config.JMXPort = &jmxPort
-	}
-
-	return &corev1.Service{
+func NewRouteForService(svc *corev1.Service) *routev1.Route {
+	return &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        cr.Name,
-			Namespace:   cr.Namespace,
-			Labels:      config.Labels,
-			Annotations: config.Annotations,
-		},
-		Spec: corev1.ServiceSpec{
-			Type: *config.ServiceType,
-			Selector: map[string]string{
-				"app":       cr.Name,
-				"component": "cryostat",
-			},
-			Ports: []corev1.ServicePort{
-				{
-					Name:       "http",
-					Port:       *config.HTTPPort,
-					TargetPort: intstr.IntOrString{IntVal: cryostatHTTPContainerPort},
-				},
-				{
-					Name:       "jfr-jmx",
-					Port:       *config.JMXPort,
-					TargetPort: intstr.IntOrString{IntVal: cryostatJMXContainerPort},
-				},
-			},
+			Name:      svc.Name,
+			Namespace: svc.Namespace,
 		},
 	}
-}
-
-func NewGrafanaService(cr *operatorv1beta1.Cryostat) *corev1.Service {
-	config := getGrafanaServiceConfig(cr)
-	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        cr.Name + "-grafana",
-			Namespace:   cr.Namespace,
-			Labels:      config.Labels,
-			Annotations: config.Annotations,
-		},
-		Spec: corev1.ServiceSpec{
-			Type: *config.ServiceType,
-			Selector: map[string]string{
-				"app":       cr.Name,
-				"component": "cryostat",
-			},
-			Ports: []corev1.ServicePort{
-				{
-					Name:       "http",
-					Port:       *config.HTTPPort,
-					TargetPort: intstr.IntOrString{IntVal: 3000},
-				},
-			},
-		},
-	}
-}
-
-func NewReportService(cr *operatorv1beta1.Cryostat) *corev1.Service {
-	// Check CR for config
-	var config *operatorv1beta1.ReportsServiceConfig
-	if cr.Spec.ServiceOptions == nil || cr.Spec.ServiceOptions.ReportsConfig == nil {
-		config = &operatorv1beta1.ReportsServiceConfig{}
-	} else {
-		config = cr.Spec.ServiceOptions.ReportsConfig
-	}
-
-	// Apply common service defaults
-	configureService(&config.ServiceConfig, cr.Name, "reports")
-
-	// Apply default HTTP port if not provided
-	if config.HTTPPort == nil {
-		httpPort := reportsContainerPort
-		config.HTTPPort = &httpPort
-	}
-
-	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        cr.Name + "-reports",
-			Namespace:   cr.Namespace,
-			Labels:      config.Labels,
-			Annotations: config.Annotations,
-		},
-		Spec: corev1.ServiceSpec{
-			Type: *config.ServiceType,
-			Selector: map[string]string{
-				"app":       cr.Name,
-				"component": "reports",
-			},
-			Ports: []corev1.ServicePort{
-				{
-					Name:       "http",
-					Port:       *config.HTTPPort,
-					TargetPort: intstr.IntOrString{IntVal: reportsContainerPort},
-				},
-			},
-		},
-	}
-}
-
-func getGrafanaServiceConfig(cr *operatorv1beta1.Cryostat) *operatorv1beta1.GrafanaServiceConfig {
-	// Check CR for config
-	var config *operatorv1beta1.GrafanaServiceConfig
-	if cr.Spec.ServiceOptions == nil || cr.Spec.ServiceOptions.GrafanaConfig == nil {
-		config = &operatorv1beta1.GrafanaServiceConfig{}
-	} else {
-		config = cr.Spec.ServiceOptions.GrafanaConfig
-	}
-
-	// Apply common service defaults
-	configureService(&config.ServiceConfig, cr.Name, "cryostat")
-
-	// Apply default HTTP port if not provided
-	if config.HTTPPort == nil {
-		httpPort := grafanaContainerPort
-		config.HTTPPort = &httpPort
-	}
-
-	return config
-}
-
-func configureService(config *operatorv1beta1.ServiceConfig, appLabel string, componentLabel string) {
-	if config.ServiceType == nil {
-		svcType := corev1.ServiceTypeClusterIP
-		config.ServiceType = &svcType
-	}
-	if config.Labels == nil {
-		config.Labels = map[string]string{}
-	}
-	if config.Annotations == nil {
-		config.Annotations = map[string]string{}
-	}
-
-	// Add required labels, overriding any user-specified labels with the same keys
-	config.Labels["app"] = appLabel
-	config.Labels["component"] = componentLabel
 }
 
 // JMXSecretNameSuffix is the suffix to be appended to the name of a

--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -49,7 +49,6 @@ import (
 	operatorv1beta1 "github.com/cryostatio/cryostat-operator/api/v1beta1"
 	consolev1 "github.com/openshift/api/console/v1"
 	oauthv1 "github.com/openshift/api/oauth/v1"
-	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -900,15 +899,6 @@ func NewJfrDatasourceContainer(cr *operatorv1beta1.Cryostat, imageTag string) co
 			},
 		},
 		Resources: cr.Spec.Resources.DataSourceResources,
-	}
-}
-
-func NewRouteForService(svc *corev1.Service) *routev1.Route {
-	return &routev1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      svc.Name,
-			Namespace: svc.Namespace,
-		},
 	}
 }
 

--- a/internal/controllers/cryostat_controller.go
+++ b/internal/controllers/cryostat_controller.go
@@ -51,8 +51,6 @@ import (
 
 	operatorv1beta1 "github.com/cryostatio/cryostat-operator/api/v1beta1"
 
-	goerrors "errors"
-
 	"github.com/cryostatio/cryostat-operator/internal/controllers/common"
 	resources "github.com/cryostatio/cryostat-operator/internal/controllers/common/resource_definitions"
 	configv1 "github.com/openshift/api/config/v1"
@@ -723,20 +721,9 @@ func (r *CryostatReconciler) createOrUpdateDeployment(ctx context.Context, deplo
 
 func requeueIfIngressNotReady(log logr.Logger, err error) (reconcile.Result, error) {
 	if err == ErrIngressNotReady {
-		log.Info(err.Error())
 		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 	return reconcile.Result{}, err
-}
-
-func getNetworkConfig(controller *operatorv1beta1.Cryostat, svc *corev1.Service) (*operatorv1beta1.NetworkConfiguration, error) {
-	if svc.Name == controller.Name {
-		return controller.Spec.NetworkOptions.CoreConfig, nil
-	} else if svc.Name == controller.Name+"-grafana" {
-		return controller.Spec.NetworkOptions.GrafanaConfig, nil
-	} else {
-		return nil, goerrors.New("Service name not recognized")
-	}
 }
 
 func removeConditionIfPresent(cr *operatorv1beta1.Cryostat, condType ...operatorv1beta1.CryostatConditionType) {

--- a/internal/controllers/ingresses.go
+++ b/internal/controllers/ingresses.go
@@ -1,0 +1,149 @@
+// Copyright The Cryostat Authors
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or data
+// (collectively the "Software"), free of charge and under any and all copyright
+// rights in the Software, and any and all patent rights owned or freely
+// licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger
+// Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+// one is included with the Software (each a "Larger Work" to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition:
+// The above copyright notice and either this complete permission notice or at
+// a minimum a reference to the UPL must be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	operatorv1beta1 "github.com/cryostatio/cryostat-operator/api/v1beta1"
+	"github.com/cryostatio/cryostat-operator/internal/controllers/common/resource_definitions"
+	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func (r *CryostatReconciler) reconcileCoreIngress(ctx context.Context, cr *operatorv1beta1.Cryostat,
+	specs *resource_definitions.ServiceSpecs) error {
+	ingress := &netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Name,
+			Namespace: cr.Namespace,
+		},
+	}
+
+	if cr.Spec.NetworkOptions == nil || cr.Spec.NetworkOptions.CoreConfig == nil ||
+		cr.Spec.NetworkOptions.CoreConfig.IngressSpec == nil {
+		// User has not requested an Ingress, delete if it exists
+		return r.deleteIngress(ctx, ingress)
+	}
+
+	url, err := r.reconcileIngress(ctx, ingress, cr, cr.Spec.NetworkOptions.CoreConfig)
+	if err != nil {
+		return err
+	}
+	specs.CoreURL = url
+	return nil
+}
+
+func (r *CryostatReconciler) reconcileGrafanaIngress(ctx context.Context, cr *operatorv1beta1.Cryostat,
+	specs *resource_definitions.ServiceSpecs) error {
+	ingress := &netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Name + "-grafana",
+			Namespace: cr.Namespace,
+		},
+	}
+
+	if cr.Spec.Minimal || cr.Spec.NetworkOptions == nil || cr.Spec.NetworkOptions.GrafanaConfig == nil ||
+		cr.Spec.NetworkOptions.GrafanaConfig.IngressSpec == nil {
+		// User has either chosen a minimal deployment or not requested
+		// an Ingress, delete if it exists
+		return r.deleteIngress(ctx, ingress)
+	}
+	url, err := r.reconcileIngress(ctx, ingress, cr, cr.Spec.NetworkOptions.GrafanaConfig)
+	if err != nil {
+		return err
+	}
+	specs.GrafanaURL = url
+	return nil
+}
+
+func (r *CryostatReconciler) reconcileIngress(ctx context.Context, ingress *netv1.Ingress, cr *operatorv1beta1.Cryostat,
+	config *operatorv1beta1.NetworkConfiguration) (*url.URL, error) {
+	ingress, err := r.createOrUpdateIngress(ctx, ingress, cr, config)
+	if err != nil {
+		return nil, err
+	}
+
+	if ingress.Spec.Rules == nil || len(ingress.Spec.Rules[0].Host) == 0 {
+		return nil, nil
+	}
+
+	host := ingress.Spec.Rules[0].Host
+	scheme := "http"
+	if ingress.Spec.TLS != nil {
+		scheme = "https"
+	}
+	return &url.URL{
+		Scheme: scheme,
+		Host:   host,
+	}, nil
+}
+
+func (r *CryostatReconciler) createOrUpdateIngress(ctx context.Context, ingress *netv1.Ingress, owner metav1.Object,
+	config *operatorv1beta1.NetworkConfiguration) (*netv1.Ingress, error) {
+	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, ingress, func() error {
+		// Set labels and annotations from CR
+		ingress.Labels = config.Labels
+		ingress.Annotations = config.Annotations
+		// Set the Cryostat CR as controller
+		if err := controllerutil.SetControllerReference(owner, ingress, r.Scheme); err != nil {
+			return err
+		}
+		// Update Ingress spec
+		ingress.Spec = *config.IngressSpec
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	r.Log.Info(fmt.Sprintf("Ingress %s", op), "name", ingress.Name, "namespace", ingress.Namespace)
+	return ingress, nil
+}
+
+func (r *CryostatReconciler) deleteIngress(ctx context.Context, ingress *netv1.Ingress) error {
+	err := r.Client.Delete(ctx, ingress)
+	if err != nil && !errors.IsNotFound(err) {
+		r.Log.Error(err, "Could not delete ingress", "name", ingress.Name, "namespace", ingress.Namespace)
+		return err
+	}
+	r.Log.Info("Ingress deleted", "name", ingress.Name, "namespace", ingress.Namespace)
+	return nil
+}

--- a/internal/controllers/routes.go
+++ b/internal/controllers/routes.go
@@ -1,0 +1,176 @@
+// Copyright The Cryostat Authors
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or data
+// (collectively the "Software"), free of charge and under any and all copyright
+// rights in the Software, and any and all patent rights owned or freely
+// licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger
+// Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+// one is included with the Software (each a "Larger Work" to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition:
+// The above copyright notice and either this complete permission notice or at
+// a minimum a reference to the UPL must be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package controllers
+
+import (
+	"context"
+	goerrors "errors"
+	"fmt"
+	"net/url"
+
+	operatorv1beta1 "github.com/cryostatio/cryostat-operator/api/v1beta1"
+	"github.com/cryostatio/cryostat-operator/internal/controllers/common/resource_definitions"
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func (r *CryostatReconciler) reconcileCoreRoute(ctx context.Context, svc *corev1.Service, cr *operatorv1beta1.Cryostat,
+	tls *resource_definitions.TLSConfig, specs *resource_definitions.ServiceSpecs) error {
+	route := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Name,
+			Namespace: cr.Namespace,
+		},
+	}
+	url, err := r.reconcileRoute(ctx, route, svc, cr, tls)
+	if err != nil {
+		return err
+	}
+	specs.CoreURL = url
+	return nil
+}
+
+func (r *CryostatReconciler) reconcileGrafanaRoute(ctx context.Context, svc *corev1.Service, cr *operatorv1beta1.Cryostat,
+	tls *resource_definitions.TLSConfig, specs *resource_definitions.ServiceSpecs) error {
+	route := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Name + "-grafana",
+			Namespace: cr.Namespace,
+		},
+	}
+
+	if cr.Spec.Minimal {
+		// Delete route if it exists
+		return r.deleteRoute(ctx, route)
+	}
+	url, err := r.reconcileRoute(ctx, route, svc, cr, tls)
+	if err != nil {
+		return err
+	}
+	specs.GrafanaURL = url
+	return nil
+}
+
+// ErrIngressNotReady is returned when Kubernetes has not yet exposed our services
+// so that they may be accessed outside of the cluster
+var ErrIngressNotReady = goerrors.New("ingress configuration not yet available")
+
+func (r *CryostatReconciler) reconcileRoute(ctx context.Context, route *routev1.Route, svc *corev1.Service,
+	cr *operatorv1beta1.Cryostat, tls *resource_definitions.TLSConfig) (*url.URL, error) {
+	port, err := getHTTPPort(svc)
+	if err != nil {
+		return nil, err
+	}
+	route, err = r.createOrUpdateRoute(ctx, route, cr, svc, port, tls)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(route.Status.Ingress) < 1 {
+		return nil, ErrIngressNotReady
+	}
+
+	return &url.URL{
+		Scheme: getProtocol(route),
+		Host:   route.Status.Ingress[0].Host,
+	}, nil
+}
+
+func (r *CryostatReconciler) createOrUpdateRoute(ctx context.Context, route *routev1.Route, owner metav1.Object,
+	svc *corev1.Service, exposePort *corev1.ServicePort, tlsConfig *resource_definitions.TLSConfig) (*routev1.Route, error) {
+	// Use edge termination by default
+	var routeTLS *routev1.TLSConfig
+	if tlsConfig == nil {
+		routeTLS = &routev1.TLSConfig{
+			Termination:                   routev1.TLSTerminationEdge,
+			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+		}
+	} else {
+		routeTLS = &routev1.TLSConfig{
+			Termination:              routev1.TLSTerminationReencrypt,
+			DestinationCACertificate: string(tlsConfig.CACert),
+		}
+	}
+
+	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, route, func() error {
+		// Set the Cryostat CR as controller
+		if err := controllerutil.SetControllerReference(owner, route, r.Scheme); err != nil {
+			return err
+		}
+		// Update Route spec
+		route.Spec.To.Kind = "Service"
+		route.Spec.To.Name = svc.Name
+		route.Spec.Port = &routev1.RoutePort{TargetPort: exposePort.TargetPort}
+		route.Spec.TLS = routeTLS
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	r.Log.Info(fmt.Sprintf("Route %s", op), "name", route.Name, "namespace", route.Namespace)
+	return route, nil
+}
+
+func getProtocol(route *routev1.Route) string {
+	if route.Spec.TLS == nil {
+		return "http"
+	}
+	return "https"
+}
+
+func (r *CryostatReconciler) deleteRoute(ctx context.Context, route *routev1.Route) error {
+	err := r.Client.Delete(ctx, route)
+	if err != nil && !errors.IsNotFound(err) {
+		r.Log.Error(err, "Could not delete route", "name", route.Name, "namespace", route.Namespace)
+		return err
+	}
+	r.Log.Info("Route deleted", "name", route.Name, "namespace", route.Namespace)
+	return nil
+}
+
+func getHTTPPort(svc *corev1.Service) (*corev1.ServicePort, error) {
+	for _, port := range svc.Spec.Ports {
+		if port.Name == httpPortName {
+			return &port, nil
+		}
+	}
+	// Shouldn't happen
+	return nil, fmt.Errorf("no \"%s\"port in %s service in %s namespace", httpPortName, svc.Name, svc.Namespace)
+}

--- a/internal/controllers/routes.go
+++ b/internal/controllers/routes.go
@@ -104,6 +104,7 @@ func (r *CryostatReconciler) reconcileRoute(ctx context.Context, route *routev1.
 	}
 
 	if len(route.Status.Ingress) < 1 {
+		r.Log.Info("Waiting for route to become available", "name", route.Name, "namespace", route.Namespace)
 		return nil, ErrIngressNotReady
 	}
 

--- a/internal/controllers/services.go
+++ b/internal/controllers/services.go
@@ -51,7 +51,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// FIXME dedup
+// FIXME duplicated from resource_definitions.go
 const (
 	cryostatHTTPContainerPort int32  = 8181
 	cryostatJMXContainerPort  int32  = 9091

--- a/internal/controllers/services.go
+++ b/internal/controllers/services.go
@@ -1,0 +1,273 @@
+// Copyright The Cryostat Authors
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or data
+// (collectively the "Software"), free of charge and under any and all copyright
+// rights in the Software, and any and all patent rights owned or freely
+// licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger
+// Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+// one is included with the Software (each a "Larger Work" to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition:
+// The above copyright notice and either this complete permission notice or at
+// a minimum a reference to the UPL must be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	operatorv1beta1 "github.com/cryostatio/cryostat-operator/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// FIXME dedup
+const (
+	cryostatHTTPContainerPort int32  = 8181
+	cryostatJMXContainerPort  int32  = 9091
+	grafanaContainerPort      int32  = 3000
+	datasourceContainerPort   int32  = 8080
+	reportsContainerPort      int32  = 10000
+	loopbackAddress           string = "127.0.0.1"
+)
+
+func coreService(cr *operatorv1beta1.Cryostat) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Name,
+			Namespace: cr.Namespace,
+		},
+	}
+}
+
+func (r *CryostatReconciler) reconcileCoreService(ctx context.Context, cr *operatorv1beta1.Cryostat) (*corev1.Service, error) {
+	config := configureCoreService(cr)
+	svc := coreService(cr)
+	return r.createOrUpdateService(ctx, svc, cr, &config.ServiceConfig, func() error {
+		svc.Spec.Selector = map[string]string{
+			"app":       cr.Name,
+			"component": "cryostat",
+		}
+		svc.Spec.Ports = []corev1.ServicePort{
+			{
+				Name:       "http",
+				Port:       *config.HTTPPort,
+				TargetPort: intstr.IntOrString{IntVal: cryostatHTTPContainerPort},
+			},
+			{
+				Name:       "jfr-jmx",
+				Port:       *config.JMXPort,
+				TargetPort: intstr.IntOrString{IntVal: cryostatJMXContainerPort},
+			},
+		}
+		return nil
+	})
+}
+
+func grafanaService(cr *operatorv1beta1.Cryostat) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Name + "-grafana",
+			Namespace: cr.Namespace,
+		},
+	}
+}
+
+func (r *CryostatReconciler) reconcileGrafanaService(ctx context.Context, cr *operatorv1beta1.Cryostat) (*corev1.Service, error) {
+	config := configureGrafanaService(cr)
+	svc := grafanaService(cr)
+
+	if cr.Spec.Minimal {
+		// Delete service if it exists
+		return r.deleteService(ctx, svc)
+	}
+	return r.createOrUpdateService(ctx, svc, cr, &config.ServiceConfig, func() error {
+		svc.Spec.Selector = map[string]string{
+			"app":       cr.Name,
+			"component": "cryostat",
+		}
+		svc.Spec.Ports = []corev1.ServicePort{
+			{
+				Name:       "http",
+				Port:       *config.HTTPPort,
+				TargetPort: intstr.IntOrString{IntVal: 3000},
+			},
+		}
+		return nil
+	})
+}
+
+func reportsService(cr *operatorv1beta1.Cryostat) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Name + "-reports",
+			Namespace: cr.Namespace,
+		},
+	}
+}
+
+func (r *CryostatReconciler) reconcileReportsService(ctx context.Context, cr *operatorv1beta1.Cryostat) (*corev1.Service, error) {
+	config := configureReportsService(cr)
+	svc := reportsService(cr)
+	if cr.Spec.ReportOptions.Replicas == 0 {
+		// Delete service if it exists
+		return r.deleteService(ctx, svc)
+	}
+	return r.createOrUpdateService(ctx, svc, cr, &config.ServiceConfig, func() error {
+		svc.Spec.Selector = map[string]string{
+			"app":       cr.Name,
+			"component": "reports",
+		}
+		svc.Spec.Ports = []corev1.ServicePort{
+			{
+				Name:       "http",
+				Port:       *config.HTTPPort,
+				TargetPort: intstr.IntOrString{IntVal: reportsContainerPort},
+			},
+		}
+		return nil
+	})
+}
+
+func configureCoreService(cr *operatorv1beta1.Cryostat) *operatorv1beta1.CoreServiceConfig {
+	// Check CR for config
+	var config *operatorv1beta1.CoreServiceConfig
+	if cr.Spec.ServiceOptions == nil || cr.Spec.ServiceOptions.CoreConfig == nil {
+		config = &operatorv1beta1.CoreServiceConfig{}
+	} else {
+		config = cr.Spec.ServiceOptions.CoreConfig
+	}
+
+	// Apply common service defaults
+	configureService(&config.ServiceConfig, cr.Name, "cryostat")
+
+	// Apply default HTTP and JMX port if not provided
+	if config.HTTPPort == nil {
+		httpPort := cryostatHTTPContainerPort
+		config.HTTPPort = &httpPort
+	}
+	if config.JMXPort == nil {
+		jmxPort := cryostatJMXContainerPort
+		config.JMXPort = &jmxPort
+	}
+
+	return config
+}
+
+func configureGrafanaService(cr *operatorv1beta1.Cryostat) *operatorv1beta1.GrafanaServiceConfig {
+	// Check CR for config
+	var config *operatorv1beta1.GrafanaServiceConfig
+	if cr.Spec.ServiceOptions == nil || cr.Spec.ServiceOptions.GrafanaConfig == nil {
+		config = &operatorv1beta1.GrafanaServiceConfig{}
+	} else {
+		config = cr.Spec.ServiceOptions.GrafanaConfig
+	}
+
+	// Apply common service defaults
+	configureService(&config.ServiceConfig, cr.Name, "cryostat")
+
+	// Apply default HTTP port if not provided
+	if config.HTTPPort == nil {
+		httpPort := grafanaContainerPort
+		config.HTTPPort = &httpPort
+	}
+
+	return config
+}
+
+func configureReportsService(cr *operatorv1beta1.Cryostat) *operatorv1beta1.ReportsServiceConfig {
+	// Check CR for config
+	var config *operatorv1beta1.ReportsServiceConfig
+	if cr.Spec.ServiceOptions == nil || cr.Spec.ServiceOptions.ReportsConfig == nil {
+		config = &operatorv1beta1.ReportsServiceConfig{}
+	} else {
+		config = cr.Spec.ServiceOptions.ReportsConfig
+	}
+
+	// Apply common service defaults
+	configureService(&config.ServiceConfig, cr.Name, "reports")
+
+	// Apply default HTTP port if not provided
+	if config.HTTPPort == nil {
+		httpPort := reportsContainerPort
+		config.HTTPPort = &httpPort
+	}
+
+	return config
+}
+
+func configureService(config *operatorv1beta1.ServiceConfig, appLabel string, componentLabel string) {
+	if config.ServiceType == nil {
+		svcType := corev1.ServiceTypeClusterIP
+		config.ServiceType = &svcType
+	}
+	if config.Labels == nil {
+		config.Labels = map[string]string{}
+	}
+	if config.Annotations == nil {
+		config.Annotations = map[string]string{}
+	}
+
+	// Add required labels, overriding any user-specified labels with the same keys
+	config.Labels["app"] = appLabel
+	config.Labels["component"] = componentLabel
+}
+
+func (r *CryostatReconciler) createOrUpdateService(ctx context.Context, svc *corev1.Service, owner metav1.Object,
+	config *operatorv1beta1.ServiceConfig, delegate controllerutil.MutateFn) (*corev1.Service, error) {
+	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, svc, func() error {
+		// Update labels and annotations
+		svc.Labels = config.Labels
+		svc.Annotations = config.Annotations
+		// Set the Cryostat CR as controller
+		if err := controllerutil.SetControllerReference(owner, svc, r.Scheme); err != nil {
+			return err
+		}
+		// Update the service type
+		svc.Spec.Type = *config.ServiceType
+		// Call the delegate for service-specific mutations
+		return delegate()
+	})
+	if err != nil {
+		return nil, err
+	}
+	r.Log.Info(fmt.Sprintf("Service %s", op), "name", svc.Name, "namespace", svc.Namespace)
+	return svc, nil
+}
+
+func (r *CryostatReconciler) deleteService(ctx context.Context, svc *corev1.Service) (*corev1.Service, error) {
+	err := r.Client.Delete(context.Background(), svc)
+	if err != nil && !errors.IsNotFound(err) {
+		r.Log.Error(err, "Could not delete service", "name", svc.Name, "namespace", svc.Namespace)
+		return nil, err
+	}
+	r.Log.Info("Service deleted", "name", svc.Name, "namespace", svc.Namespace)
+	return svc, nil
+}

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -40,7 +40,6 @@ import (
 	"time"
 
 	operatorv1beta1 "github.com/cryostatio/cryostat-operator/api/v1beta1"
-	"github.com/cryostatio/cryostat-operator/internal/controllers/common/resource_definitions"
 	certv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	certMeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/onsi/gomega"
@@ -1849,10 +1848,10 @@ func NewPodSecurityContext() *corev1.PodSecurityContext {
 }
 
 func NewNetworkConfigurationList(tls bool) operatorv1beta1.NetworkConfigurationList {
-	coreSVC := resource_definitions.NewCoreService(NewCryostat())
+	coreSVC := NewCryostatService()
 	coreIng := NewNetworkConfiguration(coreSVC.Name, coreSVC.Spec.Ports[0].Port, tls)
 
-	grafanaSVC := resource_definitions.NewGrafanaService(NewCryostat())
+	grafanaSVC := NewGrafanaService()
 	grafanaIng := NewNetworkConfiguration(grafanaSVC.Name, grafanaSVC.Spec.Ports[0].Port, tls)
 
 	return operatorv1beta1.NetworkConfigurationList{

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -1932,6 +1932,80 @@ func OtherGrafanaRoute() *routev1.Route {
 	}
 }
 
+func OtherCoreIngress() *netv1.Ingress {
+	pathtype := netv1.PathTypePrefix
+	return &netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "cryostat",
+			Namespace:   "default",
+			Annotations: map[string]string{"custom": "annotation"},
+			Labels:      map[string]string{"custom": "label"},
+		},
+		Spec: netv1.IngressSpec{
+			Rules: []netv1.IngressRule{
+				{
+					Host: "some-other-host.example.com",
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path:     "/",
+									PathType: &pathtype,
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "some-other-service",
+											Port: netv1.ServiceBackendPort{
+												Number: 2000,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func OtherGrafanaIngress() *netv1.Ingress {
+	pathtype := netv1.PathTypePrefix
+	return &netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "cryostat-grafana",
+			Namespace:   "default",
+			Annotations: map[string]string{"grafana": "annotation"},
+			Labels:      map[string]string{"grafana": "label"},
+		},
+		Spec: netv1.IngressSpec{
+			Rules: []netv1.IngressRule{
+				{
+					Host: "some-other-grafana.example.com",
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path:     "/",
+									PathType: &pathtype,
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "some-other-grafana",
+											Port: netv1.ServiceBackendPort{
+												Number: 5000,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func NewNetworkConfigurationList(tls bool) operatorv1beta1.NetworkConfigurationList {
 	coreSVC := NewCryostatService()
 	coreIng := NewNetworkConfiguration(coreSVC.Name, coreSVC.Spec.Ports[0].Port, tls)


### PR DESCRIPTION
This PR accomplishes a few things:
1. Services, Ingresses and Routes will be updated across operator versions, and reflect changes the user makes to the Cryostat CR.
2. Uses the same code paths ([CreateOrUpdate](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller/controllerutil#CreateOrUpdate)'s mutateFn) when creating or updating the object. Ensures that when the operator sets a new field in an object, we don't need to ensure that change is made in two places.
3. Begins refactoring the long cryostat_controller.go and resource_definitions.go into resource-specific source files. I plan to repeat this pattern with the other resource types. The Cryostat controller's Reconcile method should be much smaller and simpler by fanning out to resource-specific delegates once this is complete.

Apologies for the PR being large. I initially planned to break this into two or three smaller PRs, but these types depend on each other.

Fixes: #410, #411 