### PR TITLE
test(scorecard): add scorecard test for operator availability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,17 +123,13 @@ ifneq ($(SKIP_TESTS), true)
 endif
 
 .PHONY: test-scorecard
-test-scorecard: clean-scorecard custom-scorecard-patch
+test-scorecard: clean-scorecard
 ifneq ($(SKIP_TESTS), true)
 	$(CLUSTER_CLIENT) create namespace $(SCORECARD_NAMESPACE)
 	$(CLUSTER_CLIENT) -n $(SCORECARD_NAMESPACE) create -f internal/images/custom-scorecard-tests/rbac/
 	operator-sdk run bundle -n $(SCORECARD_NAMESPACE) $(BUNDLE_IMG)
 	operator-sdk scorecard -n $(SCORECARD_NAMESPACE) -s cryostat-scorecard -w 5m $(BUNDLE_IMG)
 endif
-
-.PHONY: custom-scorecard-patch
-custom-scorecard-patch:
-	envsubst < hack/custom.config.yaml.in > config/scorecard/patches/custom.config.yaml
 
 .PHONY: clean-scorecard
 clean-scorecard:
@@ -193,6 +189,7 @@ manifests: controller-gen
 	$(CONTROLLER_GEN) rbac:roleName=role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	envsubst < hack/image_tag_patch.yaml.in > config/default/image_tag_patch.yaml
 	envsubst < hack/image_pull_patch.yaml.in > config/default/image_pull_patch.yaml
+	envsubst < hack/custom.config.yaml.in > config/scorecard/patches/custom.config.yaml
 
 # Run go fmt against code
 .PHONY: fmt

--- a/Makefile
+++ b/Makefile
@@ -342,8 +342,8 @@ custom-scorecard-tests: fmt vet
 # Build the custom scorecard OCI image
 .PHONY: scorecard-build
 scorecard-build: custom-scorecard-tests
-	cd internal/images/custom-scorecard-tests/ && \
-	BUILDAH_FORMAT=docker $(IMAGE_BUILDER) build -t $(CUSTOM_SCORECARD_IMG) .
+	BUILDAH_FORMAT=docker $(IMAGE_BUILDER) build -t $(CUSTOM_SCORECARD_IMG) \
+	-f internal/images/custom-scorecard-tests/Dockerfile .
 
 # Local development/testing helpers
 

--- a/Makefile
+++ b/Makefile
@@ -129,11 +129,12 @@ ifneq ($(SKIP_TESTS), true)
 	$(CLUSTER_CLIENT) -n $(SCORECARD_NAMESPACE) create -f internal/images/custom-scorecard-tests/rbac/
 	operator-sdk run bundle -n $(SCORECARD_NAMESPACE) $(BUNDLE_IMG)
 	operator-sdk scorecard -n $(SCORECARD_NAMESPACE) -s cryostat-scorecard -w 5m $(BUNDLE_IMG)
+	- $(CLUSTER_CLIENT) delete --ignore-not-found=$(ignore-not-found) namespace $(SCORECARD_NAMESPACE)
 endif
 
 .PHONY: clean-scorecard
 clean-scorecard:
-	- $(CLUSTER_CLIENT) delete namespace $(SCORECARD_NAMESPACE)
+	- $(CLUSTER_CLIENT) delete --ignore-not-found=$(ignore-not-found) namespace $(SCORECARD_NAMESPACE)
 
 # Build manager binary
 .PHONY: manager

--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,10 @@ ifneq ($(SKIP_TESTS), true)
 endif
 
 .PHONY: test-scorecard
-test-scorecard: clean-scorecard
+test-scorecard:
 ifneq ($(SKIP_TESTS), true)
