### PR TITLE
feat(rbac): update operator-controlled RBAC objects

### DIFF
--- a/internal/controllers/common/common_utils.go
+++ b/internal/controllers/common/common_utils.go
@@ -37,9 +37,13 @@
 package common
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"io/ioutil"
 	"os"
 
+	operatorv1beta1 "github.com/cryostatio/cryostat-operator/api/v1beta1"
+	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -62,4 +66,13 @@ func (o *defaultOSUtils) GetEnv(name string) string {
 // GetFileContents reads and returns the entire file contents specified by the path
 func (o *defaultOSUtils) GetFileContents(path string) ([]byte, error) {
 	return ioutil.ReadFile(path)
+}
+
+// ClusterUniqueName returns a name for cluster-scoped objects that is
+// uniquely identified by the namespace and name of the provided Cryostat CR.
+func ClusterUniqueName(cr *operatorv1beta1.Cryostat) string {
+	// Use the SHA256 checksum of the namespaced name as a suffix
+	nn := types.NamespacedName{Namespace: cr.Namespace, Name: cr.Name}
+	suffix := fmt.Sprintf("%x", sha256.Sum256([]byte(nn.String())))
+	return "cryostat-" + suffix
 }

--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -37,8 +37,6 @@
 package resource_definitions
 
 import (
-	"crypto/sha256"
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net/url"
@@ -47,14 +45,12 @@ import (
 	"time"
 
 	operatorv1beta1 "github.com/cryostatio/cryostat-operator/api/v1beta1"
+	"github.com/cryostatio/cryostat-operator/internal/controllers/common"
 	consolev1 "github.com/openshift/api/console/v1"
-	oauthv1 "github.com/openshift/api/oauth/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -398,12 +394,14 @@ func NewPodForCR(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, imageTags *I
 			},
 		},
 	}
+	automountSAToken := true
 	return &corev1.PodSpec{
-		ServiceAccountName: cr.Name,
-		Volumes:            volumes,
-		Containers:         containers,
-		SecurityContext:    podSc,
-		HostAliases:        hostAliases,
+		ServiceAccountName:           cr.Name,
+		Volumes:                      volumes,
+		Containers:                   containers,
+		SecurityContext:              podSc,
+		HostAliases:                  hostAliases,
+		AutomountServiceAccountToken: &automountSAToken,
 	}
 }
 
