### PR TITLE
fix(reports): fix panic in reports scheduling

### DIFF
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -510,7 +510,7 @@ func NewPodForReports(cr *operatorv1beta1.Cryostat, imageTags *ImageTags, tls *T
 	if cr.Spec.ReportOptions != nil && cr.Spec.ReportOptions.SchedulingOptions != nil {
 		schedulingOptions := cr.Spec.ReportOptions.SchedulingOptions
 		nodeSelector = schedulingOptions.NodeSelector
-		if cr.Spec.SchedulingOptions.Affinity != nil {
+		if schedulingOptions.Affinity != nil {
 			affinity = &corev1.Affinity{
 				NodeAffinity:    schedulingOptions.Affinity.NodeAffinity,
 				PodAffinity:     schedulingOptions.Affinity.PodAffinity,

--- a/internal/controllers/cryostat_controller_test.go
+++ b/internal/controllers/cryostat_controller_test.go
@@ -501,35 +501,15 @@ var _ = Describe("CryostatController", func() {
 				t.checkMainDeployment()
 			})
 		})
-		Context("Switching from 0 report sidecars to 1", func() {
+		Context("with report generator service", func() {
 			var cr *operatorv1beta1.Cryostat
 			BeforeEach(func() {
-				cr = test.NewCryostat()
+				cr = test.NewCryostatWithReports()
 				t.objs = append(t.objs, cr)
 				t.reportReplicas = 1
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
-
-				cryostat := &operatorv1beta1.Cryostat{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, cryostat)
-				Expect(err).ToNot(HaveOccurred())
-
-				cryostat.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{
-					Replicas: t.reportReplicas,
-				}
-				err = t.Client.Status().Update(context.Background(), cryostat)
-				Expect(err).ToNot(HaveOccurred())
-
-				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: "default"}}
-				result, err := t.controller.Reconcile(context.Background(), req)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(result).To(Equal(reconcile.Result{}))
-			})
-			It("should configure deployment appropriately", func() {
-				t.checkMainDeployment()
-				t.checkReportsDeployment()
-				t.checkService("cryostat-reports", test.NewReportsService())
 			})
 			Context("with cert-manager disabled", func() {
 				BeforeEach(func() {
@@ -543,16 +523,14 @@ var _ = Describe("CryostatController", func() {
 					t.checkService("cryostat-reports", test.NewReportsService())
 				})
 			})
-
 			Context("with Scheduling options", func() {
 				BeforeEach(func() {
-					*cr = *test.NewCryostatWithReportsResources()
+					*cr = *test.NewCryostatWithReportsScheduling()
 				})
 				It("should configure deployment appropriately", func() {
 					t.checkReportsDeployment()
 				})
 			})
-
 			Context("with resource requirements", func() {
 				BeforeEach(func() {
 					*cr = *test.NewCryostatWithReportsResources()
@@ -599,6 +577,36 @@ var _ = Describe("CryostatController", func() {
 							"TestReplicaFailure")
 					})
 				})
+			})
+		})
+		Context("Switching from 0 report sidecars to 1", func() {
+			BeforeEach(func() {
+				cr := test.NewCryostat()
+				t.objs = append(t.objs, cr)
+				t.reportReplicas = 1
+			})
+			JustBeforeEach(func() {
+				t.reconcileCryostatFully()
+
+				cryostat := &operatorv1beta1.Cryostat{}
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, cryostat)
+				Expect(err).ToNot(HaveOccurred())
+
+				cryostat.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{
+					Replicas: t.reportReplicas,
+				}
+				err = t.Client.Status().Update(context.Background(), cryostat)
+				Expect(err).ToNot(HaveOccurred())
+
+				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: "default"}}
+				result, err := t.controller.Reconcile(context.Background(), req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+			})
+			It("should configure deployment appropriately", func() {
+				t.checkMainDeployment()
+				t.checkReportsDeployment()
+				t.checkService("cryostat-reports", test.NewReportsService())
 			})
 		})
 		Context("Switching from 1 report sidecar to 2", func() {

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -102,6 +102,14 @@ func NewCryostat() *operatorv1beta1.Cryostat {
 	}
 }
 
+func NewCryostatWithReports() *operatorv1beta1.Cryostat {
+	cr := NewCryostat()
+	cr.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{
+		Replicas: 1,
+	}
+	return cr
+}
+
 func NewCryostatWithSecrets() *operatorv1beta1.Cryostat {
 	cr := NewCryostat()
 	key := "test.crt"
@@ -303,6 +311,7 @@ func NewCryostatWithGrafanaNetworkOptions() *operatorv1beta1.Cryostat {
 func NewCryostatWithReportsResources() *operatorv1beta1.Cryostat {
 	cr := NewCryostat()
 	cr.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{
+		Replicas: 1,
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("1600m"),
@@ -378,6 +387,7 @@ func NewCryostatWithScheduling() *operatorv1beta1.Cryostat {
 func NewCryostatWithReportsScheduling() *operatorv1beta1.Cryostat {
 	cr := NewCryostat()
 	cr.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{
+		Replicas:          1,
 		SchedulingOptions: populateCryostatWithScheduling(),
 	}
 


### PR DESCRIPTION
This fixes a panic in the reports scheduling options when the main Cryostat scheduling options is not also set. This is caused by an incorrect nil-check. This also fixes a few problems in the reports tests where they did not test what they appeared to be testing.

Related to: #340 