+	@$(CLUSTER_CLIENT) get namespace $(SCORECARD_NAMESPACE) >/dev/null 2>&1 &&\
+		echo "$(SCORECARD_NAMESPACE) namespace already exists, please remove it with \"make clean-scorecard\"" >&2 && exit 1 || true
 	$(CLUSTER_CLIENT) create namespace $(SCORECARD_NAMESPACE)
 	$(CLUSTER_CLIENT) -n $(SCORECARD_NAMESPACE) create -f internal/images/custom-scorecard-tests/rbac/
 	operator-sdk run bundle -n $(SCORECARD_NAMESPACE) $(BUNDLE_IMG)

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -69,7 +69,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - operator-install
-    image: quay.io/ebaron/cryostat-operator-scorecard:2.2.0-dev00005
+    image: quay.io/cryostat/cryostat-operator-scorecard:2.2.0-dev00001
     labels:
       suite: cryostat
       test: operator-install

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -2,13 +2,14 @@ apiVersion: scorecard.operatorframework.io/v1alpha3
 kind: Configuration
 metadata:
   name: config
+serviceaccount: cryostat-scorecard
 stages:
 - parallel: true
   tests:
   - entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.0
     labels:
       suite: basic
       test: basic-check-spec-test
@@ -18,7 +19,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.0
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -28,7 +29,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.0
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -38,7 +39,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.0
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -48,7 +49,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.0
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -58,10 +59,20 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.0
     labels:
       suite: olm
       test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - cryostat-scorecard-tests
+    - operator-install
+    image: quay.io/ebaron/cryostat-operator-scorecard:2.2.0-dev00005
+    labels:
+      suite: cryostat
+      test: operator-install
     storage:
       spec:
         mountPath: {}

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -9,7 +9,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.22.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.2
     labels:
       suite: basic
       test: basic-check-spec-test
@@ -19,7 +19,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.22.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.2
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -29,7 +29,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.22.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.2
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -39,7 +39,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.22.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.2
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -49,7 +49,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.22.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.2
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -59,7 +59,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.22.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.2
     labels:
       suite: olm
       test: olm-status-descriptors-test

--- a/config/scorecard/kustomization.yaml
+++ b/config/scorecard/kustomization.yaml
@@ -14,3 +14,9 @@ patchesJson6902:
     kind: Configuration
     name: config
 # +kubebuilder:scaffold:patchesJson6902
+- path: patches/custom.config.yaml
+  target:
+    group: scorecard.operatorframework.io
+    version: v1alpha3
+    kind: Configuration
+    name: config

--- a/config/scorecard/patches/basic.config.yaml
+++ b/config/scorecard/patches/basic.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.22.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.2
     labels:
       suite: basic
       test: basic-check-spec-test

--- a/config/scorecard/patches/basic.config.yaml
+++ b/config/scorecard/patches/basic.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.0
     labels:
       suite: basic
       test: basic-check-spec-test

--- a/config/scorecard/patches/custom.config.yaml
+++ b/config/scorecard/patches/custom.config.yaml
@@ -1,0 +1,13 @@
+- op: add
+  path: /serviceaccount
+  value: cryostat-scorecard
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - cryostat-scorecard-tests
+    - operator-install
+    image: quay.io/ebaron/cryostat-operator-scorecard:2.2.0-dev00005
+    labels:
+      suite: cryostat
+      test: operator-install

--- a/config/scorecard/patches/olm.config.yaml
+++ b/config/scorecard/patches/olm.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.0
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -14,7 +14,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.0
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -24,7 +24,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.0
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -34,7 +34,7 @@
     entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.0
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -44,7 +44,7 @@
     entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.0
     labels:
       suite: olm
       test: olm-status-descriptors-test

--- a/config/scorecard/patches/olm.config.yaml
+++ b/config/scorecard/patches/olm.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.22.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.2
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -14,7 +14,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.22.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.2
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -24,7 +24,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.22.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.2
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -34,7 +34,7 @@
     entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.22.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.2
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -44,7 +44,7 @@
     entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.22.0
+    image: quay.io/operator-framework/scorecard-test:v1.22.2
     labels:
       suite: olm
       test: olm-status-descriptors-test

--- a/go.mod
+++ b/go.mod
@@ -8,13 +8,12 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.18.1
 	github.com/openshift/api v0.0.0-20220712151050-2647eb31dee7 // release-4.11