@@ -527,7 +525,6 @@ func NewPodForReports(cr *operatorv1beta1.Cryostat, imageTags *ImageTags, tls *T
 	}
 
 	return &corev1.PodSpec{
-		ServiceAccountName: cr.Name,
 		Containers: []corev1.Container{
 			{
 				Name:            cr.Name + "-reports",
@@ -1062,121 +1059,11 @@ func NewKeystoreSecretForCR(cr *operatorv1beta1.Cryostat) *corev1.Secret {
 	}
 }
 
-func NewServiceAccountForCR(cr *operatorv1beta1.Cryostat, isOpenShift bool) (*corev1.ServiceAccount, error) {
-	annotations := make(map[string]string)
-
-	if isOpenShift {
-		OAuthRedirectReference := &oauthv1.OAuthRedirectReference{
-			Reference: oauthv1.RedirectReference{
-				Kind: "Route",
-				Name: cr.Name,
-			},
-		}
-
-		ref, err := json.Marshal(OAuthRedirectReference)
-		if err != nil {
-			return nil, err
-		}
-
-		annotations = map[string]string{
-			"serviceaccounts.openshift.io/oauth-redirectreference.route": string(ref),
-		}
-	}
-
-	return &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Name,
-			Namespace: cr.Namespace,
-			Labels: map[string]string{
-				"app": "cryostat",
-			},
-			Annotations: annotations,
-		},
-	}, nil
-}
-
-func NewRoleForCR(cr *operatorv1beta1.Cryostat) *rbacv1.Role {
-	return &rbacv1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Name,
-			Namespace: cr.Namespace,
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				Verbs:     []string{"get", "list", "watch"},
-				APIGroups: []string{""},
-				Resources: []string{"endpoints"},
-			},
-			{
-				Verbs:     []string{"get"},
-				APIGroups: []string{""},
-				Resources: []string{"pods", "replicationcontrollers"},
-			},
-			{
-				Verbs:     []string{"get"},
-				APIGroups: []string{"apps"},
-				Resources: []string{"replicasets", "deployments", "daemonsets", "statefulsets"},
-			},
-			{
-				Verbs:     []string{"get"},
-				APIGroups: []string{"apps.openshift.io"},
-				Resources: []string{"deploymentconfigs"},
-			},
-			{
-				Verbs:     []string{"get", "list"},
-				APIGroups: []string{"route.openshift.io"},
-				Resources: []string{"routes"},
-			},
-		},
-	}
-}
-
-func NewRoleBindingForCR(cr *operatorv1beta1.Cryostat) *rbacv1.RoleBinding {
-	return &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Name,
-			Namespace: cr.Namespace,
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      rbacv1.ServiceAccountKind,
-				Name:      cr.Name,
-				Namespace: cr.Namespace,
-			},
-		},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "Role",
-			Name:     cr.Name,
-		},
-	}
-}
-
-func NewClusterRoleBindingForCR(cr *operatorv1beta1.Cryostat) *rbacv1.ClusterRoleBinding {
-	return &rbacv1.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: clusterUniqueName(cr),
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      rbacv1.ServiceAccountKind,
-				Name:      cr.Name,
-				Namespace: cr.Namespace,
-			},
-		},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
-			Name:     "cryostat-operator-cryostat",
-		},
-	}
-}
-
 func NewConsoleLink(cr *operatorv1beta1.Cryostat, url string) *consolev1.ConsoleLink {
 	// Cluster scoped, so use a unique name to avoid conflicts
 	return &consolev1.ConsoleLink{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: clusterUniqueName(cr),
+			Name: common.ClusterUniqueName(cr),
 		},
 		Spec: consolev1.ConsoleLinkSpec{
 			Link: consolev1.Link{
@@ -1210,13 +1097,6 @@ func getInternalDashboardURL(tls *TLSConfig) string {
 		scheme = "http"
 	}
 	return fmt.Sprintf("%s://%s:%d", scheme, healthCheckHostname, grafanaContainerPort)
-}
-
-func clusterUniqueName(cr *operatorv1beta1.Cryostat) string {
-	// Use the SHA256 checksum of the namespaced name as a suffix
-	nn := types.NamespacedName{Namespace: cr.Namespace, Name: cr.Name}
-	suffix := fmt.Sprintf("%x", sha256.Sum256([]byte(nn.String())))
-	return "cryostat-" + suffix
 }
 
 // Matches image tags of the form "major.minor.patch"

--- a/internal/controllers/cryostat_controller.go
+++ b/internal/controllers/cryostat_controller.go
@@ -59,7 +59,6 @@ import (
 	securityv1 "github.com/openshift/api/security/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -170,7 +169,8 @@ func (r *CryostatReconciler) Reconcile(ctx context.Context, request ctrl.Request
 	// Check if this Cryostat is being deleted
 	if instance.GetDeletionTimestamp() != nil {
 		if controllerutil.ContainsFinalizer(instance, cryostatFinalizer) {
-			err = r.deleteClusterRoleBinding(ctx, instance)
+			// Perform finalizer logic related to RBAC objects
+			err = r.finalizeRBAC(ctx, instance)
 			if err != nil {
 				return reconcile.Result{}, err
 			}
@@ -275,8 +275,8 @@ func (r *CryostatReconciler) Reconcile(ctx context.Context, request ctrl.Request
 		}
 	}
 
-	// Create RBAC resources for Cryostat
-	err = r.createRBAC(ctx, instance)
+	// Reconcile RBAC resources for Cryostat
+	err = r.reconcileRBAC(ctx, instance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -434,87 +434,6 @@ func (r *CryostatReconciler) createObjectIfNotExists(ctx context.Context, ns typ
 		return err
 	}
 	logger.Info("Already exists")
-	return nil
-}
-
-func (r *CryostatReconciler) createRBAC(ctx context.Context, cr *operatorv1beta1.Cryostat) error {
-	// Create ServiceAccount
-	sa, err := resources.NewServiceAccountForCR(cr, r.IsOpenShift)
-	if err != nil {
-		return err
-	}
-	newSA := sa.DeepCopy()
-	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, sa, func() error {
-		if err := controllerutil.SetControllerReference(cr, sa, r.Scheme); err != nil {
-			return err
-		}
-		// TODO just replace the labels and annotations we manage, once we allow the user to configure
-		// ServiceAccount annotations/labels in the CR, we can simply overwrite them all
-		for key, val := range newSA.GetAnnotations() {
-			metav1.SetMetaDataAnnotation(&sa.ObjectMeta, key, val)
-		}
-		if sa.Labels == nil {
-			sa.Labels = map[string]string{}
-		}
-		for key, val := range newSA.GetLabels() {
-			// TODO use metav1.SetMetaDataLabel when updating client-go, replace above initialization
-			sa.Labels[key] = val
-		}
-		// Pod needs SA token, do not allow to be disabled
-		sa.AutomountServiceAccountToken = newSA.AutomountServiceAccountToken
-		// Secrets, ImagePullSecrets are modified by Kubernetes/OpenShift
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-	r.Log.Info(fmt.Sprintf("ServiceAccount %s", op), "name", sa.Name, "namespace", sa.Namespace)
-
-	// Create Role
-	role := resources.NewRoleForCR(cr)
-	if err := controllerutil.SetControllerReference(cr, role, r.Scheme); err != nil {
-		return err
-	}
-	if err := r.createObjectIfNotExists(ctx, types.NamespacedName{Name: role.Name, Namespace: role.Namespace},
-		&rbacv1.Role{}, role); err != nil {
-		return err
-	}
-
-	// Create RoleBinding
-	binding := resources.NewRoleBindingForCR(cr)
-	if err := controllerutil.SetControllerReference(cr, binding, r.Scheme); err != nil {
-		return err
-	}
-	if err := r.createObjectIfNotExists(ctx, types.NamespacedName{Name: binding.Name, Namespace: binding.Namespace},
-		&rbacv1.RoleBinding{}, binding); err != nil {
-		return err
-	}
-
-	// Create ClusterRoleBinding
-	clusterBinding := resources.NewClusterRoleBindingForCR(cr)
-	if err := r.createObjectIfNotExists(ctx, types.NamespacedName{Name: clusterBinding.Name},
-		&rbacv1.ClusterRoleBinding{}, clusterBinding); err != nil {
-		return err
-	}
-	// ClusterRoleBinding can't be owned by namespaced CR, clean up using finalizer
-
-	return nil
-}
-
-func (r *CryostatReconciler) deleteClusterRoleBinding(ctx context.Context, cr *operatorv1beta1.Cryostat) error {
-	reqLogger := r.Log.WithValues("Request.Namespace", cr.Namespace, "Request.Name", cr.Name)
-
-	clusterBinding := resources.NewClusterRoleBindingForCR(cr)
-	err := r.Delete(ctx, clusterBinding)
-	if err != nil {
-		if kerrors.IsNotFound(err) {
-			reqLogger.Info("ClusterRoleBinding not found, proceeding with deletion", "bindingName", clusterBinding.Name)
-			return nil
-		}
-		reqLogger.Error(err, "failed to delete ClusterRoleBinding", "bindingName", clusterBinding.Name)
-		return err
-	}
-	reqLogger.Info("deleted ClusterRoleBinding", "bindingName", clusterBinding.Name)
 	return nil
 }
 

--- a/internal/controllers/cryostat_controller_test.go
+++ b/internal/controllers/cryostat_controller_test.go
@@ -337,7 +337,83 @@ var _ = Describe("CryostatController", func() {
 
 				Expect(sa.ImagePullSecrets).To(Equal(oldSA.ImagePullSecrets))
 				Expect(sa.Secrets).To(Equal(oldSA.Secrets))
-				Expect(sa.AutomountServiceAccountToken).To(BeNil())
+				Expect(sa.AutomountServiceAccountToken).To(Equal(oldSA.AutomountServiceAccountToken))
+			})
+		})
+		Context("with an existing Role", func() {
+			var cr *operatorv1beta1.Cryostat
+			var oldRole *rbacv1.Role
+			BeforeEach(func() {
+				cr = test.NewCryostat()
+				oldRole = test.OtherRole()
+				t.objs = append(t.objs, cr, oldRole)
+			})
+			It("should update the Role", func() {
+				t.reconcileCryostatFully()
+
+				role := &rbacv1.Role{}
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, role)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(metav1.IsControlledBy(role, cr)).To(BeTrue())
+
+				// Labels are unaffected
+				Expect(role.Labels).To(Equal(oldRole.Labels))
+
+				// Rules should be fully replaced
+				Expect(role.Rules).To(Equal(test.NewRole().Rules))
+			})
+		})
+		Context("with an existing Role Binding", func() {
+			var cr *operatorv1beta1.Cryostat
+			var oldBinding *rbacv1.RoleBinding
+			BeforeEach(func() {
+				cr = test.NewCryostat()
+				oldBinding = test.OtherRoleBinding()
+				t.objs = append(t.objs, cr, oldBinding)
+			})
+			It("should update the Role Binding", func() {
+				t.reconcileCryostatFully()
+
+				binding := &rbacv1.RoleBinding{}
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, binding)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(metav1.IsControlledBy(binding, cr)).To(BeTrue())
+
+				// Labels are unaffected
+				Expect(binding.Labels).To(Equal(binding.Labels))
+
+				// Subjects and RoleRef should be fully replaced
+				expected := test.NewRoleBinding()
+				Expect(binding.Subjects).To(Equal(expected.Subjects))
+				Expect(binding.RoleRef).To(Equal(expected.RoleRef))
+			})
+		})
+		Context("with an existing Cluster Role Binding", func() {
+			var cr *operatorv1beta1.Cryostat
+			var oldBinding *rbacv1.ClusterRoleBinding
+			BeforeEach(func() {
+				cr = test.NewCryostat()
+				oldBinding = test.OtherClusterRoleBinding()
+				t.objs = append(t.objs, cr, oldBinding)
+			})
+			It("should update the Cluster Role Binding", func() {
+				t.reconcileCryostatFully()
+
+				binding := &rbacv1.ClusterRoleBinding{}
+				err := t.Client.Get(context.Background(), types.NamespacedName{
+					Name: "cryostat-9ecd5050500c2566765bc593edfcce12434283e5da32a27476bc4a1569304a02",
+				}, binding)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Labels are unaffected
+				Expect(binding.Labels).To(Equal(binding.Labels))
+
+				// Subjects and RoleRef should be fully replaced
+				expected := test.NewClusterRoleBinding()
+				Expect(binding.Subjects).To(Equal(expected.Subjects))
+				Expect(binding.RoleRef).To(Equal(expected.RoleRef))
 			})
 		})
 		Context("with existing Routes", func() {
@@ -2152,8 +2228,9 @@ func (t *cryostatTestInput) checkReportsDeployment() {
 	}
 
 	checkReportsContainer(&template.Spec.Containers[0], t.TLS, t.EnvReportsImageTag, resources, test.NewReportSecurityContext(cr))
-	// Check that the proper Service Account is set
-	Expect(template.Spec.ServiceAccountName).To(Equal("cryostat"))
+	// Check that the default Service Account is used
+	Expect(template.Spec.ServiceAccountName).To(BeEmpty())
+	Expect(template.Spec.AutomountServiceAccountToken).To(BeNil())
 }
 
 func (t *cryostatTestInput) checkDeploymentHasTemplates() {

--- a/internal/controllers/cryostat_controller_test.go
+++ b/internal/controllers/cryostat_controller_test.go
@@ -359,6 +359,7 @@ var _ = Describe("CryostatController", func() {
 
 				// Labels are unaffected
 				Expect(role.Labels).To(Equal(oldRole.Labels))
+				Expect(role.Annotations).To(Equal(oldRole.Annotations))
 
 				// Rules should be fully replaced
 				Expect(role.Rules).To(Equal(test.NewRole().Rules))
@@ -382,7 +383,8 @@ var _ = Describe("CryostatController", func() {
 				Expect(metav1.IsControlledBy(binding, cr)).To(BeTrue())
 
 				// Labels are unaffected
-				Expect(binding.Labels).To(Equal(binding.Labels))
+				Expect(binding.Labels).To(Equal(oldBinding.Labels))
+				Expect(binding.Annotations).To(Equal(oldBinding.Annotations))
 
 				// Subjects and RoleRef should be fully replaced
 				expected := test.NewRoleBinding()
@@ -407,8 +409,9 @@ var _ = Describe("CryostatController", func() {
 				}, binding)
 				Expect(err).ToNot(HaveOccurred())
 
-				// Labels are unaffected
-				Expect(binding.Labels).To(Equal(binding.Labels))
+				// Labels and annotations are unaffected
+				Expect(binding.Labels).To(Equal(oldBinding.Labels))
+				Expect(binding.Annotations).To(Equal(oldBinding.Annotations))
 
 				// Subjects and RoleRef should be fully replaced
 				expected := test.NewClusterRoleBinding()
@@ -1606,6 +1609,116 @@ var _ = Describe("CryostatController", func() {
 					})
 				})
 
+			})
+		})
+		Context("with an existing Service Account", func() {
+			var cr *operatorv1beta1.Cryostat
+			var oldSA *corev1.ServiceAccount
+			BeforeEach(func() {
+				cr = test.NewCryostat()
+				oldSA = test.OtherServiceAccount()
+				t.objs = append(t.objs, cr, oldSA)
+			})
+			It("should update the Service Account", func() {
+				t.reconcileCryostatFully()
+
+				sa := &corev1.ServiceAccount{}
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, sa)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(sa.Annotations).To(Equal(map[string]string{
+					"hello": "world",
+				}))
+
+				Expect(sa.Labels).To(Equal(map[string]string{
+					"app":   "cryostat",
+					"other": "label",
+				}))
+
+				Expect(metav1.IsControlledBy(sa, cr)).To(BeTrue())
+
+				Expect(sa.ImagePullSecrets).To(Equal(oldSA.ImagePullSecrets))
+				Expect(sa.Secrets).To(Equal(oldSA.Secrets))
+				Expect(sa.AutomountServiceAccountToken).To(Equal(oldSA.AutomountServiceAccountToken))
+			})
+		})
+		Context("with an existing Role", func() {
+			var cr *operatorv1beta1.Cryostat
+			var oldRole *rbacv1.Role
+			BeforeEach(func() {
+				cr = test.NewCryostat()
+				oldRole = test.OtherRole()
+				t.objs = append(t.objs, cr, oldRole)
+			})
+			It("should update the Role", func() {
+				t.reconcileCryostatFully()
+
+				role := &rbacv1.Role{}
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, role)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(metav1.IsControlledBy(role, cr)).To(BeTrue())
+
+				// Labels are unaffected
+				Expect(role.Labels).To(Equal(oldRole.Labels))
+				Expect(role.Annotations).To(Equal(oldRole.Annotations))
+
+				// Rules should be fully replaced
+				Expect(role.Rules).To(Equal(test.NewRole().Rules))
+			})
+		})
+		Context("with an existing Role Binding", func() {
+			var cr *operatorv1beta1.Cryostat
+			var oldBinding *rbacv1.RoleBinding
+			BeforeEach(func() {
+				cr = test.NewCryostat()
+				oldBinding = test.OtherRoleBinding()
+				t.objs = append(t.objs, cr, oldBinding)
+			})
+			It("should update the Role Binding", func() {
+				t.reconcileCryostatFully()
+
+				binding := &rbacv1.RoleBinding{}
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, binding)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(metav1.IsControlledBy(binding, cr)).To(BeTrue())
+
+				// Labels are unaffected
+				Expect(binding.Labels).To(Equal(oldBinding.Labels))
+				Expect(binding.Annotations).To(Equal(oldBinding.Annotations))
+
+				// Subjects and RoleRef should be fully replaced
+				expected := test.NewRoleBinding()
+				Expect(binding.Subjects).To(Equal(expected.Subjects))
+				Expect(binding.RoleRef).To(Equal(expected.RoleRef))
+			})
+		})
+		Context("with an existing Cluster Role Binding", func() {
+			var cr *operatorv1beta1.Cryostat
+			var oldBinding *rbacv1.ClusterRoleBinding
+			BeforeEach(func() {
+				cr = test.NewCryostat()
+				oldBinding = test.OtherClusterRoleBinding()
+				t.objs = append(t.objs, cr, oldBinding)
+			})
+			It("should update the Cluster Role Binding", func() {
+				t.reconcileCryostatFully()
+
+				binding := &rbacv1.ClusterRoleBinding{}
+				err := t.Client.Get(context.Background(), types.NamespacedName{
+					Name: "cryostat-9ecd5050500c2566765bc593edfcce12434283e5da32a27476bc4a1569304a02",
+				}, binding)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Labels and annotations are unaffected
+				Expect(binding.Labels).To(Equal(oldBinding.Labels))
+				Expect(binding.Annotations).To(Equal(oldBinding.Annotations))
+
+				// Subjects and RoleRef should be fully replaced
+				expected := test.NewClusterRoleBinding()
+				Expect(binding.Subjects).To(Equal(expected.Subjects))
+				Expect(binding.RoleRef).To(Equal(expected.RoleRef))
 			})
 		})
 	})

