### PR TITLE
fix(gitignore): ignore bundle tmp directory from catalog build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ bin
 
 # Cache directory
 cache/
+
+# OPM tmp directory
+bundle_tmp*/


### PR DESCRIPTION
Related #438 
Related #430 

Catalog build generates a temporary directory that should not be checked into git.