+	github.com/operator-framework/api v0.16.0
 	k8s.io/api v0.24.0
 	k8s.io/apimachinery v0.24.0
 	k8s.io/client-go v0.24.0
 	sigs.k8s.io/controller-runtime v0.12.1
 )
-
-require github.com/operator-framework/api v0.16.0
 
 require (
 	cloud.google.com/go v0.90.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.12.1
 )
 
+require github.com/operator-framework/api v0.16.0
+
 require (
 	cloud.google.com/go v0.90.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
@@ -25,6 +27,7 @@ require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
@@ -56,6 +59,7 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,7 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
@@ -399,6 +400,8 @@ github.com/openshift/api v0.0.0-20220712151050-2647eb31dee7 h1:zjlaMHqzNrrm8bnlt
 github.com/openshift/api v0.0.0-20220712151050-2647eb31dee7/go.mod h1:LEnw1IVscIxyDnltE3Wi7bQb/QzIM8BfPNKoGA1Qlxw=
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/operator-framework/api v0.16.0 h1:swUOhVv7QDszxBTwYM8QAtyeqI4EQHNVAiKMS+xjakY=
+github.com/operator-framework/api v0.16.0/go.mod h1:kk8xJahHJR3bKqrA+A+1VIrhOTmyV76k+ARv+iV+u1Q=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
@@ -451,6 +454,7 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=

--- a/hack/custom.config.yaml.in
+++ b/hack/custom.config.yaml.in
@@ -7,7 +7,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - operator-install
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.2.0-dev00001"
+    image: "${CUSTOM_SCORECARD_IMG}"
     labels:
       suite: cryostat
       test: operator-install

--- a/internal/images/custom-scorecard-tests/.gitignore
+++ b/internal/images/custom-scorecard-tests/.gitignore
@@ -1,1 +1,3 @@
+# Include Dockerfile and entrypoint but not tests binary
+!bin/
 bin/cryostat-scorecard-tests

--- a/internal/images/custom-scorecard-tests/.gitignore
+++ b/internal/images/custom-scorecard-tests/.gitignore
@@ -1,0 +1,1 @@
+bin/cryostat-scorecard-tests

--- a/internal/images/custom-scorecard-tests/Dockerfile
+++ b/internal/images/custom-scorecard-tests/Dockerfile
@@ -34,13 +34,34 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# Build the manager binary
+FROM docker.io/library/golang:1.18 as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY internal/images/custom-scorecard-tests/main.go internal/images/custom-scorecard-tests/main.go
+COPY internal/test/scorecard/ internal/test/scorecard/
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o cryostat-scorecard-tests \
+    internal/images/custom-scorecard-tests/main.go
+
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ENV TEST=/usr/local/bin/cryostat-scorecard-tests \
     USER_UID=1001 \
     USER_NAME=test
 
-COPY bin /usr/local/bin
+COPY internal/images/custom-scorecard-tests/bin/user_setup /usr/local/bin/
+COPY internal/images/custom-scorecard-tests/bin/entrypoint /usr/local/bin/
+COPY --from=builder /workspace/cryostat-scorecard-tests /usr/local/bin/
 RUN  /usr/local/bin/user_setup
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/internal/images/custom-scorecard-tests/Dockerfile
+++ b/internal/images/custom-scorecard-tests/Dockerfile
@@ -1,0 +1,48 @@
+# Copyright The Cryostat Authors
+#
+# The Universal Permissive License (UPL), Version 1.0
+#
+# Subject to the condition set forth below, permission is hereby granted to any
+# person obtaining a copy of this software, associated documentation and/or data
+# (collectively the "Software"), free of charge and under any and all copyright
+# rights in the Software, and any and all patent rights owned or freely
+# licensable by each licensor hereunder covering either (i) the unmodified
+# Software as contributed to or provided by such licensor, or (ii) the Larger
+# Works (as defined below), to deal in both
+#
+# (a) the Software, and
+# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+# one is included with the Software (each a "Larger Work" to which the Software
+# is contributed by such licensors),
+#
+# without restriction, including without limitation the rights to copy, create
+# derivative works of, display, perform, and distribute the Software and make,
+# use, sell, offer for sale, import, export, have made, and have sold the
+# Software and the Larger Work(s), and to sublicense the foregoing rights on
+# either these or other terms.
+#
+# This license is subject to the following condition:
+# The above copyright notice and either this complete permission notice or at
+# a minimum a reference to the UPL must be included in all copies or
+# substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+ENV TEST=/usr/local/bin/cryostat-scorecard-tests \
+    USER_UID=1001 \
+    USER_NAME=test
+
+COPY bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}