--- a/internal/controllers/rbac.go
+++ b/internal/controllers/rbac.go
@@ -1,0 +1,312 @@
+// Copyright The Cryostat Authors
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or data
+// (collectively the "Software"), free of charge and under any and all copyright
+// rights in the Software, and any and all patent rights owned or freely
+// licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger
+// Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+// one is included with the Software (each a "Larger Work" to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition:
+// The above copyright notice and either this complete permission notice or at
+// a minimum a reference to the UPL must be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	operatorv1beta1 "github.com/cryostatio/cryostat-operator/api/v1beta1"
+	"github.com/cryostatio/cryostat-operator/internal/controllers/common"
+	oauthv1 "github.com/openshift/api/oauth/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func (r *CryostatReconciler) reconcileRBAC(ctx context.Context, cr *operatorv1beta1.Cryostat) error {
+	err := r.reconcileServiceAccount(ctx, cr)
+	if err != nil {
+		return err
+	}
+	err = r.reconcileRole(ctx, cr)
+	if err != nil {
+		return err
+	}
+	err = r.reconcileRoleBinding(ctx, cr)
+	if err != nil {
+		return err
+	}
+	err = r.reconcileClusterRoleBinding(ctx, cr)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *CryostatReconciler) finalizeRBAC(ctx context.Context, cr *operatorv1beta1.Cryostat) error {
+	return r.deleteClusterRoleBinding(ctx, cr)
+}
+
+func newServiceAccount(cr *operatorv1beta1.Cryostat) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Name,
+			Namespace: cr.Namespace,
+		},
+	}
+}
+
+func (r *CryostatReconciler) reconcileServiceAccount(ctx context.Context, cr *operatorv1beta1.Cryostat) error {
+	sa := newServiceAccount(cr)
+	labels := map[string]string{
+		"app": "cryostat",
+	}
+	annotations := map[string]string{}
+	// If running on OpenShift, set the route reference as an annotation.
+	// This will tell OpenShift's OAuth to redirect to the route when
+	// this Service Account is used as an OAuth client.
+	if r.IsOpenShift {
+		oAuthRedirectReference := &oauthv1.OAuthRedirectReference{
+			Reference: oauthv1.RedirectReference{
+				Kind: "Route",
+				Name: newCoreRoute(cr).Name,
+			},
+		}
+
+		ref, err := json.Marshal(oAuthRedirectReference)
+		if err != nil {
+			return err
+		}
+
+		annotations["serviceaccounts.openshift.io/oauth-redirectreference.route"] = string(ref)
+	}
+	return r.createOrUpdateServiceAccount(ctx, sa, cr, labels, annotations)
+}
+
+func newRole(cr *operatorv1beta1.Cryostat) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Name,
+			Namespace: cr.Namespace,
+		},
+	}
+}
+
+func (r *CryostatReconciler) reconcileRole(ctx context.Context, cr *operatorv1beta1.Cryostat) error {
+	role := newRole(cr)
+	rules := []rbacv1.PolicyRule{
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{""},
+			Resources: []string{"endpoints"},
+		},
+		{
+			Verbs:     []string{"get"},
+			APIGroups: []string{""},
+			Resources: []string{"pods", "replicationcontrollers"},
+		},
+		{
+			Verbs:     []string{"get"},
+			APIGroups: []string{"apps"},
+			Resources: []string{"replicasets", "deployments", "daemonsets", "statefulsets"},
+		},
+		{
+			Verbs:     []string{"get"},
+			APIGroups: []string{"apps.openshift.io"},
+			Resources: []string{"deploymentconfigs"},
+		},
+		{
+			Verbs:     []string{"get", "list"},
+			APIGroups: []string{"route.openshift.io"},
+			Resources: []string{"routes"},
+		},
+	}
+	return r.createOrUpdateRole(ctx, role, cr, rules)
+}
+
+func (r *CryostatReconciler) reconcileRoleBinding(ctx context.Context, cr *operatorv1beta1.Cryostat) error {
+	binding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Name,
+			Namespace: cr.Namespace,
+		},
+	}
+
+	sa := newServiceAccount(cr)
+	subjects := []rbacv1.Subject{
+		{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      sa.Name,
+			Namespace: sa.Namespace,
+		},
+	}
+
+	roleRef := &rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "Role",
+		Name:     newRole(cr).Name,
+	}
+
+	return r.createOrUpdateRoleBinding(ctx, binding, cr, subjects, roleRef)
+}
+
+func newClusterRoleBinding(cr *operatorv1beta1.Cryostat) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: common.ClusterUniqueName(cr),
+		},
+	}
+}
+
+const clusterRoleName = "cryostat-operator-cryostat"
+
+func (r *CryostatReconciler) reconcileClusterRoleBinding(ctx context.Context, cr *operatorv1beta1.Cryostat) error {
+	binding := newClusterRoleBinding(cr)
+
+	sa := newServiceAccount(cr)
+	subjects := []rbacv1.Subject{
+		{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      sa.Name,
+			Namespace: sa.Namespace,
+		},
+	}
+
+	roleRef := &rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "ClusterRole",
+		Name:     clusterRoleName,
+	}
+
+	return r.createOrUpdateClusterRoleBinding(ctx, binding, cr, subjects, roleRef)
+}
+
+func (r *CryostatReconciler) createOrUpdateServiceAccount(ctx context.Context, sa *corev1.ServiceAccount,
+	owner metav1.Object, labels map[string]string, annotations map[string]string) error {
+	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, sa, func() error {
+		// TODO just replace the labels and annotations we manage, once we allow the user to configure
+		// ServiceAccount annotations/labels in the CR, we can simply overwrite them all
+
+		// Update labels and annotations managed by the operator
+		for key, val := range labels {
+			metav1.SetMetaDataLabel(&sa.ObjectMeta, key, val)
+		}
+		for key, val := range annotations {
+			metav1.SetMetaDataAnnotation(&sa.ObjectMeta, key, val)
+		}
+
+		// Set the Cryostat CR as controller
+		if err := controllerutil.SetControllerReference(owner, sa, r.Scheme); err != nil {
+			return err
+		}
+		// AutomountServiceAccountToken specified in Pod, which takes precedence
+		// Secrets, ImagePullSecrets are modified by Kubernetes/OpenShift
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	r.Log.Info(fmt.Sprintf("Service Account %s", op), "name", sa.Name, "namespace", sa.Namespace)
+	return nil
+}
+
+func (r *CryostatReconciler) createOrUpdateRole(ctx context.Context, role *rbacv1.Role,
+	owner metav1.Object, rules []rbacv1.PolicyRule) error {
+	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, role, func() error {
+		// Update the list of PolicyRules
+		role.Rules = rules
+
+		// Set the Cryostat CR as controller
+		if err := controllerutil.SetControllerReference(owner, role, r.Scheme); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	r.Log.Info(fmt.Sprintf("Role %s", op), "name", role.Name, "namespace", role.Namespace)
+	return nil
+}
+
+func (r *CryostatReconciler) createOrUpdateRoleBinding(ctx context.Context, binding *rbacv1.RoleBinding,
+	owner metav1.Object, subjects []rbacv1.Subject, roleRef *rbacv1.RoleRef) error {
+	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, binding, func() error {
+		// Update the list of Subjects
+		binding.Subjects = subjects
+		// Update the Role reference
+		binding.RoleRef = *roleRef
+
+		// Set the Cryostat CR as controller
+		if err := controllerutil.SetControllerReference(owner, binding, r.Scheme); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	r.Log.Info(fmt.Sprintf("Role Binding %s", op), "name", binding.Name, "namespace", binding.Namespace)
+	return nil
+}
+
+func (r *CryostatReconciler) createOrUpdateClusterRoleBinding(ctx context.Context, binding *rbacv1.ClusterRoleBinding,
+	owner metav1.Object, subjects []rbacv1.Subject, roleRef *rbacv1.RoleRef) error {
+	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, binding, func() error {
+		// Update the list of Subjects
+		binding.Subjects = subjects
+		// Update the Role reference
+		binding.RoleRef = *roleRef
+
+		// ClusterRoleBinding can't be owned by namespaced CR, clean up using finalizer
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	r.Log.Info(fmt.Sprintf("Cluster Role Binding %s", op), "name", binding.Name, "namespace", binding.Namespace)
+	return nil
+}
+
+func (r *CryostatReconciler) deleteClusterRoleBinding(ctx context.Context, cr *operatorv1beta1.Cryostat) error {
+	clusterBinding := newClusterRoleBinding(cr) // TODO move to finalizeRBAC, add tests
+	err := r.Delete(ctx, clusterBinding)
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			r.Log.Info("ClusterRoleBinding not found, proceeding with deletion", "bindingName", clusterBinding.Name)
+			return nil
+		}
+		r.Log.Error(err, "failed to delete ClusterRoleBinding", "bindingName", clusterBinding.Name)
+		return err
+	}
+	r.Log.Info("deleted ClusterRoleBinding", "bindingName", clusterBinding.Name)
+	return nil
+}

--- a/internal/controllers/rbac.go
+++ b/internal/controllers/rbac.go
@@ -297,7 +297,7 @@ func (r *CryostatReconciler) createOrUpdateClusterRoleBinding(ctx context.Contex
 }
 
 func (r *CryostatReconciler) deleteClusterRoleBinding(ctx context.Context, cr *operatorv1beta1.Cryostat) error {
-	clusterBinding := newClusterRoleBinding(cr) // TODO move to finalizeRBAC, add tests
+	clusterBinding := newClusterRoleBinding(cr)
 	err := r.Delete(ctx, clusterBinding)
 	if err != nil {
 		if kerrors.IsNotFound(err) {

--- a/internal/controllers/routes.go
+++ b/internal/controllers/routes.go
@@ -51,14 +51,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func (r *CryostatReconciler) reconcileCoreRoute(ctx context.Context, svc *corev1.Service, cr *operatorv1beta1.Cryostat,
-	tls *resource_definitions.TLSConfig, specs *resource_definitions.ServiceSpecs) error {
-	route := &routev1.Route{
+func newCoreRoute(cr *operatorv1beta1.Cryostat) *routev1.Route {
+	return &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
 		},
 	}
+}
+
+func (r *CryostatReconciler) reconcileCoreRoute(ctx context.Context, svc *corev1.Service, cr *operatorv1beta1.Cryostat,
+	tls *resource_definitions.TLSConfig, specs *resource_definitions.ServiceSpecs) error {
+	route := newCoreRoute(cr)
 	coreConfig := configureCoreRoute(cr)
 	url, err := r.reconcileRoute(ctx, route, svc, cr, tls, coreConfig)
 	if err != nil {

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -2044,6 +2044,25 @@ func NewRole() *rbacv1.Role {
 	}
 }
 
+func OtherRole() *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cryostat",
+			Namespace: "default",
+			Labels: map[string]string{
+				"test": "label",
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     []string{"*"},
+				APIGroups: []string{"*"},
+				Resources: []string{"*"},
+			},
+		},
+	}
+}
+
 func NewAuthClusterRole() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2085,6 +2104,34 @@ func NewRoleBinding() *rbacv1.RoleBinding {
 	}
 }
 
+func OtherRoleBinding() *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cryostat",
+			Namespace: "default",
+			Labels: map[string]string{
+				"test": "label",
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      "not-cryostat",
+				Namespace: "default",
+			},
+			{
+				Kind: rbacv1.UserKind,
+				Name: "also-not-cryostat",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "not-cryostat",
+		},
+	}
+}
+
 func NewClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2101,6 +2148,33 @@ func NewClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
 			Name:     "cryostat-operator-cryostat",
+		},
+	}
+}
+
+func OtherClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cryostat-9ecd5050500c2566765bc593edfcce12434283e5da32a27476bc4a1569304a02",
+			Labels: map[string]string{
+				"test": "label",
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      "not-cryostat",
+				Namespace: "default",
+			},
+			{
+				Kind: rbacv1.UserKind,
+				Name: "also-not-cryostat",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "not-cryostat",
 		},
 	}
 }


### PR DESCRIPTION
This is mostly refactoring RBAC reconciling logic into a separate `rbac.go` file. This PR also ensures that Roles, RoleBindings and ClusterRoleBindings created by the operator are kept up-to-date across operator upgrades, and includes new test cases to exercise this. There are a couple of other changes here:
1. The reports pod now uses the "default" Service Account instead of the Cryostat one. The reports generator doesn't require access to the Kubernetes API, so the elevated permissions given to Cryostat aren't necessary here.
2. Instead of controlling the value of `AutomountServiceAccountToken` in the Service Account, we simply set this to true for the Cryostat pod template. Cryostat depends on its Service Account token being mounted upon startup. The definition in the Pod spec takes priority over any setting in the Service Account. [1]

Fixes: #409 

[1] https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server