### PR TITLE
fix(deploy): recreate deployment if selector changed

### DIFF
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -105,6 +105,7 @@ func NewDeploymentForCR(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, image
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
+			// Selector is immutable, avoid modifying if possible
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app":       cr.Name,
@@ -149,6 +150,7 @@ func NewDeploymentForReports(cr *operatorv1beta1.Cryostat, imageTags *ImageTags,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
+			// Selector is immutable, avoid modifying if possible
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app":       cr.Name,

--- a/internal/controllers/cryostat_controller_test.go
+++ b/internal/controllers/cryostat_controller_test.go
@@ -277,9 +277,11 @@ var _ = Describe("CryostatController", func() {
 				oldDeploy = test.OtherDeployment()
 				t.objs = append(t.objs, cr, oldDeploy)
 			})
-			It("should update the Deployment", func() {
+			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
 
+			})
+			It("should update the Deployment", func() {
 				deploy := &appsv1.Deployment{}
 				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, deploy)
 				Expect(err).ToNot(HaveOccurred())
@@ -302,6 +304,15 @@ var _ = Describe("CryostatController", func() {
 				// Deployment Selector is immutable
 				Expect(deploy.Spec.Selector).To(Equal(oldDeploy.Spec.Selector))
 				Expect(deploy.Spec.Replicas).To(Equal(oldDeploy.Spec.Replicas))
+			})
+			Context("with a different selector", func() {
+				BeforeEach(func() {
+					selector := metav1.AddLabelToSelector(&metav1.LabelSelector{}, "other", "label")
+					oldDeploy.Spec.Selector = selector
+				})
+				It("should delete and recreate the deployment", func() {
+					t.checkMainDeployment()
+				})
 			})
 		})
 		Context("with an existing Service Account", func() {

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -1606,7 +1606,7 @@ func OtherDeployment() *appsv1.Deployment {
 					},
 				},
 			},
-			Selector: metav1.AddLabelToSelector(&metav1.LabelSelector{}, "other", "label"),
+			Selector: NewMainDeploymentSelector(),
 			Replicas: &replicas,
 		},
 	}


### PR DESCRIPTION
This PR modifies the Deployment update code to detect when the immutable selector has changed. When this is detected, the operator deletes the deployment and recreates it. With this change it should be possible to upgrade from 2.0 to 2.2, the deployment selectors were changed in 2.1. I built a catalog image to help test this upgrade scenario: `quay.io/ebaron/cryostat-operator-catalog:selector-fix-01`.

To test:
1. Create the following objects:
```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
    name: cryostat-catalog
    namespace: openshift-marketplace
spec:
    sourceType: grpc
    image: quay.io/ebaron/cryostat-operator-catalog:selector-fix-01
    displayName: Cryostat Catalog
    publisher: Cryostat Authors
    updateStrategy:
        registryPoll:
            interval: 10m
```

```yaml
apiVersion: operators.coreos.com/v1
kind: OperatorGroup
metadata:
    name: cryostat-operator-group
    namespace: cryostat-operator-system
spec:
    targetNamespaces:
    - cryostat-operator-system
```

```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
    name: sub-to-cryostat-operator
    namespace: cryostat-operator-system
spec:
    channel: alpha
    name: cryostat-operator
    source: cryostat-catalog
    sourceNamespace: openshift-marketplace
    installPlanApproval: Manual
    startingCSV: cryostat-operator.v2.0.1-dev
    config:
        env:
        - name: RELATED_IMAGE_CORE
          value: quay.io/ebaron/cryostat:before-db
```
2. Approve the install plan for cryostat-operator.v2.0.1-dev.
3. Create a Cryostat instance.
4. Approve the install plan to upgrade to cryostat-operator.v2.2.0-dev.
5. The Cryostat deployment selector should have the `component` label:
```
kubectl get -ojsonpath='{.spec.selector}' deploy cryostat-sample | jq
{
  "matchLabels": {
    "app": "cryostat-sample",
    "component": "cryostat",
    "kind": "cryostat"
  }
}
```
6. The upgraded Cryostat application should function as normal.

Fixes: #433, #388 