--- a/internal/images/custom-scorecard-tests/bin/entrypoint
+++ b/internal/images/custom-scorecard-tests/bin/entrypoint
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+exec ${TEST} $@

--- a/internal/images/custom-scorecard-tests/bin/user_setup
+++ b/internal/images/custom-scorecard-tests/bin/user_setup
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -x
+
+# ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
+echo "${USER_NAME}:x:${USER_UID}:0:${USER_NAME} user:${HOME}:/sbin/nologin" >> /etc/passwd
+
+mkdir -p "${HOME}"
+chown "${USER_UID}:0" "${HOME}"
+chmod ug+rwx "${HOME}"
+
+# no need for this script to remain in the image after running
+rm "$0"

--- a/internal/images/custom-scorecard-tests/main.go
+++ b/internal/images/custom-scorecard-tests/main.go
@@ -1,0 +1,102 @@
+// Copyright The Cryostat Authors
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or data
+// (collectively the "Software"), free of charge and under any and all copyright
+// rights in the Software, and any and all patent rights owned or freely
+// licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger
+// Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+// one is included with the Software (each a "Larger Work" to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition:
+// The above copyright notice and either this complete permission notice or at
+// a minimum a reference to the UPL must be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	scapiv1alpha3 "github.com/operator-framework/api/pkg/apis/scorecard/v1alpha3"
+	apimanifests "github.com/operator-framework/api/pkg/manifests"
+
+	tests "github.com/cryostatio/cryostat-operator/internal/test/scorecard"
+)
+
+const podBundleRoot = "/bundle"
+
+func main() {
+	entrypoint := os.Args[1:]
+	if len(entrypoint) == 0 {
+		log.Fatal("specify one or more test name arguments")
+	}
+
+	// Get namespace from SCORECARD_NAMESPACE environment variable
+	namespace := os.Getenv("SCORECARD_NAMESPACE")
+	if len(namespace) == 0 {
+		log.Fatal("SCORECARD_NAMESPACE environment variable not set")
+	}
+
+	// Read the pod's untar'd bundle from a well-known path.
+	bundle, err := apimanifests.GetBundleFromDir(podBundleRoot)
+	if err != nil {
+		log.Fatalf("failed to read bundle manifest: %s", err.Error())
+	}
+
+	var result scapiv1alpha3.TestStatus
+
+	switch entrypoint[0] {
+	case tests.OperatorInstallTestName:
+		result = tests.OperatorInstallTest(bundle, namespace)
+	default:
+		result = printValidTests()
+	}
+
+	prettyJSON, err := json.MarshalIndent(result, "", "    ")
+	if err != nil {
+		log.Fatal("failed to generate json", err)
+	}
+	fmt.Printf("%s\n", string(prettyJSON))
+}
+
+func printValidTests() scapiv1alpha3.TestStatus {
+	result := scapiv1alpha3.TestResult{}
+	result.State = scapiv1alpha3.FailState
+	result.Errors = make([]string, 0)
+	result.Suggestions = make([]string, 0)
+
+	str := fmt.Sprintf("valid tests for this image include: %s", strings.Join([]string{
+		tests.OperatorInstallTestName,
+	}, ","))
+	result.Errors = append(result.Errors, str)
+
+	return scapiv1alpha3.TestStatus{
+		Results: []scapiv1alpha3.TestResult{result},
+	}
+}

