### PR TITLE
fix(auth-properties): update docs links and add missing custom cluster-role in tests

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -274,7 +274,7 @@ spec:
 
 When running on OpenShift, the user is required to have sufficient permissions for certain Kubernetes resources that are mapped into Cryostat-managed resources for authorization.
 
-The mappings can be specified using a ConfigMap that is compatible with [`OpenShiftAuthManager.properties`](https://github.com/cryostatio/cryostat/blob/bd95e1a11e9e29cc39559f4a5fdeaae77e81b4c6/src/main/resources/io/cryostat/net/openshift/OpenShiftAuthManager.properties). For example:
+The mappings can be specified using a ConfigMap that is compatible with [`OpenShiftAuthManager.properties`](https://github.com/cryostatio/cryostat/blob/6db048682b2b0048c1f6ea9215de626b5a5be284/src/main/resources/io/cryostat/net/openshift/OpenShiftAuthManager.properties). For example:
 ```yaml
 apiVersion: v1
 kind: ConfigMap
@@ -288,7 +288,7 @@ data:
     CREDENTIALS=cryostats.operator.cryostat.io
 ```
 
-If custom mapping is specified, a ClusterRole must be defined and should contain permissions for all Kubernetes objects listed in custom permission mapping. This ClusterRole will give additional rules on top of [default rules](placeholder). <!-- FIXME add link after merging -->
+If custom mapping is specified, a ClusterRole must be defined and should contain permissions for all Kubernetes objects listed in custom permission mapping. This ClusterRole will give additional rules on top of [default rules](https://github.com/cryostatio/cryostat-operator/blob/1b5d1ab97fca925e14b6c2baf2585f5e04426440/config/rbac/oauth_client.yaml).
 
 
 **Note**: Using [`Secret`](https://kubernetes.io/docs/concepts/configuration/secret/) in mapping can fail with access denied under [security protection](https://kubernetes.io/docs/concepts/configuration/secret/#information-security-for-secrets) against escalations. Find more details about this issue [here](https://docs.openshift.com/container-platform/4.11/authentication/tokens-scoping.html#scoping-tokens-role-scope_configuring-internal-oauth).

--- a/internal/controllers/cryostat_controller_test.go
+++ b/internal/controllers/cryostat_controller_test.go
@@ -1299,7 +1299,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("Cryostat CR has authorization properties", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatWithAuthProperties(), test.NewAuthPropertiesConfigMap())
+				t.objs = append(t.objs, test.NewCryostatWithAuthProperties(), test.NewAuthPropertiesConfigMap(), test.NewAuthClusterRole())
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
@@ -1431,7 +1431,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("Cryostat CR has authorization properties", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatWithAuthProperties(), test.NewAuthPropertiesConfigMap())
+				t.objs = append(t.objs, test.NewCryostatWithAuthProperties(), test.NewAuthPropertiesConfigMap(), test.NewAuthClusterRole())
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -374,7 +374,7 @@ func NewCryostatWithAuthProperties() *operatorv1beta1.Cryostat {
 	cr.Spec.AuthProperties = &operatorv1beta1.AuthorizationProperties{
 		ConfigMapName:   "authConfigMapName",
 		Filename:        "auth.properties",
-		ClusterRoleName: "oauth-cluster-role",
+		ClusterRoleName: "custom-auth-cluster-role",
 	}
 	return cr
 }
@@ -1341,7 +1341,7 @@ func NewCoreEnvironmentVariables(minimal bool, tls bool, externalTLS bool, opens
 		if authProps {
 			envs = append(envs, corev1.EnvVar{
 				Name:  "CRYOSTAT_CUSTOM_OAUTH_ROLE",
-				Value: "oauth-cluster-role",
+				Value: "custom-auth-cluster-role",
 			})
 		}
 	}
@@ -2247,7 +2247,7 @@ func NewRole() *rbacv1.Role {
 func NewAuthClusterRole() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "custom-auth-client",
+			Name: "custom-auth-cluster-role",
 		},
 		Rules: []rbacv1.PolicyRule{
 			{

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -2244,6 +2244,26 @@ func NewRole() *rbacv1.Role {
 	}
 }
 
+func NewAuthClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "custom-auth-client",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     []string{"get", "update", "patch", "delete"},
+				APIGroups: []string{"group"},
+				Resources: []string{"resources"},
+			},
+			{
+				Verbs:     []string{"get", "update", "patch", "delete"},
+				APIGroups: []string{"another_group"},
+				Resources: []string{"another_resources"},
+			},
+		},
+	}
+}
+
 func NewRoleBinding() *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2316,7 +2336,7 @@ func NewAuthPropertiesConfigMap() *corev1.ConfigMap {
 			Namespace: "default",
 		},
 		Data: map[string]string{
-			"auth.properties": "CRYOSTAT_RESOURCE=K8S_RESOURCE\nANOTHER_CRYOSTAT_RESOURCE=ANOTHER_K8S_RESOURCE",
+			"auth.properties": "CRYOSTAT_RESOURCE=resources.group\nANOTHER_CRYOSTAT_RESOURCE=another_resources.another_group",
 		},
 	}
 }


### PR DESCRIPTION
Related to #440 

Updated config docs with permanent links to permission mapping files.

Added missing custom cluster-role in unit tests for auth-properties.