### PR TITLE
fix(security): support restricted pod security standard

### DIFF
--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -442,8 +442,13 @@ spec:
                     memory: 64Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
               securityContext:
                 runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: cryostat-operator-service-account
               terminationGracePeriodSeconds: 10
       permissions:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,6 +29,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -20,6 +20,8 @@ spec:
       serviceAccountName: service-account
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager

--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -180,7 +180,8 @@ func NewDeploymentForCR(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, image
 	}
 }
 
-func NewDeploymentForReports(cr *operatorv1beta1.Cryostat, imageTags *ImageTags, tls *TLSConfig) *appsv1.Deployment {
+func NewDeploymentForReports(cr *operatorv1beta1.Cryostat, imageTags *ImageTags, tls *TLSConfig,
+	openshift bool) *appsv1.Deployment {
 	replicas := int32(0)
 	if cr.Spec.ReportOptions != nil {
 		replicas = cr.Spec.ReportOptions.Replicas
@@ -217,7 +218,7 @@ func NewDeploymentForReports(cr *operatorv1beta1.Cryostat, imageTags *ImageTags,
 						"component": "reports",
 					},
 				},
-				Spec: *NewPodForReports(cr, imageTags, tls),
+				Spec: *NewPodForReports(cr, imageTags, tls, openshift),
 			},
 			Replicas: &replicas,
 		},
@@ -377,8 +378,9 @@ func NewPodForCR(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, imageTags *I
 	nonRoot := true
 	sc := &corev1.PodSecurityContext{
 		// Ensure PV mounts are writable
-		FSGroup:      &fsGroup,
-		RunAsNonRoot: &nonRoot,
+		FSGroup:        &fsGroup,
+		RunAsNonRoot:   &nonRoot,
+		SeccompProfile: seccompProfile(openshift),
 	}
 
 	// Use HostAlias for loopback address to allow health checks to
@@ -404,7 +406,8 @@ func NewPodForCR(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, imageTags *I
 // https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
 const capabilityAll corev1.Capability = "ALL"
 
-func NewPodForReports(cr *operatorv1beta1.Cryostat, imageTags *ImageTags, tls *TLSConfig) *corev1.PodSpec {
+func NewPodForReports(cr *operatorv1beta1.Cryostat, imageTags *ImageTags, tls *TLSConfig,
+	openshift bool) *corev1.PodSpec {
 	resources := corev1.ResourceRequirements{}
 	if cr.Spec.ReportOptions != nil {
 		resources = cr.Spec.ReportOptions.Resources
@@ -526,7 +529,8 @@ func NewPodForReports(cr *operatorv1beta1.Cryostat, imageTags *ImageTags, tls *T
 		},
 		Volumes: volumes,
 		SecurityContext: &corev1.PodSecurityContext{
-			RunAsNonRoot: &nonRoot,
+			RunAsNonRoot:   &nonRoot,
+			SeccompProfile: seccompProfile(openshift),
 		},
 	}
 }
@@ -1215,5 +1219,17 @@ func newVolumeForCR(cr *operatorv1beta1.Cryostat) []corev1.Volume {
 			Name:         cr.Name,
 			VolumeSource: volumeSource,
 		},
+	}
+}
+
+func seccompProfile(openshift bool) *corev1.SeccompProfile {
+	// For backward-compatibility with OpenShift < 4.11,
+	// leave the seccompProfile empty. In OpenShift >= 4.11,
+	// the restricted-v2 SCC will populate it for us.
+	if openshift {
+		return nil
+	}
+	return &corev1.SeccompProfile{
+		Type: corev1.SeccompProfileTypeRuntimeDefault,
 	}
 }

--- a/internal/controllers/cryostat_controller.go
+++ b/internal/controllers/cryostat_controller.go
@@ -385,7 +385,7 @@ func (r *CryostatReconciler) reconcileReports(ctx context.Context, reqLogger log
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	deployment := resources.NewDeploymentForReports(instance, imageTags, tls)
+	deployment := resources.NewDeploymentForReports(instance, imageTags, tls, r.IsOpenShift)
 	if desired == 0 {
 		if err := r.Client.Delete(ctx, deployment); err != nil && !errors.IsNotFound(err) {
 			return reconcile.Result{}, err

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -1587,10 +1587,39 @@ func NewReportsVolumes(tls bool) []corev1.Volume {
 	}
 }
 
-func NewPodSecurityContext() *corev1.PodSecurityContext {
+func NewPodSecurityContext(openshift bool) *corev1.PodSecurityContext {
 	fsGroup := int64(18500)
+	return commonPodSecurityContext(openshift, &fsGroup)
+}
+
+func NewReportsPodSecurityContext(openshift bool) *corev1.PodSecurityContext {
+	return commonPodSecurityContext(openshift, nil)
+}
+
+func commonPodSecurityContext(openshift bool, fsGroup *int64) *corev1.PodSecurityContext {
+	nonRoot := true
+	var seccompProfile *corev1.SeccompProfile
+	if !openshift {
+		seccompProfile = &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		}
+	}
 	return &corev1.PodSecurityContext{
-		FSGroup: &fsGroup,
+		FSGroup:        fsGroup,
+		RunAsNonRoot:   &nonRoot,
+		SeccompProfile: seccompProfile,
+	}
+}
+
+func NewSecurityContext() *corev1.SecurityContext {
+	privEscalation := false
+	return &corev1.SecurityContext{
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"ALL",
+			},
+		},
+		AllowPrivilegeEscalation: &privEscalation,
 	}
 }
 


### PR DESCRIPTION
The primary difficulty with this fix is that OpenShift < 4.11 does not permit you to set `seccompProfile` by default. Following the discussion in https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/1417, I decided to take the following approach with this PR.

For the operator deployment:
- Set `runAsNonRoot` and `seccompProfile` in the pod security context. This is not backwards compatible with OpenShift < 4.11. In the downstream release, we will have to remove `seccompProfile` to support these versions. The `restricted-v2` Security Context Constraint (SCC) will set the `seccompProfile` for us when it is necessary. The alternative is not being compliant on standard Kubernetes, which does not have a SCC mechanism. The end result will be upstream releases will continue to work on Kubernetes 1.19, and OpenShift >= 4.11. Downstream releases will continue to work on OpenShift >= 4.6.
- Drop all capabilities and disallow privilege escalation.

For the operand deployments:
- Set `runAsNonRoot` and if not running on OpenShift, set `seccompProfile`. This preserves backwards compatibility, and relies on the `restricted-v2` SCC to set `seccompProfile` in OpenShift >= 4.11.
- Drop all capabilities and disallow privilege escalation.

Fixes: #404