--- a/internal/images/custom-scorecard-tests/rbac/scorecard_role.yaml
+++ b/internal/images/custom-scorecard-tests/rbac/scorecard_role.yaml
@@ -1,0 +1,48 @@
+# Copyright The Cryostat Authors
+#
+# The Universal Permissive License (UPL), Version 1.0
+#
+# Subject to the condition set forth below, permission is hereby granted to any
+# person obtaining a copy of this software, associated documentation and/or data
+# (collectively the "Software"), free of charge and under any and all copyright
+# rights in the Software, and any and all patent rights owned or freely
+# licensable by each licensor hereunder covering either (i) the unmodified
+# Software as contributed to or provided by such licensor, or (ii) the Larger
+# Works (as defined below), to deal in both
+#
+# (a) the Software, and
+# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+# one is included with the Software (each a "Larger Work" to which the Software
+# is contributed by such licensors),
+#
+# without restriction, including without limitation the rights to copy, create
+# derivative works of, display, perform, and distribute the Software and make,
+# use, sell, offer for sale, import, export, have made, and have sold the
+# Software and the Larger Work(s), and to sublicense the foregoing rights on
+# either these or other terms.
+#
+# This license is subject to the following condition:
+# The above copyright notice and either this complete permission notice or at
+# a minimum a reference to the UPL must be included in all copies or
+# substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Permissions for Cryostat custom Scorecard tests
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cryostat-scorecard
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get

--- a/internal/images/custom-scorecard-tests/rbac/scorecard_role_binding.yaml
+++ b/internal/images/custom-scorecard-tests/rbac/scorecard_role_binding.yaml
@@ -1,0 +1,47 @@
+# Copyright The Cryostat Authors
+#
+# The Universal Permissive License (UPL), Version 1.0
+#
+# Subject to the condition set forth below, permission is hereby granted to any
+# person obtaining a copy of this software, associated documentation and/or data
+# (collectively the "Software"), free of charge and under any and all copyright
+# rights in the Software, and any and all patent rights owned or freely
+# licensable by each licensor hereunder covering either (i) the unmodified
+# Software as contributed to or provided by such licensor, or (ii) the Larger
+# Works (as defined below), to deal in both
+#
+# (a) the Software, and
+# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+# one is included with the Software (each a "Larger Work" to which the Software
+# is contributed by such licensors),
+#
+# without restriction, including without limitation the rights to copy, create
+# derivative works of, display, perform, and distribute the Software and make,
+# use, sell, offer for sale, import, export, have made, and have sold the
+# Software and the Larger Work(s), and to sublicense the foregoing rights on
+# either these or other terms.
+#
+# This license is subject to the following condition:
+# The above copyright notice and either this complete permission notice or at
+# a minimum a reference to the UPL must be included in all copies or
+# substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cryostat-scorecard
+subjects:
+- kind: ServiceAccount
+  name: cryostat-scorecard
+roleRef:
+  kind: Role
+  name: cryostat-scorecard
+  apiGroup: rbac.authorization.k8s.io

--- a/internal/images/custom-scorecard-tests/rbac/scorecard_service_account.yaml
+++ b/internal/images/custom-scorecard-tests/rbac/scorecard_service_account.yaml
@@ -1,0 +1,40 @@
+# Copyright The Cryostat Authors
+#
+# The Universal Permissive License (UPL), Version 1.0
+#
+# Subject to the condition set forth below, permission is hereby granted to any
+# person obtaining a copy of this software, associated documentation and/or data
+# (collectively the "Software"), free of charge and under any and all copyright
+# rights in the Software, and any and all patent rights owned or freely
+# licensable by each licensor hereunder covering either (i) the unmodified
+# Software as contributed to or provided by such licensor, or (ii) the Larger
+# Works (as defined below), to deal in both
+#
+# (a) the Software, and
+# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+# one is included with the Software (each a "Larger Work" to which the Software
+# is contributed by such licensors),
+#
+# without restriction, including without limitation the rights to copy, create
+# derivative works of, display, perform, and distribute the Software and make,
+# use, sell, offer for sale, import, export, have made, and have sold the
+# Software and the Larger Work(s), and to sublicense the foregoing rights on
+# either these or other terms.
+#
+# This license is subject to the following condition:
+# The above copyright notice and either this complete permission notice or at
+# a minimum a reference to the UPL must be included in all copies or
+# substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cryostat-scorecard

