### PR TITLE
fix(reports): add nil-check and remove side effects

### DIFF
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -181,10 +181,10 @@ func NewDeploymentForCR(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, image
 }
 
 func NewDeploymentForReports(cr *operatorv1beta1.Cryostat, imageTags *ImageTags, tls *TLSConfig) *appsv1.Deployment {
-	if cr.Spec.ReportOptions == nil {
-		cr.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{Replicas: 0}
+	replicas := int32(0)
+	if cr.Spec.ReportOptions != nil {
+		replicas = cr.Spec.ReportOptions.Replicas
 	}
-	replicas := cr.Spec.ReportOptions.Replicas
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name + "-reports",
@@ -616,7 +616,7 @@ func NewCoreContainer(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, imageTa
 		envs = append(envs, reportsEnvs...)
 	} else {
 		subProcessMaxHeapSize := "200"
-		if cr.Spec.ReportOptions.SubProcessMaxHeapSize != 0 {
+		if cr.Spec.ReportOptions != nil && cr.Spec.ReportOptions.SubProcessMaxHeapSize != 0 {
 			subProcessMaxHeapSize = strconv.Itoa(int(cr.Spec.ReportOptions.SubProcessMaxHeapSize))
 		}
 		subprocessReportHeapEnv := []corev1.EnvVar{

--- a/internal/controllers/cryostat_controller.go
+++ b/internal/controllers/cryostat_controller.go
@@ -376,10 +376,10 @@ func (r *CryostatReconciler) reconcileReports(ctx context.Context, reqLogger log
 	tls *resources.TLSConfig, imageTags *resources.ImageTags, serviceSpecs *resources.ServiceSpecs) (reconcile.Result, error) {
 	reqLogger.Info("Spec", "Reports", instance.Spec.ReportOptions)
 
-	if instance.Spec.ReportOptions == nil {
-		instance.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{Replicas: 0}
+	desired := int32(0)
+	if instance.Spec.ReportOptions != nil {
+		desired = instance.Spec.ReportOptions.Replicas
 	}
-	desired := instance.Spec.ReportOptions.Replicas
 
 	err := r.reconcileReportsService(ctx, instance, tls, serviceSpecs)
 	if err != nil {

--- a/internal/controllers/cryostat_controller_test.go
+++ b/internal/controllers/cryostat_controller_test.go
@@ -431,7 +431,9 @@ var _ = Describe("CryostatController", func() {
 				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
-				cryostat.Spec.ReportOptions.Replicas = t.reportReplicas
+				cryostat.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{
+					Replicas: t.reportReplicas,
+				}
 				err = t.Client.Status().Update(context.Background(), cryostat)
 				Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controllers/services.go
+++ b/internal/controllers/services.go
@@ -155,7 +155,7 @@ func (r *CryostatReconciler) reconcileReportsService(ctx context.Context, cr *op
 		},
 	}
 
-	if cr.Spec.ReportOptions.Replicas == 0 {
+	if cr.Spec.ReportOptions == nil || cr.Spec.ReportOptions.Replicas == 0 {
 		// Delete service if it exists
 		return r.deleteService(ctx, svc)
 	}


### PR DESCRIPTION
Unfortunately it's not possible to add a regression test for this while using the fake client (see #448). Although after removing any side effects modifying `spec.reportOptions`, the segfault occurs as expected in the tests. Adding the nil-check in `NewCoreContainer` fixes it.

Fixes: #447 