### PR TITLE
fix(deploy): use recreate strategy and 1 replica

### DIFF
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -101,6 +101,8 @@ const (
 
 func NewDeploymentForCR(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, imageTags *ImageTags,
 	tls *TLSConfig, fsGroup int64, openshift bool) *appsv1.Deployment {
+	// Force one replica to avoid lock file and PVC contention
+	replicas := int32(1)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
@@ -135,6 +137,10 @@ func NewDeploymentForCR(cr *operatorv1beta1.Cryostat, specs *ServiceSpecs, image
 					},
 				},
 				Spec: *NewPodForCR(cr, specs, imageTags, tls, fsGroup, openshift),
+			},
+			Replicas: &replicas,
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
 			},
 		},
 	}

--- a/internal/controllers/cryostat_controller.go
+++ b/internal/controllers/cryostat_controller.go
@@ -500,10 +500,10 @@ func (r *CryostatReconciler) createOrUpdateDeployment(ctx context.Context, deplo
 			// Return error so deployment can be recreated
 			return errSelectorModified
 		}
-		// Set the replica count, if managed by the operator
-		if deployCopy.Spec.Replicas != nil {
-			deploy.Spec.Replicas = deployCopy.Spec.Replicas
-		}
+		// Set the replica count and update strategy
+		deploy.Spec.Replicas = deployCopy.Spec.Replicas
+		deploy.Spec.Strategy = deployCopy.Spec.Strategy
+
 		// Update pod template spec to propagate any changes from Cryostat CR
 		deploy.Spec.Template.Spec = deployCopy.Spec.Template.Spec
 		// Update pod template metadata

--- a/internal/controllers/cryostat_controller_test.go
+++ b/internal/controllers/cryostat_controller_test.go
@@ -309,7 +309,8 @@ var _ = Describe("CryostatController", func() {
 
 				// Deployment Selector is immutable
 				Expect(deploy.Spec.Selector).To(Equal(oldDeploy.Spec.Selector))
-				Expect(deploy.Spec.Replicas).To(Equal(oldDeploy.Spec.Replicas))
+				Expect(deploy.Spec.Replicas).To(Equal(&[]int32{1}[0]))
+				Expect(deploy.Spec.Strategy).To(Equal(test.NewMainDeploymentStrategy()))
 			})
 			Context("with a different selector", func() {
 				BeforeEach(func() {
@@ -2578,6 +2579,9 @@ func (t *cryostatTestInput) checkMainDeployment() {
 	}))
 	Expect(metav1.IsControlledBy(deployment, cr)).To(BeTrue())
 	Expect(deployment.Spec.Selector).To(Equal(test.NewMainDeploymentSelector()))
+	Expect(deployment.Spec.Replicas).ToNot(BeNil())
+	Expect(*deployment.Spec.Replicas).To(Equal(int32(1)))
+	Expect(deployment.Spec.Strategy).To(Equal(test.NewMainDeploymentStrategy()))
 
 	// compare Pod template
 	t.checkMainPodTemplate(deployment, cr)
@@ -2669,7 +2673,9 @@ func (t *cryostatTestInput) checkReportsDeployment() {
 	}))
 	Expect(metav1.IsControlledBy(deployment, cr)).To(BeTrue())
 	Expect(deployment.Spec.Selector).To(Equal(test.NewReportsDeploymentSelector()))
+	Expect(deployment.Spec.Replicas).ToNot(BeNil())
 	Expect(*deployment.Spec.Replicas).To(Equal(t.reportReplicas))
+	Expect(deployment.Spec.Strategy).To(BeZero())
 
 	// compare Pod template
 	template := deployment.Spec.Template

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -1720,6 +1720,12 @@ func NewReportsDeploymentSelector() *metav1.LabelSelector {
 	}
 }
 
+func NewMainDeploymentStrategy() appsv1.DeploymentStrategy {
+	return appsv1.DeploymentStrategy{
+		Type: appsv1.RecreateDeploymentStrategyType,
+	}
+}
+
 func OtherDeployment() *appsv1.Deployment {
 	replicas := int32(2)
 	return &appsv1.Deployment{


### PR DESCRIPTION
There are two bugs that occur due to replicas contending for access to the credentials database, and replicas on different nodes competing for the PVC itself. Cryostat is currently meant to work as a single replica, but during rolling updates there could be two simultaneously.

To avoid these issues, we're changing the deployment strategy from the default of `RollingUpdate` to `Recreate`. As a result there will be some brief downtime in response to upgrades or configuration changes. The other change is the operator managing the `Replicas` field of the main Cryostat deployment. This is to ensure that the replica count stays at 1 to avoid the above bugs.

To test:
1. `make deploy create_cryostat_cr OPERATOR_IMG=....`
2. `kubectl edit cryostat cryostat-sample`. Change some field such as setting `reportOptions.replicas` to 1.
3. The Cryostat deployment should scale down to 0 and then back up to 1, reflecting this new configuration.
4. Try manually scaling up/down the Cryostat deployment. After a brief time, the operator should revert the deployment to 1 replica.

Fixes: #487, #491 