--- a/internal/test/scorecard/tests.go
+++ b/internal/test/scorecard/tests.go
@@ -1,0 +1,126 @@
+// Copyright The Cryostat Authors
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or data
+// (collectively the "Software"), free of charge and under any and all copyright
+// rights in the Software, and any and all patent rights owned or freely
+// licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger
+// Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+// one is included with the Software (each a "Larger Work" to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition:
+// The above copyright notice and either this complete permission notice or at
+// a minimum a reference to the UPL must be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package scorecard
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	scapiv1alpha3 "github.com/operator-framework/api/pkg/apis/scorecard/v1alpha3"
+	apimanifests "github.com/operator-framework/api/pkg/manifests"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	OperatorInstallTestName = "operator-install"
+	operatorDeploymentName  = "cryostat-operator-controller-manager"
+)
+
+// OperatorInstallTest
+func OperatorInstallTest(bundle *apimanifests.Bundle, namespace string) scapiv1alpha3.TestStatus {
+	r := scapiv1alpha3.TestResult{}
+	r.Name = OperatorInstallTestName
+	r.State = scapiv1alpha3.PassState
+	r.Errors = make([]string, 0)
+	r.Suggestions = make([]string, 0)
+
+	// Implement relevant custom test logic here
+
+	client, err := newKubeClient()
+	if err != nil {
+		return fail(r, fmt.Sprintf("failed to create client: %s", err.Error()))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+	defer cancel()
+	err = wait.PollImmediateUntilWithContext(ctx, time.Second, func(ctx context.Context) (done bool, err error) {
+		deploy, err := client.AppsV1().Deployments(namespace).Get(ctx, operatorDeploymentName, metav1.GetOptions{})
+		if err != nil {
+			if kerrors.IsNotFound(err) {
+				r.Log += fmt.Sprintf("deployment %s is not yet found\n", deploy.Name)
+				return false, nil // Retry
+			}
+			return false, fmt.Errorf("failed to get operator deployment: %s", err.Error())
+		}
+		// Check for Available condition
+		for _, condition := range deploy.Status.Conditions {
+			if condition.Type == appsv1.DeploymentAvailable &&
+				condition.Status == corev1.ConditionTrue {
+				r.Log += fmt.Sprintf("deployment %s is available\n", deploy.Name)
+				return true, nil
+			}
+		}
+		r.Log += fmt.Sprintf("deployment %s is not yet available\n", deploy.Name)
+		return false, nil
+	})
+	if err != nil {
+		return fail(r, fmt.Sprintf("operator deployment did not become available: %s", err.Error()))
+	}
+
+	return wrapResult(r)
+}
+
+func wrapResult(r scapiv1alpha3.TestResult) scapiv1alpha3.TestStatus {
+	return scapiv1alpha3.TestStatus{
+		Results: []scapiv1alpha3.TestResult{r},
+	}
+}
+
+func newKubeClient() (*kubernetes.Clientset, error) {
+	// Get in-cluster REST config from pod
+	config, err := ctrl.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new Clientset to communicate with the cluster
+	return kubernetes.NewForConfig(config)
+}
+
+func fail(r scapiv1alpha3.TestResult, message string) scapiv1alpha3.TestStatus {
+	r.State = scapiv1alpha3.FailState
+	r.Errors = append(r.Errors, message)
+	return wrapResult(r)
+}

--- a/internal/test/scorecard/tests.go
+++ b/internal/test/scorecard/tests.go
@@ -80,7 +80,7 @@ func OperatorInstallTest(bundle *apimanifests.Bundle, namespace string) scapiv1a
 		deploy, err := client.AppsV1().Deployments(namespace).Get(ctx, operatorDeploymentName, metav1.GetOptions{})
 		if err != nil {
 			if kerrors.IsNotFound(err) {
-				r.Log += fmt.Sprintf("deployment %s is not yet found\n", deploy.Name)
+				r.Log += fmt.Sprintf("deployment %s is not yet found\n", operatorDeploymentName)
 				return false, nil // Retry
 			}
 			return false, fmt.Errorf("failed to get operator deployment: %s", err.Error())

--- a/internal/test/scorecard/tests.go
+++ b/internal/test/scorecard/tests.go
@@ -60,7 +60,7 @@ const (
 )
 
 // OperatorInstallTest checks that the operator installed correctly
-func OperatorInstallTest(bundle *apimanifests.Bundle, namespace string) scapiv1alpha3.TestStatus {
+func OperatorInstallTest(bundle *apimanifests.Bundle, namespace string) scapiv1alpha3.TestResult {
 	r := scapiv1alpha3.TestResult{}
 	r.Name = OperatorInstallTestName
 	r.State = scapiv1alpha3.PassState
@@ -100,13 +100,7 @@ func OperatorInstallTest(bundle *apimanifests.Bundle, namespace string) scapiv1a
 		return fail(r, fmt.Sprintf("operator deployment did not become available: %s", err.Error()))
 	}
 
-	return wrapResult(r)
-}
-
-func wrapResult(r scapiv1alpha3.TestResult) scapiv1alpha3.TestStatus {
-	return scapiv1alpha3.TestStatus{
-		Results: []scapiv1alpha3.TestResult{r},
-	}
+	return r
 }
 
 func newKubeClient() (*kubernetes.Clientset, error) {
@@ -120,8 +114,8 @@ func newKubeClient() (*kubernetes.Clientset, error) {
 	return kubernetes.NewForConfig(config)
 }
 
-func fail(r scapiv1alpha3.TestResult, message string) scapiv1alpha3.TestStatus {
+func fail(r scapiv1alpha3.TestResult, message string) scapiv1alpha3.TestResult {
 	r.State = scapiv1alpha3.FailState
 	r.Errors = append(r.Errors, message)
-	return wrapResult(r)
+	return r
 }


### PR DESCRIPTION
This adds the first custom scorecard test for the operator. This test is pretty basic, it just verifies that the operator deployment becomes available. It should help to serve as a simple smoke test to ensure that the operator can at least start.

I followed the instructions in the Operator SDK guide on custom scorecard tests for the most part. [1] The sample test image for Tekton was also a useful resource [2]. The tests run in a separate namespace with the operator bundle installed and RBAC objects used by the test pod created.

To test it out:
1. Build the custom scorecard test image and push to Quay.
    ```
    export CUSTOM_SCORECARD_IMG="quay.io/<your name>/cryostat-operator-scorecard:some-unique-tag"
    make scorecard-build 
    podman push "$CUSTOM_SCORECARD_IMG"
    ```
2. Generate bundle and push to Quay (with CUSTOM_SCORECARD_IMG defined from step 1).
    ```
    export BUNDLE_IMG="quay.io/<your name>/cryostat-operator-bundle:latest"
    make bundle bundle-build
    podman push "$BUNDLE_IMG"
    ```
3. Run scorecard tests (with running cluster)
    ```
    make test-scorecard
    ```

You should see a result for the custom test like the following:
```
--------------------------------------------------------------------------------
Image:      quay.io/<your name>/cryostat-operator-scorecard:some-unique-tag
Entrypoint: [cryostat-scorecard-tests operator-install]
Labels:
	"test":"operator-install"
	"suite":"cryostat"
Results:
	Name: operator-install
	State: pass

	Log:
		deployment cryostat-operator-controller-manager is available


--------------------------------------------------------------------------------
```

Fixes: #444 

[1] https://sdk.operatorframework.io/docs/testing-operators/scorecard/custom-tests/
[2] https://github.com/operator-framework/tekton-scorecard-image