### PR TITLE
test(resources): multi-namespace support for test resources

### DIFF
--- a/internal/controllers/cryostat_controller_test.go
+++ b/internal/controllers/cryostat_controller_test.go
@@ -419,9 +419,10 @@ var _ = Describe("CryostatController", func() {
 			It("should update the Cluster Role Binding", func() {
 				t.reconcileCryostatFully()
 
+				expected := t.NewClusterRoleBinding()
 				binding := &rbacv1.ClusterRoleBinding{}
 				err := t.Client.Get(context.Background(), types.NamespacedName{
-					Name: "cryostat-ffc3f6d167f69f78c5882a8f67be7efcc7f2f9062145a98f99f7863922c52b10",
+					Name: expected.Name,
 				}, binding)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -430,7 +431,6 @@ var _ = Describe("CryostatController", func() {
 				Expect(binding.Annotations).To(Equal(oldBinding.Annotations))
 
 				// Subjects and RoleRef should be fully replaced
-				expected := t.NewClusterRoleBinding()
 				Expect(binding.Subjects).To(Equal(expected.Subjects))
 				Expect(binding.RoleRef).To(Equal(expected.RoleRef))
 			})
@@ -1947,9 +1947,10 @@ var _ = Describe("CryostatController", func() {
 			It("should update the Cluster Role Binding", func() {
 				t.reconcileCryostatFully()
 
+				expected := t.NewClusterRoleBinding()
 				binding := &rbacv1.ClusterRoleBinding{}
 				err := t.Client.Get(context.Background(), types.NamespacedName{
-					Name: "cryostat-ffc3f6d167f69f78c5882a8f67be7efcc7f2f9062145a98f99f7863922c52b10",
+					Name: expected.Name,
 				}, binding)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1958,7 +1959,6 @@ var _ = Describe("CryostatController", func() {
 				Expect(binding.Annotations).To(Equal(oldBinding.Annotations))
 
 				// Subjects and RoleRef should be fully replaced
-				expected := t.NewClusterRoleBinding()
 				Expect(binding.Subjects).To(Equal(expected.Subjects))
 				Expect(binding.RoleRef).To(Equal(expected.RoleRef))
 			})
@@ -2190,11 +2190,10 @@ func (t *cryostatTestInput) expectRBAC() {
 	Expect(binding.Subjects).To(Equal(expectedBinding.Subjects))
 	Expect(binding.RoleRef).To(Equal(expectedBinding.RoleRef))
 
-	clusterBinding := &rbacv1.ClusterRoleBinding{}
-	err = t.Client.Get(context.Background(), types.NamespacedName{
-		Name: "cryostat-ffc3f6d167f69f78c5882a8f67be7efcc7f2f9062145a98f99f7863922c52b10"}, clusterBinding)
-	Expect(err).ToNot(HaveOccurred())
 	expectedClusterBinding := t.NewClusterRoleBinding()
+	clusterBinding := &rbacv1.ClusterRoleBinding{}
+	err = t.Client.Get(context.Background(), types.NamespacedName{Name: expectedClusterBinding.Name}, clusterBinding)
+	Expect(err).ToNot(HaveOccurred())
 	Expect(clusterBinding.GetName()).To(Equal(expectedClusterBinding.GetName()))
 	Expect(clusterBinding.GetNamespace()).To(Equal(expectedClusterBinding.GetNamespace()))
 	Expect(clusterBinding.GetLabels()).To(Equal(expectedClusterBinding.GetLabels()))
@@ -2205,8 +2204,7 @@ func (t *cryostatTestInput) expectRBAC() {
 
 func (t *cryostatTestInput) checkClusterRoleBindingDeleted() {
 	clusterBinding := &rbacv1.ClusterRoleBinding{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{
-		Name: "cryostat-ffc3f6d167f69f78c5882a8f67be7efcc7f2f9062145a98f99f7863922c52b10"}, clusterBinding)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: t.NewClusterRoleBinding().Name}, clusterBinding)
 	Expect(kerrors.IsNotFound(err)).To(BeTrue())
 }
 

--- a/internal/controllers/cryostat_controller_test.go
+++ b/internal/controllers/cryostat_controller_test.go
@@ -73,12 +73,10 @@ import (
 )
 
 type cryostatTestInput struct {
-	controller     *controllers.CryostatReconciler
-	objs           []runtime.Object
-	minimal        bool
-	reportReplicas int32
-	externalTLS    bool
+	controller *controllers.CryostatReconciler
+	objs       []runtime.Object
 	test.TestReconcilerConfig
+	*test.TestResources
 }
 
 var _ = Describe("CryostatController", func() {
@@ -97,7 +95,7 @@ var _ = Describe("CryostatController", func() {
 		t.controller = &controllers.CryostatReconciler{
 			Client:        t.Client,
 			Scheme:        s,
-			IsOpenShift:   true,
+			IsOpenShift:   t.OpenShift,
 			EventRecorder: record.NewFakeRecorder(1024),
 			RESTMapper:    test.NewTESTRESTMapper(),
 			Log:           logger,
@@ -108,14 +106,18 @@ var _ = Describe("CryostatController", func() {
 	BeforeEach(func() {
 		t = &cryostatTestInput{
 			TestReconcilerConfig: test.TestReconcilerConfig{
-				TLS:                true,
 				GeneratedPasswords: []string{"grafana", "credentials_database", "jmx", "keystore"},
 			},
-			externalTLS: true,
+			TestResources: &test.TestResources{
+				Namespace:   "test",
+				TLS:         true,
+				ExternalTLS: true,
+				OpenShift:   true,
+			},
 		}
 		t.objs = []runtime.Object{
-			test.NewNamespace(),
-			test.NewApiServer(),
+			t.NewNamespace(),
+			t.NewApiServer(),
 		}
 	})
 
@@ -126,7 +128,7 @@ var _ = Describe("CryostatController", func() {
 	Describe("reconciling a request in OpenShift", func() {
 		Context("successfully creates required resources", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostat())
+				t.objs = append(t.objs, t.NewCryostat())
 			})
 			It("should create certificates", func() {
 				t.expectCertificates()
@@ -138,7 +140,7 @@ var _ = Describe("CryostatController", func() {
 				t.expectRoutes()
 			})
 			It("should create persistent volume claim and set owner", func() {
-				t.expectPVC(test.NewDefaultPVC())
+				t.expectPVC(t.NewDefaultPVC())
 			})
 			It("should create Grafana secret and set owner", func() {
 				t.expectGrafanaSecret()
@@ -151,7 +153,7 @@ var _ = Describe("CryostatController", func() {
 			})
 			It("should create Grafana service and set owner", func() {
 				service := &corev1.Service{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-grafana", Namespace: "default"}, service)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-grafana", Namespace: t.Namespace}, service)
 				Expect(kerrors.IsNotFound(err)).To(BeTrue())
 
 				t.reconcileCryostatFully()
@@ -164,7 +166,7 @@ var _ = Describe("CryostatController", func() {
 				t.expectStatusApplicationURL()
 			})
 			It("should set GrafanaSecret in CR Status", func() {
-				t.expectStatusGrafanaSecretName(test.NewGrafanaSecret().Name)
+				t.expectStatusGrafanaSecretName(t.NewGrafanaSecret().Name)
 			})
 			It("should create deployment and set owner", func() {
 				t.expectDeployment()
@@ -215,9 +217,9 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("succesfully creates required resources for minimal deployment", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewMinimalCryostat())
-				t.minimal = true
+				t.Minimal = true
 				t.GeneratedPasswords = []string{"credentials_database", "jmx", "keystore"}
+				t.objs = append(t.objs, t.NewCryostat())
 			})
 			It("should create certificates", func() {
 				t.expectCertificates()
@@ -229,7 +231,7 @@ var _ = Describe("CryostatController", func() {
 				t.expectRoutes()
 			})
 			It("should create persistent volume claim and set owner", func() {
-				t.expectPVC(test.NewDefaultPVC())
+				t.expectPVC(t.NewDefaultPVC())
 			})
 			It("should create Credentials Database secret and set owner", func() {
 				t.expectCredentialsDatabaseSecret()
@@ -252,7 +254,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("after cryostat reconciled successfully", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostat())
+				t.objs = append(t.objs, t.NewCryostat())
 			})
 			It("should be idempotent", func() {
 				t.expectIdempotence()
@@ -260,8 +262,8 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("After a minimal cryostat reconciled successfully", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewMinimalCryostat())
-				t.minimal = true
+				t.Minimal = true
+				t.objs = append(t.objs, t.NewCryostat())
 			})
 			It("should be idempotent", func() {
 				t.expectIdempotence()
@@ -269,7 +271,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("Cryostat does not exist", func() {
 			It("should do nothing", func() {
-				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "does-not-exist", Namespace: "default"}}
+				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "does-not-exist", Namespace: t.Namespace}}
 				result, err := t.controller.Reconcile(context.Background(), req)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{}))
@@ -279,8 +281,8 @@ var _ = Describe("CryostatController", func() {
 			var cr *operatorv1beta1.Cryostat
 			var oldDeploy *appsv1.Deployment
 			BeforeEach(func() {
-				cr = test.NewCryostat()
-				oldDeploy = test.OtherDeployment()
+				cr = t.NewCryostat()
+				oldDeploy = t.OtherDeployment()
 				t.objs = append(t.objs, cr, oldDeploy)
 			})
 			JustBeforeEach(func() {
@@ -289,7 +291,7 @@ var _ = Describe("CryostatController", func() {
 			})
 			It("should update the Deployment", func() {
 				deploy := &appsv1.Deployment{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, deploy)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, deploy)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(deploy.Annotations).To(Equal(map[string]string{
@@ -310,7 +312,7 @@ var _ = Describe("CryostatController", func() {
 				// Deployment Selector is immutable
 				Expect(deploy.Spec.Selector).To(Equal(oldDeploy.Spec.Selector))
 				Expect(deploy.Spec.Replicas).To(Equal(&[]int32{1}[0]))
-				Expect(deploy.Spec.Strategy).To(Equal(test.NewMainDeploymentStrategy()))
+				Expect(deploy.Spec.Strategy).To(Equal(t.NewMainDeploymentStrategy()))
 			})
 			Context("with a different selector", func() {
 				BeforeEach(func() {
@@ -326,15 +328,15 @@ var _ = Describe("CryostatController", func() {
 			var cr *operatorv1beta1.Cryostat
 			var oldSA *corev1.ServiceAccount
 			BeforeEach(func() {
-				cr = test.NewCryostat()
-				oldSA = test.OtherServiceAccount()
+				cr = t.NewCryostat()
+				oldSA = t.OtherServiceAccount()
 				t.objs = append(t.objs, cr, oldSA)
 			})
 			It("should update the Service Account", func() {
 				t.reconcileCryostatFully()
 
 				sa := &corev1.ServiceAccount{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, sa)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, sa)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(sa.Annotations).To(Equal(map[string]string{
@@ -358,15 +360,15 @@ var _ = Describe("CryostatController", func() {
 			var cr *operatorv1beta1.Cryostat
 			var oldRole *rbacv1.Role
 			BeforeEach(func() {
-				cr = test.NewCryostat()
-				oldRole = test.OtherRole()
+				cr = t.NewCryostat()
+				oldRole = t.OtherRole()
 				t.objs = append(t.objs, cr, oldRole)
 			})
 			It("should update the Role", func() {
 				t.reconcileCryostatFully()
 
 				role := &rbacv1.Role{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, role)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, role)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(metav1.IsControlledBy(role, cr)).To(BeTrue())
@@ -376,22 +378,22 @@ var _ = Describe("CryostatController", func() {
 				Expect(role.Annotations).To(Equal(oldRole.Annotations))
 
 				// Rules should be fully replaced
-				Expect(role.Rules).To(Equal(test.NewRole().Rules))
+				Expect(role.Rules).To(Equal(t.NewRole().Rules))
 			})
 		})
 		Context("with an existing Role Binding", func() {
 			var cr *operatorv1beta1.Cryostat
 			var oldBinding *rbacv1.RoleBinding
 			BeforeEach(func() {
-				cr = test.NewCryostat()
-				oldBinding = test.OtherRoleBinding()
+				cr = t.NewCryostat()
+				oldBinding = t.OtherRoleBinding()
 				t.objs = append(t.objs, cr, oldBinding)
 			})
 			It("should update the Role Binding", func() {
 				t.reconcileCryostatFully()
 
 				binding := &rbacv1.RoleBinding{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, binding)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, binding)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(metav1.IsControlledBy(binding, cr)).To(BeTrue())
@@ -401,7 +403,7 @@ var _ = Describe("CryostatController", func() {
 				Expect(binding.Annotations).To(Equal(oldBinding.Annotations))
 
 				// Subjects and RoleRef should be fully replaced
-				expected := test.NewRoleBinding()
+				expected := t.NewRoleBinding()
 				Expect(binding.Subjects).To(Equal(expected.Subjects))
 				Expect(binding.RoleRef).To(Equal(expected.RoleRef))
 			})
@@ -410,8 +412,8 @@ var _ = Describe("CryostatController", func() {
 			var cr *operatorv1beta1.Cryostat
 			var oldBinding *rbacv1.ClusterRoleBinding
 			BeforeEach(func() {
-				cr = test.NewCryostat()
-				oldBinding = test.OtherClusterRoleBinding()
+				cr = t.NewCryostat()
+				oldBinding = t.OtherClusterRoleBinding()
 				t.objs = append(t.objs, cr, oldBinding)
 			})
 			It("should update the Cluster Role Binding", func() {
@@ -419,7 +421,7 @@ var _ = Describe("CryostatController", func() {
 
 				binding := &rbacv1.ClusterRoleBinding{}
 				err := t.Client.Get(context.Background(), types.NamespacedName{
-					Name: "cryostat-9ecd5050500c2566765bc593edfcce12434283e5da32a27476bc4a1569304a02",
+					Name: "cryostat-ffc3f6d167f69f78c5882a8f67be7efcc7f2f9062145a98f99f7863922c52b10",
 				}, binding)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -428,7 +430,7 @@ var _ = Describe("CryostatController", func() {
 				Expect(binding.Annotations).To(Equal(oldBinding.Annotations))
 
 				// Subjects and RoleRef should be fully replaced
-				expected := test.NewClusterRoleBinding()
+				expected := t.NewClusterRoleBinding()
 				Expect(binding.Subjects).To(Equal(expected.Subjects))
 				Expect(binding.RoleRef).To(Equal(expected.RoleRef))
 			})
@@ -437,21 +439,21 @@ var _ = Describe("CryostatController", func() {
 			var cr *operatorv1beta1.Cryostat
 			var oldSecret *corev1.Secret
 			BeforeEach(func() {
-				cr = test.NewCryostat()
-				oldSecret = test.OtherGrafanaSecret()
+				cr = t.NewCryostat()
+				oldSecret = t.OtherGrafanaSecret()
 				t.objs = append(t.objs, cr, oldSecret)
 			})
 			It("should update the username but not password", func() {
 				t.reconcileCryostatFully()
 
 				secret := &corev1.Secret{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: oldSecret.Name, Namespace: "default"}, secret)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: oldSecret.Name, Namespace: t.Namespace}, secret)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(metav1.IsControlledBy(secret, cr)).To(BeTrue())
 
 				// Username should be replaced, but not password
-				expected := test.NewGrafanaSecret()
+				expected := t.NewGrafanaSecret()
 				Expect(secret.StringData["GF_SECURITY_ADMIN_USER"]).To(Equal(expected.StringData["GF_SECURITY_ADMIN_USER"]))
 				Expect(secret.StringData["GF_SECURITY_ADMIN_PASSWORD"]).To(Equal(oldSecret.StringData["GF_SECURITY_ADMIN_PASSWORD"]))
 			})
@@ -460,21 +462,21 @@ var _ = Describe("CryostatController", func() {
 			var cr *operatorv1beta1.Cryostat
 			var oldSecret *corev1.Secret
 			BeforeEach(func() {
-				cr = test.NewCryostat()
-				oldSecret = test.OtherJMXSecret()
+				cr = t.NewCryostat()
+				oldSecret = t.OtherJMXSecret()
 				t.objs = append(t.objs, cr, oldSecret)
 			})
 			It("should update the username but not password", func() {
 				t.reconcileCryostatFully()
 
 				secret := &corev1.Secret{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: oldSecret.Name, Namespace: "default"}, secret)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: oldSecret.Name, Namespace: t.Namespace}, secret)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(metav1.IsControlledBy(secret, cr)).To(BeTrue())
 
 				// Username should be replaced, but not password
-				expected := test.NewJMXSecret()
+				expected := t.NewJMXSecret()
 				Expect(secret.StringData["CRYOSTAT_RJMX_USER"]).To(Equal(expected.StringData["CRYOSTAT_RJMX_USER"]))
 				Expect(secret.StringData["CRYOSTAT_RJMX_PASS"]).To(Equal(oldSecret.StringData["CRYOSTAT_RJMX_PASS"]))
 			})
@@ -483,15 +485,15 @@ var _ = Describe("CryostatController", func() {
 			var cr *operatorv1beta1.Cryostat
 			var oldSecret *corev1.Secret
 			BeforeEach(func() {
-				cr = test.NewCryostat()
-				oldSecret = test.OtherCredentialsDatabaseSecret()
+				cr = t.NewCryostat()
+				oldSecret = t.OtherCredentialsDatabaseSecret()
 				t.objs = append(t.objs, cr, oldSecret)
 			})
 			It("should not update password", func() {
 				t.reconcileCryostatFully()
 
 				secret := &corev1.Secret{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: oldSecret.Name, Namespace: "default"}, secret)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: oldSecret.Name, Namespace: t.Namespace}, secret)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(metav1.IsControlledBy(secret, cr)).To(BeTrue())
@@ -503,9 +505,9 @@ var _ = Describe("CryostatController", func() {
 			var oldCoreRoute *openshiftv1.Route
 			var oldGrafanaRoute *openshiftv1.Route
 			BeforeEach(func() {
-				cr = test.NewCryostat()
-				oldCoreRoute = test.OtherCoreRoute()
-				oldGrafanaRoute = test.OtherGrafanaRoute()
+				cr = t.NewCryostat()
+				oldCoreRoute = t.OtherCoreRoute()
+				oldGrafanaRoute = t.OtherGrafanaRoute()
 				t.objs = append(t.objs, cr, oldCoreRoute, oldGrafanaRoute)
 			})
 			It("should update the Routes", func() {
@@ -517,31 +519,31 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("Switching from a minimal to a non-minimal deployment", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewMinimalCryostat())
-				t.minimal = true
+				t.Minimal = true
 				t.GeneratedPasswords = []string{"credentials_database", "jmx", "keystore", "grafana"}
+				t.objs = append(t.objs, t.NewCryostat())
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
 
 				cryostat := &operatorv1beta1.Cryostat{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, cryostat)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
-				t.minimal = false
+				t.Minimal = false
 				cryostat.Spec.Minimal = false
 				err = t.Client.Update(context.Background(), cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
-				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: "default"}}
-				t.updateRouteStatus(req, test.NewGrafanaRoute(t.TLS))
+				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
+				t.updateRouteStatus(req, t.NewGrafanaRoute())
 			})
 			It("should create Grafana network resources", func() {
 				t.checkGrafanaService()
 			})
 			It("should create the Grafana secret", func() {
 				t.checkGrafanaSecret()
-				t.checkStatusGrafanaSecretName(test.NewGrafanaSecret().Name)
+				t.checkStatusGrafanaSecretName(t.NewGrafanaSecret().Name)
 			})
 			It("should configure deployment appropriately", func() {
 				t.checkMainDeployment()
@@ -549,36 +551,36 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("Switching from a non-minimal to a minimal deployment", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostat())
+				t.objs = append(t.objs, t.NewCryostat())
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
 
 				cryostat := &operatorv1beta1.Cryostat{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, cryostat)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
-				t.minimal = true
+				t.Minimal = true
 				cryostat.Spec.Minimal = true
 				err = t.Client.Status().Update(context.Background(), cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
-				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: "default"}}
+				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
 				_, err = t.controller.Reconcile(context.Background(), req)
 				Expect(err).ToNot(HaveOccurred())
 			})
 			It("should delete Grafana network resources", func() {
 				service := &corev1.Service{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-grafana", Namespace: "default"}, service)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-grafana", Namespace: t.Namespace}, service)
 				Expect(kerrors.IsNotFound(err)).To(BeTrue())
 
 				route := &openshiftv1.Route{}
-				err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-grafana", Namespace: "default"}, route)
+				err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-grafana", Namespace: t.Namespace}, route)
 				Expect(kerrors.IsNotFound(err)).To(BeTrue())
 			})
 			It("should delete the Grafana secret", func() {
 				secret := &corev1.Secret{}
-				notExpected := test.NewGrafanaSecret()
+				notExpected := t.NewGrafanaSecret()
 				err := t.Client.Get(context.Background(), types.NamespacedName{Name: notExpected.Name, Namespace: notExpected.Namespace}, secret)
 				Expect(kerrors.IsNotFound(err)).To(BeTrue())
 
@@ -591,9 +593,9 @@ var _ = Describe("CryostatController", func() {
 		Context("with report generator service", func() {
 			var cr *operatorv1beta1.Cryostat
 			BeforeEach(func() {
-				cr = test.NewCryostatWithReports()
+				t.ReportReplicas = 1
+				cr = t.NewCryostat()
 				t.objs = append(t.objs, cr)
-				t.reportReplicas = 1
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
@@ -607,12 +609,12 @@ var _ = Describe("CryostatController", func() {
 				It("should configure deployment appropriately", func() {
 					t.checkMainDeployment()
 					t.checkReportsDeployment()
-					t.checkService("cryostat-reports", test.NewReportsService())
+					t.checkService("cryostat-reports", t.NewReportsService())
 				})
 			})
 			Context("with Scheduling options", func() {
 				BeforeEach(func() {
-					*cr = *test.NewCryostatWithReportsScheduling()
+					*cr = *t.NewCryostatWithReportsScheduling()
 				})
 				It("should configure deployment appropriately", func() {
 					t.checkReportsDeployment()
@@ -621,22 +623,22 @@ var _ = Describe("CryostatController", func() {
 			Context("with resource requirements", func() {
 				Context("fully specified", func() {
 					BeforeEach(func() {
-						*cr = *test.NewCryostatWithReportsResources()
+						*cr = *t.NewCryostatWithReportsResources()
 					})
 					It("should configure deployment appropriately", func() {
 						t.checkMainDeployment()
 						t.checkReportsDeployment()
-						t.checkService("cryostat-reports", test.NewReportsService())
+						t.checkService("cryostat-reports", t.NewReportsService())
 					})
 				})
 				Context("with low limits", func() {
 					BeforeEach(func() {
-						*cr = *test.NewCryostatWithReportLowResourceLimit()
+						*cr = *t.NewCryostatWithReportLowResourceLimit()
 					})
 					It("should configure deployment appropriately", func() {
 						t.checkMainDeployment()
 						t.checkReportsDeployment()
-						t.checkService("cryostat-reports", test.NewReportsService())
+						t.checkService("cryostat-reports", t.NewReportsService())
 					})
 				})
 			})
@@ -680,24 +682,23 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("Switching from 0 report sidecars to 1", func() {
 			BeforeEach(func() {
-				cr := test.NewCryostat()
-				t.objs = append(t.objs, cr)
-				t.reportReplicas = 1
+				t.objs = append(t.objs, t.NewCryostat())
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
 
 				cryostat := &operatorv1beta1.Cryostat{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, cryostat)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
+				t.ReportReplicas = 1
 				cryostat.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{
-					Replicas: t.reportReplicas,
+					Replicas: t.ReportReplicas,
 				}
 				err = t.Client.Status().Update(context.Background(), cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
-				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: "default"}}
+				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
 				result, err := t.controller.Reconcile(context.Background(), req)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{}))
@@ -705,31 +706,27 @@ var _ = Describe("CryostatController", func() {
 			It("should configure deployment appropriately", func() {
 				t.checkMainDeployment()
 				t.checkReportsDeployment()
-				t.checkService("cryostat-reports", test.NewReportsService())
+				t.checkService("cryostat-reports", t.NewReportsService())
 			})
 		})
 		Context("Switching from 1 report sidecar to 2", func() {
 			BeforeEach(func() {
-				t.reportReplicas = 1
-				cr := test.NewCryostat()
-				cr.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{
-					Replicas: t.reportReplicas,
-				}
-				t.objs = append(t.objs, cr)
+				t.ReportReplicas = 1
+				t.objs = append(t.objs, t.NewCryostat())
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
 
 				cryostat := &operatorv1beta1.Cryostat{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, cryostat)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
-				t.reportReplicas = 2
-				cryostat.Spec.ReportOptions.Replicas = t.reportReplicas
+				t.ReportReplicas = 2
+				cryostat.Spec.ReportOptions.Replicas = t.ReportReplicas
 				err = t.Client.Status().Update(context.Background(), cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
-				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: "default"}}
+				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
 				result, err := t.controller.Reconcile(context.Background(), req)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{}))
@@ -737,31 +734,27 @@ var _ = Describe("CryostatController", func() {
 			It("should configure deployment appropriately", func() {
 				t.checkMainDeployment()
 				t.checkReportsDeployment()
-				t.checkService("cryostat-reports", test.NewReportsService())
+				t.checkService("cryostat-reports", t.NewReportsService())
 			})
 		})
 		Context("Switching from 2 report sidecars to 1", func() {
 			BeforeEach(func() {
-				t.reportReplicas = 2
-				cr := test.NewCryostat()
-				cr.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{
-					Replicas: t.reportReplicas,
-				}
-				t.objs = append(t.objs, cr)
+				t.ReportReplicas = 2
+				t.objs = append(t.objs, t.NewCryostat())
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
 
 				cryostat := &operatorv1beta1.Cryostat{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, cryostat)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
-				t.reportReplicas = 1
-				cryostat.Spec.ReportOptions.Replicas = t.reportReplicas
+				t.ReportReplicas = 1
+				cryostat.Spec.ReportOptions.Replicas = t.ReportReplicas
 				err = t.Client.Status().Update(context.Background(), cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
-				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: "default"}}
+				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
 				result, err := t.controller.Reconcile(context.Background(), req)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{}))
@@ -769,32 +762,28 @@ var _ = Describe("CryostatController", func() {
 			It("should configure deployment appropriately", func() {
 				t.checkMainDeployment()
 				t.checkReportsDeployment()
-				t.checkService("cryostat-reports", test.NewReportsService())
+				t.checkService("cryostat-reports", t.NewReportsService())
 			})
 		})
 		Context("Switching from 1 report sidecar to 0", func() {
 			BeforeEach(func() {
-				t.reportReplicas = 1
-				cr := test.NewCryostat()
-				cr.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{
-					Replicas: t.reportReplicas,
-				}
-				t.objs = append(t.objs, cr)
+				t.ReportReplicas = 1
+				t.objs = append(t.objs, t.NewCryostat())
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
 				t.makeDeploymentAvailable("cryostat-reports")
 
 				cryostat := &operatorv1beta1.Cryostat{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, cryostat)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
-				t.reportReplicas = 0
-				cryostat.Spec.ReportOptions.Replicas = t.reportReplicas
+				t.ReportReplicas = 0
+				cryostat.Spec.ReportOptions.Replicas = t.ReportReplicas
 				err = t.Client.Status().Update(context.Background(), cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
-				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: "default"}}
+				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
 				result, err := t.controller.Reconcile(context.Background(), req)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{}))
@@ -813,9 +802,9 @@ var _ = Describe("CryostatController", func() {
 		Context("Cryostat CR has list of certificate secrets", func() {
 			var cr *operatorv1beta1.Cryostat
 			BeforeEach(func() {
-				cr = test.NewCryostatWithSecrets()
+				cr = t.NewCryostatWithSecrets()
 				t.objs = append(t.objs, cr,
-					newFakeSecret("testCert1"), newFakeSecret("testCert2"))
+					t.newFakeSecret("testCert1"), t.newFakeSecret("testCert2"))
 			})
 			It("Should add volumes and volumeMounts to deployment", func() {
 				t.expectDeploymentHasCertSecrets()
@@ -833,8 +822,8 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("Adding a certificate to the TrustedCertSecrets list", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostat(), newFakeSecret("testCert1"),
-					newFakeSecret("testCert2"))
+				t.objs = append(t.objs, t.NewCryostat(), t.newFakeSecret("testCert1"),
+					t.newFakeSecret("testCert2"))
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
@@ -842,36 +831,36 @@ var _ = Describe("CryostatController", func() {
 			It("Should update the corresponding deployment", func() {
 				// Get Cryostat CR after reconciling
 				cr := &operatorv1beta1.Cryostat{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, cr)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, cr)
 				Expect(err).ToNot(HaveOccurred())
 
 				// Update it with new TrustedCertSecrets
-				cr.Spec.TrustedCertSecrets = test.NewCryostatWithSecrets().Spec.TrustedCertSecrets
+				cr.Spec.TrustedCertSecrets = t.NewCryostatWithSecrets().Spec.TrustedCertSecrets
 				err = t.Client.Update(context.Background(), cr)
 				Expect(err).ToNot(HaveOccurred())
 
-				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: "default"}}
+				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
 				result, err := t.controller.Reconcile(context.Background(), req)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{}))
 
 				deployment := &appsv1.Deployment{}
-				err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, deployment)
+				err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, deployment)
 				Expect(err).ToNot(HaveOccurred())
 
 				volumes := deployment.Spec.Template.Spec.Volumes
-				expectedVolumes := test.NewVolumesWithSecrets(t.TLS)
+				expectedVolumes := t.NewVolumesWithSecrets()
 				Expect(volumes).To(ConsistOf(expectedVolumes))
 
 				volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-				expectedVolumeMounts := test.NewCoreVolumeMounts(t.TLS)
+				expectedVolumeMounts := t.NewCoreVolumeMounts()
 				Expect(volumeMounts).To(ConsistOf(expectedVolumeMounts))
 			})
 		})
 		Context("Cryostat CR has list of event templates", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatWithTemplates(), test.NewTemplateConfigMap(),
-					test.NewOtherTemplateConfigMap())
+				t.objs = append(t.objs, t.NewCryostatWithTemplates(), t.NewTemplateConfigMap(),
+					t.NewOtherTemplateConfigMap())
 			})
 			It("Should add volumes and volumeMounts to deployment", func() {
 				t.reconcileCryostatFully()
@@ -880,12 +869,12 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("Cryostat CR has list of event templates with TLS disabled", func() {
 			BeforeEach(func() {
-				certManager := false
-				cr := test.NewCryostatWithTemplates()
-				cr.Spec.EnableCertManager = &certManager
-				t.objs = append(t.objs, cr, test.NewTemplateConfigMap(),
-					test.NewOtherTemplateConfigMap())
 				t.TLS = false
+				cr := t.NewCryostatWithTemplates()
+				certManager := false
+				cr.Spec.EnableCertManager = &certManager
+				t.objs = append(t.objs, cr, t.NewTemplateConfigMap(),
+					t.NewOtherTemplateConfigMap())
 			})
 			It("Should add volumes and volumeMounts to deployment", func() {
 				t.reconcileCryostatFully()
@@ -894,8 +883,8 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("Adding a template to the EventTemplates list", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostat(), test.NewTemplateConfigMap(),
-					test.NewOtherTemplateConfigMap())
+				t.objs = append(t.objs, t.NewCryostat(), t.NewTemplateConfigMap(),
+					t.NewOtherTemplateConfigMap())
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
@@ -903,15 +892,15 @@ var _ = Describe("CryostatController", func() {
 			It("Should update the corresponding deployment", func() {
 				// Get Cryostat CR after reconciling
 				cr := &operatorv1beta1.Cryostat{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, cr)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, cr)
 				Expect(err).ToNot(HaveOccurred())
 
 				// Update it with new EventTemplates
-				cr.Spec.EventTemplates = test.NewCryostatWithTemplates().Spec.EventTemplates
+				cr.Spec.EventTemplates = t.NewCryostatWithTemplates().Spec.EventTemplates
 				err = t.Client.Update(context.Background(), cr)
 				Expect(err).ToNot(HaveOccurred())
 
-				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: "default"}}
+				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
 				result, err := t.controller.Reconcile(context.Background(), req)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{}))
@@ -921,33 +910,33 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("with custom PVC spec overriding all defaults", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatWithPVCSpec())
+				t.objs = append(t.objs, t.NewCryostatWithPVCSpec())
 			})
 			It("should create the PVC with requested spec", func() {
-				t.expectPVC(test.NewCustomPVC())
+				t.expectPVC(t.NewCustomPVC())
 			})
 		})
 		Context("with custom PVC spec overriding some defaults", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatWithPVCSpecSomeDefault())
+				t.objs = append(t.objs, t.NewCryostatWithPVCSpecSomeDefault())
 			})
 			It("should create the PVC with requested spec", func() {
-				t.expectPVC(test.NewCustomPVCSomeDefault())
+				t.expectPVC(t.NewCustomPVCSomeDefault())
 			})
 		})
 		Context("with custom PVC config with no spec", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatWithPVCLabelsOnly())
+				t.objs = append(t.objs, t.NewCryostatWithPVCLabelsOnly())
 			})
 			It("should create the PVC with requested label", func() {
-				t.expectPVC(test.NewDefaultPVCWithLabel())
+				t.expectPVC(t.NewDefaultPVCWithLabel())
 			})
 		})
 		Context("with an existing PVC", func() {
 			var oldPVC *corev1.PersistentVolumeClaim
 			BeforeEach(func() {
-				oldPVC = test.NewDefaultPVC()
-				t.objs = append(t.objs, test.NewCryostatWithPVCSpec(), oldPVC)
+				oldPVC = t.NewDefaultPVC()
+				t.objs = append(t.objs, t.NewCryostatWithPVCSpec(), oldPVC)
 			})
 			Context("that successfully updates", func() {
 				BeforeEach(func() {
@@ -961,7 +950,7 @@ var _ = Describe("CryostatController", func() {
 					t.reconcileCryostatFully()
 				})
 				It("should update metadata and resource requests", func() {
-					expected := test.NewDefaultPVC()
+					expected := t.NewDefaultPVC()
 					metav1.SetMetaDataLabel(&expected.ObjectMeta, "my", "label")
 					metav1.SetMetaDataLabel(&expected.ObjectMeta, "another", "label")
 					metav1.SetMetaDataLabel(&expected.ObjectMeta, "app", "cryostat")
@@ -981,7 +970,7 @@ var _ = Describe("CryostatController", func() {
 					t.controller.Client = t.Client
 
 					// Expect an Invalid status error after reconciling
-					req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: "default"}}
+					req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
 					_, err := t.controller.Reconcile(context.Background(), req)
 					Expect(err).To(HaveOccurred())
 					Expect(kerrors.IsInvalid(err)).To(BeTrue())
@@ -996,10 +985,10 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("with custom EmptyDir config", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatWithDefaultEmptyDir())
+				t.objs = append(t.objs, t.NewCryostatWithDefaultEmptyDir())
 			})
 			It("should create the EmptyDir with default specs", func() {
-				t.expectEmptyDir(test.NewDefaultEmptyDir())
+				t.expectEmptyDir(t.NewDefaultEmptyDir())
 			})
 			It("should set Cryostat database to h2:mem", func() {
 				t.expectInMemoryDatabase()
@@ -1007,10 +996,10 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("with custom EmptyDir config with requested spec", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatWithEmptyDirSpec())
+				t.objs = append(t.objs, t.NewCryostatWithEmptyDirSpec())
 			})
 			It("should create the EmptyDir with requested specs", func() {
-				t.expectEmptyDir(test.NewEmptyDirWithSpec())
+				t.expectEmptyDir(t.NewEmptyDirWithSpec())
 			})
 			It("should set Cryostat database to h2:file", func() {
 				t.expectInMemoryDatabase()
@@ -1019,16 +1008,16 @@ var _ = Describe("CryostatController", func() {
 		Context("with overriden image tags", func() {
 			var mainDeploy, reportsDeploy *appsv1.Deployment
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatWithReportsSvc())
-				t.reportReplicas = 1
-				mainDeploy = &appsv1.Deployment{}
-				reportsDeploy = &appsv1.Deployment{}
+				t.ReportReplicas = 1
+				t.objs = append(t.objs, t.NewCryostatWithReportsSvc())
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, mainDeploy)
+				mainDeploy = &appsv1.Deployment{}
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, mainDeploy)
 				Expect(err).ToNot(HaveOccurred())
-				err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-reports", Namespace: "default"}, reportsDeploy)
+				reportsDeploy = &appsv1.Deployment{}
+				err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-reports", Namespace: t.Namespace}, reportsDeploy)
 				Expect(err).ToNot(HaveOccurred())
 			})
 			Context("for development", func() {
@@ -1138,7 +1127,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("when deleted", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostat())
+				t.objs = append(t.objs, t.NewCryostat())
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
@@ -1156,7 +1145,7 @@ var _ = Describe("CryostatController", func() {
 			})
 			Context("ClusterRoleBinding does not exist", func() {
 				JustBeforeEach(func() {
-					err := t.Client.Delete(context.Background(), test.NewClusterRoleBinding())
+					err := t.Client.Delete(context.Background(), t.NewClusterRoleBinding())
 					Expect(err).ToNot(HaveOccurred())
 					t.reconcileDeletedCryostat()
 				})
@@ -1167,14 +1156,14 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("on OpenShift", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostat())
+				t.objs = append(t.objs, t.NewCryostat())
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
 			})
 			It("should create ConsoleLink", func() {
 				link := &consolev1.ConsoleLink{}
-				expectedLink := test.NewConsoleLink()
+				expectedLink := t.NewConsoleLink()
 				err := t.Client.Get(context.Background(), types.NamespacedName{Name: expectedLink.Name}, link)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(link.Spec).To(Equal(expectedLink.Spec))
@@ -1182,12 +1171,12 @@ var _ = Describe("CryostatController", func() {
 			Context("with an existing ConsoleLink", func() {
 				var oldLink *consolev1.ConsoleLink
 				BeforeEach(func() {
-					oldLink = test.OtherConsoleLink()
+					oldLink = t.OtherConsoleLink()
 					t.objs = append(t.objs, oldLink)
 				})
 				It("should update the ConsoleLink", func() {
 					link := &consolev1.ConsoleLink{}
-					expectedLink := test.NewConsoleLink()
+					expectedLink := t.NewConsoleLink()
 					err := t.Client.Get(context.Background(), types.NamespacedName{Name: expectedLink.Name}, link)
 					Expect(err).ToNot(HaveOccurred())
 					// Existing labels and annotations should remain
@@ -1212,12 +1201,12 @@ var _ = Describe("CryostatController", func() {
 			Context("with restricted SCC", func() {
 				BeforeEach(func() {
 					t.objs = []runtime.Object{
-						test.NewCryostat(), test.NewNamespaceWithSCCSupGroups(), test.NewApiServer(),
+						t.NewCryostat(), t.NewNamespaceWithSCCSupGroups(), t.NewApiServer(),
 					}
 				})
 				It("should set fsGroup to value derived from namespace", func() {
 					deploy := &appsv1.Deployment{}
-					err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, deploy)
+					err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, deploy)
 					Expect(err).ToNot(HaveOccurred())
 					sc := deploy.Spec.Template.Spec.SecurityContext
 					Expect(sc).ToNot(BeNil())
@@ -1232,7 +1221,7 @@ var _ = Describe("CryostatController", func() {
 					})
 					It("should delete the ConsoleLink", func() {
 						link := &consolev1.ConsoleLink{}
-						expectedLink := test.NewConsoleLink()
+						expectedLink := t.NewConsoleLink()
 						err := t.Client.Get(context.Background(), types.NamespacedName{Name: expectedLink.Name}, link)
 						Expect(kerrors.IsNotFound(err)).To(BeTrue())
 					})
@@ -1249,7 +1238,7 @@ var _ = Describe("CryostatController", func() {
 				})
 				Context("ConsoleLink does not exist", func() {
 					JustBeforeEach(func() {
-						err := t.Client.Delete(context.Background(), test.NewConsoleLink())
+						err := t.Client.Delete(context.Background(), t.NewConsoleLink())
 						Expect(err).ToNot(HaveOccurred())
 						t.reconcileDeletedCryostat()
 					})
@@ -1261,8 +1250,8 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("with cert-manager disabled in CR", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatCertManagerDisabled())
 				t.TLS = false
+				t.objs = append(t.objs, t.NewCryostatCertManagerDisabled())
 			})
 			It("should create deployment and set owner", func() {
 				t.expectDeployment()
@@ -1270,7 +1259,7 @@ var _ = Describe("CryostatController", func() {
 			It("should not create certificates", func() {
 				certs := &certv1.CertificateList{}
 				t.Client.List(context.Background(), certs, &ctrlclient.ListOptions{
-					Namespace: "default",
+					Namespace: t.Namespace,
 				})
 				Expect(certs.Items).To(BeEmpty())
 			})
@@ -1280,7 +1269,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("with cert-manager not configured in CR", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatCertManagerUndefined())
+				t.objs = append(t.objs, t.NewCryostatCertManagerUndefined())
 			})
 			It("should create deployment and set owner", func() {
 				t.expectDeployment()
@@ -1299,10 +1288,10 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("with DISABLE_SERVICE_TLS=true", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatCertManagerUndefined())
 				disableTLS := true
 				t.EnvDisableTLS = &disableTLS
 				t.TLS = false
+				t.objs = append(t.objs, t.NewCryostatCertManagerUndefined())
 			})
 			It("should create deployment and set owner", func() {
 				t.expectDeployment()
@@ -1310,7 +1299,7 @@ var _ = Describe("CryostatController", func() {
 			It("should not create certificates", func() {
 				certs := &certv1.CertificateList{}
 				t.Client.List(context.Background(), certs, &ctrlclient.ListOptions{
-					Namespace: "default",
+					Namespace: t.Namespace,
 				})
 				Expect(certs.Items).To(BeEmpty())
 			})
@@ -1325,13 +1314,13 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("Disable cert-manager after being enabled", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostat())
+				t.objs = append(t.objs, t.NewCryostat())
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
 
 				cryostat := &operatorv1beta1.Cryostat{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, cryostat)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
 				t.TLS = false
@@ -1340,7 +1329,7 @@ var _ = Describe("CryostatController", func() {
 				err = t.Client.Status().Update(context.Background(), cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
-				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: "default"}}
+				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
 				_, err = t.controller.Reconcile(context.Background(), req)
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -1357,14 +1346,14 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("Enable cert-manager after being disabled", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatCertManagerDisabled())
 				t.TLS = false
+				t.objs = append(t.objs, t.NewCryostatCertManagerDisabled())
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
 
 				cryostat := &operatorv1beta1.Cryostat{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, cryostat)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
 				t.TLS = true
@@ -1373,7 +1362,7 @@ var _ = Describe("CryostatController", func() {
 				err = t.Client.Status().Update(context.Background(), cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
-				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: "default"}}
+				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
 				_, err = t.controller.Reconcile(context.Background(), req)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1404,10 +1393,10 @@ var _ = Describe("CryostatController", func() {
 			})
 			Context("and enabled", func() {
 				BeforeEach(func() {
-					t.objs = append(t.objs, test.NewCryostat())
+					t.objs = append(t.objs, t.NewCryostat())
 				})
 				JustBeforeEach(func() {
-					req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: "default"}}
+					req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
 					_, err := t.controller.Reconcile(context.Background(), req)
 					Expect(err).To(HaveOccurred())
 				})
@@ -1424,11 +1413,11 @@ var _ = Describe("CryostatController", func() {
 			})
 			Context("and disabled", func() {
 				BeforeEach(func() {
-					t.objs = append(t.objs, test.NewCryostatCertManagerDisabled())
 					t.TLS = false
+					t.objs = append(t.objs, t.NewCryostatCertManagerDisabled())
 				})
 				JustBeforeEach(func() {
-					req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: "default"}}
+					req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
 					_, err := t.controller.Reconcile(context.Background(), req)
 					Expect(err).ToNot(HaveOccurred())
 				})
@@ -1448,33 +1437,33 @@ var _ = Describe("CryostatController", func() {
 			})
 			Context("containing core config", func() {
 				BeforeEach(func() {
-					t.objs = append(t.objs, test.NewCryostatWithCoreSvc())
+					t.objs = append(t.objs, t.NewCryostatWithCoreSvc())
 				})
 				It("should created the service as described", func() {
-					t.checkService("cryostat", test.NewCustomizedCoreService())
+					t.checkService("cryostat", t.NewCustomizedCoreService())
 				})
 			})
 			Context("containing grafana config", func() {
 				BeforeEach(func() {
-					t.objs = append(t.objs, test.NewCryostatWithGrafanaSvc())
+					t.objs = append(t.objs, t.NewCryostatWithGrafanaSvc())
 				})
 				It("should created the service as described", func() {
-					t.checkService("cryostat-grafana", test.NewCustomizedGrafanaService())
+					t.checkService("cryostat-grafana", t.NewCustomizedGrafanaService())
 				})
 			})
 			Context("containing reports config", func() {
 				BeforeEach(func() {
-					t.objs = append(t.objs, test.NewCryostatWithReportsSvc())
-					t.reportReplicas = 1
+					t.ReportReplicas = 1
+					t.objs = append(t.objs, t.NewCryostatWithReportsSvc())
 				})
 				It("should created the service as described", func() {
-					t.checkService("cryostat-reports", test.NewCustomizedReportsService())
+					t.checkService("cryostat-reports", t.NewCustomizedReportsService())
 				})
 			})
 			Context("and existing services", func() {
 				var cr *operatorv1beta1.Cryostat
 				BeforeEach(func() {
-					t.objs = append(t.objs, test.NewCryostat())
+					t.objs = append(t.objs, t.NewCryostat())
 				})
 				JustBeforeEach(func() {
 					// Fetch the current Cryostat CR
@@ -1495,27 +1484,27 @@ var _ = Describe("CryostatController", func() {
 				})
 				Context("containing core config", func() {
 					BeforeEach(func() {
-						cr = test.NewCryostatWithCoreSvc()
+						cr = t.NewCryostatWithCoreSvc()
 					})
 					It("should created the service as described", func() {
-						t.checkService("cryostat", test.NewCustomizedCoreService())
+						t.checkService("cryostat", t.NewCustomizedCoreService())
 					})
 				})
 				Context("containing grafana config", func() {
 					BeforeEach(func() {
-						cr = test.NewCryostatWithGrafanaSvc()
+						cr = t.NewCryostatWithGrafanaSvc()
 					})
 					It("should created the service as described", func() {
-						t.checkService("cryostat-grafana", test.NewCustomizedGrafanaService())
+						t.checkService("cryostat-grafana", t.NewCustomizedGrafanaService())
 					})
 				})
 				Context("containing reports config", func() {
 					BeforeEach(func() {
-						cr = test.NewCryostatWithReportsSvc()
-						t.reportReplicas = 1
+						t.ReportReplicas = 1
+						cr = t.NewCryostatWithReportsSvc()
 					})
 					It("should created the service as described", func() {
-						t.checkService("cryostat-reports", test.NewCustomizedReportsService())
+						t.checkService("cryostat-reports", t.NewCustomizedReportsService())
 					})
 				})
 			})
@@ -1526,33 +1515,33 @@ var _ = Describe("CryostatController", func() {
 			})
 			Context("containing MaxWsConnections", func() {
 				BeforeEach(func() {
-					t.objs = append(t.objs, test.NewCryostatWithWsConnectionsSpec())
+					t.objs = append(t.objs, t.NewCryostatWithWsConnectionsSpec())
 				})
 				It("should set max WebSocket connections", func() {
-					t.checkCoreHasEnvironmentVariables(test.NewWsConnectionsEnv())
+					t.checkCoreHasEnvironmentVariables(t.NewWsConnectionsEnv())
 				})
 			})
 			Context("containing SubProcessMaxHeapSize", func() {
 				BeforeEach(func() {
-					t.objs = append(t.objs, test.NewCryostatWithReportSubprocessHeapSpec())
+					t.objs = append(t.objs, t.NewCryostatWithReportSubprocessHeapSpec())
 				})
 				It("should set report subprocess max heap size", func() {
-					t.checkCoreHasEnvironmentVariables(test.NewReportSubprocessHeapEnv())
+					t.checkCoreHasEnvironmentVariables(t.NewReportSubprocessHeapEnv())
 				})
 			})
 			Context("containing JmxCacheOptions", func() {
 				BeforeEach(func() {
-					t.objs = append(t.objs, test.NewCryostatWithJmxCacheOptionsSpec())
+					t.objs = append(t.objs, t.NewCryostatWithJmxCacheOptionsSpec())
 				})
 				It("should set JMX cache options", func() {
-					t.checkCoreHasEnvironmentVariables(test.NewJmxCacheOptionsEnv())
+					t.checkCoreHasEnvironmentVariables(t.NewJmxCacheOptionsEnv())
 				})
 			})
 		})
 		Context("with resource requirements", func() {
 			Context("fully specified", func() {
 				BeforeEach(func() {
-					t.objs = append(t.objs, test.NewCryostatWithResources())
+					t.objs = append(t.objs, t.NewCryostatWithResources())
 				})
 				It("should create expected deployment", func() {
 					t.expectDeployment()
@@ -1560,7 +1549,7 @@ var _ = Describe("CryostatController", func() {
 			})
 			Context("with low limits", func() {
 				BeforeEach(func() {
-					t.objs = append(t.objs, test.NewCryostatWithLowResourceLimit())
+					t.objs = append(t.objs, t.NewCryostatWithLowResourceLimit())
 				})
 				It("should create expected deployment", func() {
 					t.expectDeployment()
@@ -1573,24 +1562,24 @@ var _ = Describe("CryostatController", func() {
 			})
 			Context("containing core config", func() {
 				BeforeEach(func() {
-					t.objs = append(t.objs, test.NewCryostatWithCoreNetworkOptions())
+					t.objs = append(t.objs, t.NewCryostatWithCoreNetworkOptions())
 				})
 				It("should create the route as described", func() {
-					t.checkRoute(test.NewCustomCoreRoute(t.TLS))
+					t.checkRoute(t.NewCustomCoreRoute())
 				})
 			})
 			Context("containing grafana config", func() {
 				BeforeEach(func() {
-					t.objs = append(t.objs, test.NewCryostatWithGrafanaNetworkOptions())
+					t.objs = append(t.objs, t.NewCryostatWithGrafanaNetworkOptions())
 				})
 				It("should create the route as described", func() {
-					t.checkRoute(test.NewCustomGrafanaRoute(t.TLS))
+					t.checkRoute(t.NewCustomGrafanaRoute())
 				})
 			})
 		})
 		Context("Cryostat CR has authorization properties", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatWithAuthProperties(), test.NewAuthPropertiesConfigMap(), test.NewAuthClusterRole())
+				t.objs = append(t.objs, t.NewCryostatWithAuthProperties(), t.NewAuthPropertiesConfigMap(), t.NewAuthClusterRole())
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
@@ -1605,7 +1594,7 @@ var _ = Describe("CryostatController", func() {
 			})
 			Context("containing Cryostat security options", func() {
 				BeforeEach(func() {
-					t.objs = append(t.objs, test.NewCryostatWithSecurityOptions())
+					t.objs = append(t.objs, t.NewCryostatWithSecurityOptions())
 				})
 				It("should add security context as described", func() {
 					t.checkMainDeployment()
@@ -1614,7 +1603,7 @@ var _ = Describe("CryostatController", func() {
 			Context("containing Report security options", func() {
 				Context("with 0 report replica", func() {
 					BeforeEach(func() {
-						t.objs = append(t.objs, test.NewCryostatWithReportSecurityOptions())
+						t.objs = append(t.objs, t.NewCryostatWithReportSecurityOptions())
 					})
 					It("should add security context as described", func() {
 						t.expectNoReportsDeployment()
@@ -1622,9 +1611,8 @@ var _ = Describe("CryostatController", func() {
 				})
 				Context("with 1 report replicas", func() {
 					BeforeEach(func() {
-						t.reportReplicas = 1
-						cr := test.NewCryostatWithReportSecurityOptions()
-						cr.Spec.ReportOptions.Replicas = t.reportReplicas
+						t.ReportReplicas = 1
+						cr := t.NewCryostatWithReportSecurityOptions()
 						t.objs = append(t.objs, cr)
 					})
 					It("should add security context as described", func() {
@@ -1636,7 +1624,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("with Scheduling options", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatWithScheduling())
+				t.objs = append(t.objs, t.NewCryostatWithScheduling())
 			})
 			It("should configure deployment appropriately", func() {
 				t.expectDeployment()
@@ -1645,7 +1633,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("with built-in target discovery mechanism disabled", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatWithBuiltInDiscoveryDisabled())
+				t.objs = append(t.objs, t.NewCryostatWithBuiltInDiscoveryDisabled())
 			})
 			It("should configure deployment appropriately", func() {
 				t.expectDeployment()
@@ -1653,7 +1641,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("with secret provided for database password", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatWithDatabaseSecretProvided())
+				t.objs = append(t.objs, t.NewCryostatWithDatabaseSecretProvided())
 			})
 			It("should configure deployment appropriately", func() {
 				t.expectDeployment()
@@ -1662,18 +1650,18 @@ var _ = Describe("CryostatController", func() {
 				t.reconcileCryostatFully()
 
 				secret := &corev1.Secret{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-jmx-credentials-db", Namespace: "default"}, secret)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-jmx-credentials-db", Namespace: t.Namespace}, secret)
 				Expect(kerrors.IsNotFound(err)).To(BeTrue())
 			})
 			Context("with an existing Credentials Database Secret", func() {
 				BeforeEach(func() {
-					t.objs = append(t.objs, test.NewCredentialsDatabaseSecret())
+					t.objs = append(t.objs, t.NewCredentialsDatabaseSecret())
 				})
 				It("should not delete the existing Credentials Database Secret", func() {
 					t.reconcileCryostatFully()
 
 					secret := &corev1.Secret{}
-					err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-jmx-credentials-db", Namespace: "default"}, secret)
+					err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-jmx-credentials-db", Namespace: t.Namespace}, secret)
 					Expect(err).ToNot(HaveOccurred())
 				})
 			})
@@ -1681,12 +1669,12 @@ var _ = Describe("CryostatController", func() {
 	})
 
 	Describe("reconciling a request in Kubernetes", func() {
-		JustBeforeEach(func() {
-			t.controller.IsOpenShift = false
+		BeforeEach(func() {
+			t.OpenShift = false
 		})
 		Context("with TLS ingress", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatWithIngress())
+				t.objs = append(t.objs, t.NewCryostatWithIngress())
 			})
 			It("should create ingresses", func() {
 				t.expectIngresses()
@@ -1704,8 +1692,8 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("with non-TLS ingress", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatWithIngressNoTLS())
-				t.externalTLS = false
+				t.ExternalTLS = false
+				t.objs = append(t.objs, t.NewCryostatWithIngress())
 			})
 			It("should create ingresses", func() {
 				t.expectIngresses()
@@ -1723,7 +1711,7 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("no ingress configuration is provided", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostat())
+				t.objs = append(t.objs, t.NewCryostat())
 			})
 			It("should not create ingresses or routes", func() {
 				t.reconcileCryostatFully()
@@ -1736,9 +1724,9 @@ var _ = Describe("CryostatController", func() {
 			var oldCoreIngress *netv1.Ingress
 			var oldGrafanaIngress *netv1.Ingress
 			BeforeEach(func() {
-				cr = test.NewCryostatWithIngress()
-				oldCoreIngress = test.OtherCoreIngress()
-				oldGrafanaIngress = test.OtherGrafanaIngress()
+				cr = t.NewCryostatWithIngress()
+				oldCoreIngress = t.OtherCoreIngress()
+				oldGrafanaIngress = t.OtherGrafanaIngress()
 				t.objs = append(t.objs, cr, oldCoreIngress, oldGrafanaIngress)
 			})
 			It("should update the Ingresses", func() {
@@ -1746,27 +1734,29 @@ var _ = Describe("CryostatController", func() {
 			})
 		})
 		Context("networkConfig for one of the services is nil", func() {
+			var cr *operatorv1beta1.Cryostat
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatWithIngress())
+				cr = t.NewCryostatWithIngress()
+				t.objs = append(t.objs, cr)
 			})
 			It("should only create specified ingresses", func() {
 				c := &operatorv1beta1.Cryostat{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, c)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, c)
 				Expect(err).ToNot(HaveOccurred())
 				err = t.Client.Update(context.Background(), c)
 				Expect(err).ToNot(HaveOccurred())
 
 				t.reconcileCryostatFully()
-				expectedConfig := test.NewNetworkConfigurationList(t.externalTLS)
+				expectedConfig := cr.Spec.NetworkOptions
 
 				ingress := &netv1.Ingress{}
-				err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, ingress)
+				err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, ingress)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ingress.Annotations).To(Equal(expectedConfig.CoreConfig.Annotations))
 				Expect(ingress.Labels).To(Equal(expectedConfig.CoreConfig.Labels))
 				Expect(ingress.Spec).To(Equal(*expectedConfig.CoreConfig.IngressSpec))
 
-				err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-grafana", Namespace: "default"}, ingress)
+				err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-grafana", Namespace: t.Namespace}, ingress)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ingress.Annotations).To(Equal(expectedConfig.GrafanaConfig.Annotations))
 				Expect(ingress.Labels).To(Equal(expectedConfig.GrafanaConfig.Labels))
@@ -1775,34 +1765,36 @@ var _ = Describe("CryostatController", func() {
 			})
 		})
 		Context("ingressSpec for one of the services is nil", func() {
+			var cr *operatorv1beta1.Cryostat
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatWithIngress())
+				cr = t.NewCryostatWithIngress()
+				t.objs = append(t.objs, cr)
 			})
 			It("should only create specified ingresses", func() {
 				c := &operatorv1beta1.Cryostat{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, c)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, c)
 				Expect(err).ToNot(HaveOccurred())
 				c.Spec.NetworkOptions.CoreConfig.IngressSpec = nil
 				err = t.Client.Update(context.Background(), c)
 				Expect(err).ToNot(HaveOccurred())
 
 				t.reconcileCryostatFully()
-				expectedConfig := test.NewNetworkConfigurationList(t.externalTLS)
+				expectedConfig := cr.Spec.NetworkOptions
 
 				ingress := &netv1.Ingress{}
-				err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-grafana", Namespace: "default"}, ingress)
+				err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-grafana", Namespace: t.Namespace}, ingress)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ingress.Annotations).To(Equal(expectedConfig.GrafanaConfig.Annotations))
 				Expect(ingress.Labels).To(Equal(expectedConfig.GrafanaConfig.Labels))
 				Expect(ingress.Spec).To(Equal(*expectedConfig.GrafanaConfig.IngressSpec))
 
-				err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, ingress)
+				err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, ingress)
 				Expect(kerrors.IsNotFound(err)).To(BeTrue())
 			})
 		})
 		Context("Cryostat CR has authorization properties", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, test.NewCryostatWithAuthProperties(), test.NewAuthPropertiesConfigMap(), test.NewAuthClusterRole())
+				t.objs = append(t.objs, t.NewCryostatWithAuthProperties(), t.NewAuthPropertiesConfigMap(), t.NewAuthClusterRole())
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
@@ -1813,12 +1805,9 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("with report generator service", func() {
 			BeforeEach(func() {
-				cr := test.NewCryostatWithIngress()
-				cr.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{
-					Replicas: 1,
-				}
+				t.ReportReplicas = 1
+				cr := t.NewCryostatWithIngress()
 				t.objs = append(t.objs, cr)
-				t.reportReplicas = 1
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
@@ -1828,7 +1817,7 @@ var _ = Describe("CryostatController", func() {
 				t.checkReportsDeployment()
 			})
 			It("should create the reports service", func() {
-				t.checkService("cryostat-reports", test.NewReportsService())
+				t.checkService("cryostat-reports", t.NewReportsService())
 			})
 		})
 		Context("with security options", func() {
@@ -1837,7 +1826,7 @@ var _ = Describe("CryostatController", func() {
 			})
 			Context("containing Cryostat security options", func() {
 				BeforeEach(func() {
-					t.objs = append(t.objs, test.NewCryostatWithSecurityOptions())
+					t.objs = append(t.objs, t.NewCryostatWithSecurityOptions())
 				})
 				It("should add security context as described", func() {
 					t.checkMainDeployment()
@@ -1846,7 +1835,7 @@ var _ = Describe("CryostatController", func() {
 			Context("containing Report security options", func() {
 				Context("with 0 report replica", func() {
 					BeforeEach(func() {
-						t.objs = append(t.objs, test.NewCryostatWithReportSecurityOptions())
+						t.objs = append(t.objs, t.NewCryostatWithReportSecurityOptions())
 					})
 					It("should add security context as described", func() {
 						t.expectNoReportsDeployment()
@@ -1854,10 +1843,8 @@ var _ = Describe("CryostatController", func() {
 				})
 				Context("with 1 report replicas", func() {
 					BeforeEach(func() {
-						t.reportReplicas = 1
-						cr := test.NewCryostatWithReportSecurityOptions()
-						cr.Spec.ReportOptions.Replicas = t.reportReplicas
-						t.objs = append(t.objs, cr)
+						t.ReportReplicas = 1
+						t.objs = append(t.objs, t.NewCryostatWithReportSecurityOptions())
 					})
 					It("should add security context as described", func() {
 						t.checkReportsDeployment()
@@ -1870,15 +1857,15 @@ var _ = Describe("CryostatController", func() {
 			var cr *operatorv1beta1.Cryostat
 			var oldSA *corev1.ServiceAccount
 			BeforeEach(func() {
-				cr = test.NewCryostat()
-				oldSA = test.OtherServiceAccount()
+				cr = t.NewCryostat()
+				oldSA = t.OtherServiceAccount()
 				t.objs = append(t.objs, cr, oldSA)
 			})
 			It("should update the Service Account", func() {
 				t.reconcileCryostatFully()
 
 				sa := &corev1.ServiceAccount{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, sa)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, sa)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(sa.Annotations).To(Equal(map[string]string{
@@ -1901,15 +1888,15 @@ var _ = Describe("CryostatController", func() {
 			var cr *operatorv1beta1.Cryostat
 			var oldRole *rbacv1.Role
 			BeforeEach(func() {
-				cr = test.NewCryostat()
-				oldRole = test.OtherRole()
+				cr = t.NewCryostat()
+				oldRole = t.OtherRole()
 				t.objs = append(t.objs, cr, oldRole)
 			})
 			It("should update the Role", func() {
 				t.reconcileCryostatFully()
 
 				role := &rbacv1.Role{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, role)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, role)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(metav1.IsControlledBy(role, cr)).To(BeTrue())
@@ -1919,22 +1906,22 @@ var _ = Describe("CryostatController", func() {
 				Expect(role.Annotations).To(Equal(oldRole.Annotations))
 
 				// Rules should be fully replaced
-				Expect(role.Rules).To(Equal(test.NewRole().Rules))
+				Expect(role.Rules).To(Equal(t.NewRole().Rules))
 			})
 		})
 		Context("with an existing Role Binding", func() {
 			var cr *operatorv1beta1.Cryostat
 			var oldBinding *rbacv1.RoleBinding
 			BeforeEach(func() {
-				cr = test.NewCryostat()
-				oldBinding = test.OtherRoleBinding()
+				cr = t.NewCryostat()
+				oldBinding = t.OtherRoleBinding()
 				t.objs = append(t.objs, cr, oldBinding)
 			})
 			It("should update the Role Binding", func() {
 				t.reconcileCryostatFully()
 
 				binding := &rbacv1.RoleBinding{}
-				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, binding)
+				err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, binding)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(metav1.IsControlledBy(binding, cr)).To(BeTrue())
@@ -1944,7 +1931,7 @@ var _ = Describe("CryostatController", func() {
 				Expect(binding.Annotations).To(Equal(oldBinding.Annotations))
 
 				// Subjects and RoleRef should be fully replaced
-				expected := test.NewRoleBinding()
+				expected := t.NewRoleBinding()
 				Expect(binding.Subjects).To(Equal(expected.Subjects))
 				Expect(binding.RoleRef).To(Equal(expected.RoleRef))
 			})
@@ -1953,8 +1940,8 @@ var _ = Describe("CryostatController", func() {
 			var cr *operatorv1beta1.Cryostat
 			var oldBinding *rbacv1.ClusterRoleBinding
 			BeforeEach(func() {
-				cr = test.NewCryostat()
-				oldBinding = test.OtherClusterRoleBinding()
+				cr = t.NewCryostat()
+				oldBinding = t.OtherClusterRoleBinding()
 				t.objs = append(t.objs, cr, oldBinding)
 			})
 			It("should update the Cluster Role Binding", func() {
@@ -1962,7 +1949,7 @@ var _ = Describe("CryostatController", func() {
 
 				binding := &rbacv1.ClusterRoleBinding{}
 				err := t.Client.Get(context.Background(), types.NamespacedName{
-					Name: "cryostat-9ecd5050500c2566765bc593edfcce12434283e5da32a27476bc4a1569304a02",
+					Name: "cryostat-ffc3f6d167f69f78c5882a8f67be7efcc7f2f9062145a98f99f7863922c52b10",
 				}, binding)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1971,7 +1958,7 @@ var _ = Describe("CryostatController", func() {
 				Expect(binding.Annotations).To(Equal(oldBinding.Annotations))
 
 				// Subjects and RoleRef should be fully replaced
-				expected := test.NewClusterRoleBinding()
+				expected := t.NewClusterRoleBinding()
 				Expect(binding.Subjects).To(Equal(expected.Subjects))
 				Expect(binding.RoleRef).To(Equal(expected.RoleRef))
 			})
@@ -1979,11 +1966,11 @@ var _ = Describe("CryostatController", func() {
 	})
 })
 
-func newFakeSecret(name string) *corev1.Secret {
+func (t *cryostatTestInput) newFakeSecret(name string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: "default",
+			Namespace: t.Namespace,
 		},
 		Data: map[string][]byte{
 			corev1.TLSCertKey: []byte(name + "-bytes"),
@@ -1995,7 +1982,7 @@ func (t *cryostatTestInput) makeCertificatesReady() {
 	certNames := []string{"cryostat", "cryostat-ca", "cryostat-grafana", "cryostat-reports"}
 	for _, certName := range certNames {
 		cert := &certv1.Certificate{}
-		err := t.Client.Get(context.Background(), types.NamespacedName{Name: certName, Namespace: "default"}, cert)
+		err := t.Client.Get(context.Background(), types.NamespacedName{Name: certName, Namespace: t.Namespace}, cert)
 		Expect(err).ToNot(HaveOccurred())
 		cert.Status.Conditions = append(cert.Status.Conditions, certv1.CertificateCondition{
 			Type:   certv1.CertificateConditionReady,
@@ -2010,7 +1997,7 @@ func (t *cryostatTestInput) initializeSecrets() {
 	// Create secrets
 	secretNames := []string{"cryostat-ca", "cryostat-tls", "cryostat-grafana-tls", "cryostat-reports-tls"}
 	for _, secretName := range secretNames {
-		secret := newFakeSecret(secretName)
+		secret := t.newFakeSecret(secretName)
 		err := t.Client.Create(context.Background(), secret)
 		Expect(err).ToNot(HaveOccurred())
 	}
@@ -2037,10 +2024,10 @@ func (t *cryostatTestInput) updateRouteStatus(req reconcile.Request,
 }
 
 func (t *cryostatTestInput) checkRoutes() {
-	if !t.minimal {
-		t.checkRoute(test.NewGrafanaRoute(t.TLS))
+	if !t.Minimal {
+		t.checkRoute(t.NewGrafanaRoute())
 	}
-	t.checkRoute(test.NewCoreRoute(t.TLS))
+	t.checkRoute(t.NewCoreRoute())
 }
 
 func (t *cryostatTestInput) checkRoute(expected *openshiftv1.Route) *openshiftv1.Route {
@@ -2057,7 +2044,7 @@ func (t *cryostatTestInput) checkRoute(expected *openshiftv1.Route) *openshiftv1
 
 func (t *cryostatTestInput) checkConditionPresent(condType operatorv1beta1.CryostatConditionType, status metav1.ConditionStatus, reason string) {
 	cr := &operatorv1beta1.Cryostat{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, cr)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, cr)
 	Expect(err).ToNot(HaveOccurred())
 
 	condition := meta.FindStatusCondition(cr.Status.Conditions, string(condType))
@@ -2068,7 +2055,7 @@ func (t *cryostatTestInput) checkConditionPresent(condType operatorv1beta1.Cryos
 
 func (t *cryostatTestInput) checkConditionAbsent(condType operatorv1beta1.CryostatConditionType) {
 	cr := &operatorv1beta1.Cryostat{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, cr)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, cr)
 	Expect(err).ToNot(HaveOccurred())
 
 	condition := meta.FindStatusCondition(cr.Status.Conditions, string(condType))
@@ -2076,7 +2063,7 @@ func (t *cryostatTestInput) checkConditionAbsent(condType operatorv1beta1.Cryost
 }
 
 func (t *cryostatTestInput) reconcileCryostatFully() {
-	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: "default"}}
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
 	result, err := t.controller.Reconcile(context.Background(), req)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(result).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
@@ -2088,11 +2075,11 @@ func (t *cryostatTestInput) reconcileCryostatFully() {
 	}
 
 	// Add ingress config to routes
-	if t.controller.IsOpenShift {
-		if t.minimal {
-			t.updateRouteStatus(req, test.NewCoreRoute(t.TLS))
+	if t.OpenShift {
+		if t.Minimal {
+			t.updateRouteStatus(req, t.NewCoreRoute())
 		} else {
-			t.updateRouteStatus(req, test.NewGrafanaRoute(t.TLS), test.NewCoreRoute(t.TLS))
+			t.updateRouteStatus(req, t.NewGrafanaRoute(), t.NewCoreRoute())
 		}
 	}
 
@@ -2104,7 +2091,7 @@ func (t *cryostatTestInput) reconcileCryostatFully() {
 func (t *cryostatTestInput) reconcileDeletedCryostat() {
 	// Simulate deletion by setting DeletionTimestamp
 	cr := &operatorv1beta1.Cryostat{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, cr)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, cr)
 	Expect(err).ToNot(HaveOccurred())
 
 	delTime := metav1.Unix(0, 1598045501618*int64(time.Millisecond))
@@ -2113,7 +2100,7 @@ func (t *cryostatTestInput) reconcileDeletedCryostat() {
 	Expect(err).ToNot(HaveOccurred())
 
 	// Reconcile again
-	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: "default"}}
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
 	result, err := t.controller.Reconcile(context.Background(), req)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(result).To(Equal(reconcile.Result{}))
@@ -2132,12 +2119,12 @@ func checkMetadata(object metav1.Object, expected metav1.Object) {
 
 func (t *cryostatTestInput) expectNoCryostat() {
 	instance := &operatorv1beta1.Cryostat{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, instance)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, instance)
 	Expect(kerrors.IsNotFound(err)).To(BeTrue())
 }
 
 func (t *cryostatTestInput) expectCertificates() {
-	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: "default"}}
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
 	result, err := t.controller.Reconcile(context.Background(), req)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(result).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
@@ -2150,7 +2137,7 @@ func (t *cryostatTestInput) expectCertificates() {
 
 func (t *cryostatTestInput) checkCertificates() {
 	// Check certificates
-	certs := []*certv1.Certificate{test.NewCryostatCert(), test.NewCACert(), test.NewGrafanaCert(), test.NewReportsCert()}
+	certs := []*certv1.Certificate{t.NewCryostatCert(), t.NewCACert(), t.NewGrafanaCert(), t.NewReportsCert()}
 	for _, expected := range certs {
 		actual := &certv1.Certificate{}
 		err := t.Client.Get(context.Background(), types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, actual)
@@ -2159,7 +2146,7 @@ func (t *cryostatTestInput) checkCertificates() {
 		Expect(actual.Spec).To(Equal(expected.Spec))
 	}
 	// Check issuers as well
-	issuers := []*certv1.Issuer{test.NewSelfSignedIssuer(), test.NewCryostatCAIssuer()}
+	issuers := []*certv1.Issuer{t.NewSelfSignedIssuer(), t.NewCryostatCAIssuer()}
 	for _, expected := range issuers {
 		actual := &certv1.Issuer{}
 		err := t.Client.Get(context.Background(), types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, actual)
@@ -2168,7 +2155,7 @@ func (t *cryostatTestInput) checkCertificates() {
 		Expect(actual.Spec).To(Equal(expected.Spec))
 	}
 	// Check keystore secret
-	expectedSecret := test.NewKeystoreSecret()
+	expectedSecret := t.NewKeystoreSecret()
 	secret := &corev1.Secret{}
 	err := t.Client.Get(context.Background(), types.NamespacedName{Name: expectedSecret.Name, Namespace: expectedSecret.Namespace}, secret)
 	Expect(err).ToNot(HaveOccurred())
@@ -2180,34 +2167,34 @@ func (t *cryostatTestInput) expectRBAC() {
 	t.reconcileCryostatFully()
 
 	sa := &corev1.ServiceAccount{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, sa)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, sa)
 	Expect(err).ToNot(HaveOccurred())
-	expectedSA := test.NewServiceAccount(t.controller.IsOpenShift)
+	expectedSA := t.NewServiceAccount()
 	checkMetadata(sa, expectedSA)
 	Expect(sa.Secrets).To(Equal(expectedSA.Secrets))
 	Expect(sa.ImagePullSecrets).To(Equal(expectedSA.ImagePullSecrets))
 	Expect(sa.AutomountServiceAccountToken).To(Equal(expectedSA.AutomountServiceAccountToken))
 
 	role := &rbacv1.Role{}
-	err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, role)
+	err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, role)
 	Expect(err).ToNot(HaveOccurred())
-	expectedRole := test.NewRole()
+	expectedRole := t.NewRole()
 	checkMetadata(role, expectedRole)
 	Expect(role.Rules).To(Equal(expectedRole.Rules))
 
 	binding := &rbacv1.RoleBinding{}
-	err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, binding)
+	err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, binding)
 	Expect(err).ToNot(HaveOccurred())
-	expectedBinding := test.NewRoleBinding()
+	expectedBinding := t.NewRoleBinding()
 	checkMetadata(binding, expectedBinding)
 	Expect(binding.Subjects).To(Equal(expectedBinding.Subjects))
 	Expect(binding.RoleRef).To(Equal(expectedBinding.RoleRef))
 
 	clusterBinding := &rbacv1.ClusterRoleBinding{}
 	err = t.Client.Get(context.Background(), types.NamespacedName{
-		Name: "cryostat-9ecd5050500c2566765bc593edfcce12434283e5da32a27476bc4a1569304a02"}, clusterBinding)
+		Name: "cryostat-ffc3f6d167f69f78c5882a8f67be7efcc7f2f9062145a98f99f7863922c52b10"}, clusterBinding)
 	Expect(err).ToNot(HaveOccurred())
-	expectedClusterBinding := test.NewClusterRoleBinding()
+	expectedClusterBinding := t.NewClusterRoleBinding()
 	Expect(clusterBinding.GetName()).To(Equal(expectedClusterBinding.GetName()))
 	Expect(clusterBinding.GetNamespace()).To(Equal(expectedClusterBinding.GetNamespace()))
 	Expect(clusterBinding.GetLabels()).To(Equal(expectedClusterBinding.GetLabels()))
@@ -2219,7 +2206,7 @@ func (t *cryostatTestInput) expectRBAC() {
 func (t *cryostatTestInput) checkClusterRoleBindingDeleted() {
 	clusterBinding := &rbacv1.ClusterRoleBinding{}
 	err := t.Client.Get(context.Background(), types.NamespacedName{
-		Name: "cryostat-9ecd5050500c2566765bc593edfcce12434283e5da32a27476bc4a1569304a02"}, clusterBinding)
+		Name: "cryostat-ffc3f6d167f69f78c5882a8f67be7efcc7f2f9062145a98f99f7863922c52b10"}, clusterBinding)
 	Expect(kerrors.IsNotFound(err)).To(BeTrue())
 }
 
@@ -2230,23 +2217,26 @@ func (t *cryostatTestInput) expectRoutes() {
 
 func (t *cryostatTestInput) expectNoRoutes() {
 	svc := &openshiftv1.Route{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, svc)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, svc)
 	Expect(kerrors.IsNotFound(err)).To(BeTrue())
-	err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-grafana", Namespace: "default"}, svc)
+	err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-grafana", Namespace: t.Namespace}, svc)
 	Expect(kerrors.IsNotFound(err)).To(BeTrue())
 }
 
 func (t *cryostatTestInput) checkIngresses() {
-	expectedConfig := test.NewNetworkConfigurationList(t.externalTLS)
+	cr := &operatorv1beta1.Cryostat{}
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, cr)
+	Expect(err).ToNot(HaveOccurred())
+	expectedConfig := cr.Spec.NetworkOptions
 
 	ingress := &netv1.Ingress{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, ingress)
+	err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, ingress)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(ingress.Annotations).To(Equal(expectedConfig.CoreConfig.Annotations))
 	Expect(ingress.Labels).To(Equal(expectedConfig.CoreConfig.Labels))
 	Expect(ingress.Spec).To(Equal(*expectedConfig.CoreConfig.IngressSpec))
 
-	err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-grafana", Namespace: "default"}, ingress)
+	err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-grafana", Namespace: t.Namespace}, ingress)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(ingress.Annotations).To(Equal(expectedConfig.GrafanaConfig.Annotations))
 	Expect(ingress.Labels).To(Equal(expectedConfig.GrafanaConfig.Labels))
@@ -2260,15 +2250,15 @@ func (t *cryostatTestInput) expectIngresses() {
 
 func (t *cryostatTestInput) expectNoIngresses() {
 	ing := &netv1.Ingress{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, ing)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, ing)
 	Expect(kerrors.IsNotFound(err)).To(BeTrue())
-	err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-grafana", Namespace: "default"}, ing)
+	err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-grafana", Namespace: t.Namespace}, ing)
 	Expect(kerrors.IsNotFound(err)).To(BeTrue())
 }
 
 func (t *cryostatTestInput) expectPVC(expectedPvc *corev1.PersistentVolumeClaim) {
 	pvc := &corev1.PersistentVolumeClaim{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, pvc)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, pvc)
 	Expect(kerrors.IsNotFound(err)).To(BeTrue())
 
 	t.reconcileCryostatFully()
@@ -2278,7 +2268,7 @@ func (t *cryostatTestInput) expectPVC(expectedPvc *corev1.PersistentVolumeClaim)
 
 func (t *cryostatTestInput) checkPVC(expectedPVC *corev1.PersistentVolumeClaim) {
 	pvc := &corev1.PersistentVolumeClaim{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, pvc)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, pvc)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Compare to desired spec
@@ -2300,7 +2290,7 @@ func (t *cryostatTestInput) expectEmptyDir(expectedEmptyDir *corev1.EmptyDirVolu
 	t.reconcileCryostatFully()
 
 	deployment := &appsv1.Deployment{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, deployment)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, deployment)
 	Expect(err).ToNot(HaveOccurred())
 
 	volume := deployment.Spec.Template.Spec.Volumes[0]
@@ -2315,17 +2305,17 @@ func (t *cryostatTestInput) expectInMemoryDatabase() {
 	t.reconcileCryostatFully()
 
 	deployment := &appsv1.Deployment{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, deployment)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, deployment)
 	Expect(err).ToNot(HaveOccurred())
 
 	containers := deployment.Spec.Template.Spec.Containers
 	coreContainer := containers[0]
-	Expect(coreContainer.Env).ToNot(ContainElements(test.DatabaseConfigEnvironmentVariables()))
+	Expect(coreContainer.Env).ToNot(ContainElements(t.DatabaseConfigEnvironmentVariables()))
 }
 
 func (t *cryostatTestInput) expectGrafanaSecret() {
 	secret := &corev1.Secret{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-grafana-basic", Namespace: "default"}, secret)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-grafana-basic", Namespace: t.Namespace}, secret)
 	Expect(kerrors.IsNotFound(err)).To(BeTrue())
 
 	t.reconcileCryostatFully()
@@ -2334,18 +2324,18 @@ func (t *cryostatTestInput) expectGrafanaSecret() {
 
 func (t *cryostatTestInput) checkGrafanaSecret() {
 	secret := &corev1.Secret{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-grafana-basic", Namespace: "default"}, secret)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-grafana-basic", Namespace: t.Namespace}, secret)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Compare to desired spec
-	expectedSecret := test.NewGrafanaSecret()
+	expectedSecret := t.NewGrafanaSecret()
 	checkMetadata(secret, expectedSecret)
 	Expect(secret.StringData).To(Equal(expectedSecret.StringData))
 }
 
 func (t *cryostatTestInput) expectCredentialsDatabaseSecret() {
 	secret := &corev1.Secret{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-jmx-credentials-db", Namespace: "default"}, secret)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-jmx-credentials-db", Namespace: t.Namespace}, secret)
 	Expect(kerrors.IsNotFound(err)).To(BeTrue())
 
 	t.reconcileCryostatFully()
@@ -2354,48 +2344,48 @@ func (t *cryostatTestInput) expectCredentialsDatabaseSecret() {
 
 func (t *cryostatTestInput) checkCredentialsDatabaseSecret() {
 	secret := &corev1.Secret{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-jmx-credentials-db", Namespace: "default"}, secret)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-jmx-credentials-db", Namespace: t.Namespace}, secret)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Compare to desired spec
-	expectedSecret := test.NewCredentialsDatabaseSecret()
+	expectedSecret := t.NewCredentialsDatabaseSecret()
 	checkMetadata(secret, expectedSecret)
 	Expect(secret.StringData).To(Equal(expectedSecret.StringData))
 }
 
 func (t *cryostatTestInput) expectJMXSecret() {
 	secret := &corev1.Secret{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-jmx-auth", Namespace: "default"}, secret)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-jmx-auth", Namespace: t.Namespace}, secret)
 	Expect(kerrors.IsNotFound(err)).To(BeTrue())
 
 	t.reconcileCryostatFully()
 
-	err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-jmx-auth", Namespace: "default"}, secret)
+	err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-jmx-auth", Namespace: t.Namespace}, secret)
 	Expect(err).ToNot(HaveOccurred())
 
-	expectedSecret := test.NewJMXSecret()
+	expectedSecret := t.NewJMXSecret()
 	checkMetadata(secret, expectedSecret)
 	Expect(secret.StringData).To(Equal(expectedSecret.StringData))
 }
 
 func (t *cryostatTestInput) expectCoreService() {
 	service := &corev1.Service{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, service)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, service)
 	Expect(kerrors.IsNotFound(err)).To(BeTrue())
 
 	t.reconcileCryostatFully()
 
-	t.checkService("cryostat", test.NewCryostatService())
+	t.checkService("cryostat", t.NewCryostatService())
 }
 
 func (t *cryostatTestInput) expectStatusApplicationURL() {
 	instance := &operatorv1beta1.Cryostat{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, instance)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, instance)
 	Expect(err).ToNot(HaveOccurred())
 
 	t.reconcileCryostatFully()
 
-	err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, instance)
+	err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, instance)
 	Expect(err).ToNot(HaveOccurred())
 
 	Expect(instance.Status.ApplicationURL).To(Equal("https://cryostat.example.com"))
@@ -2403,7 +2393,7 @@ func (t *cryostatTestInput) expectStatusApplicationURL() {
 
 func (t *cryostatTestInput) expectStatusGrafanaSecretName(secretName string) {
 	instance := &operatorv1beta1.Cryostat{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, instance)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, instance)
 	Expect(err).ToNot(HaveOccurred())
 
 	t.reconcileCryostatFully()
@@ -2412,7 +2402,7 @@ func (t *cryostatTestInput) expectStatusGrafanaSecretName(secretName string) {
 
 func (t *cryostatTestInput) checkStatusGrafanaSecretName(secretName string) {
 	instance := &operatorv1beta1.Cryostat{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, instance)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, instance)
 	Expect(err).ToNot(HaveOccurred())
 
 	Expect(instance.Status.GrafanaSecret).To(Equal(secretName))
@@ -2420,7 +2410,7 @@ func (t *cryostatTestInput) checkStatusGrafanaSecretName(secretName string) {
 
 func (t *cryostatTestInput) expectDeployment() {
 	deployment := &appsv1.Deployment{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, deployment)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, deployment)
 	Expect(kerrors.IsNotFound(err)).To(BeTrue())
 
 	t.reconcileCryostatFully()
@@ -2430,20 +2420,20 @@ func (t *cryostatTestInput) expectDeployment() {
 func (t *cryostatTestInput) expectDeploymentHasCertSecrets() {
 	t.reconcileCryostatFully()
 	deployment := &appsv1.Deployment{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, deployment)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, deployment)
 	Expect(err).ToNot(HaveOccurred())
 
 	volumes := deployment.Spec.Template.Spec.Volumes
-	expectedVolumes := test.NewVolumesWithSecrets(t.TLS)
+	expectedVolumes := t.NewVolumesWithSecrets()
 	Expect(volumes).To(ConsistOf(expectedVolumes))
 
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	expectedVolumeMounts := test.NewCoreVolumeMounts(t.TLS)
+	expectedVolumeMounts := t.NewCoreVolumeMounts()
 	Expect(volumeMounts).To(ConsistOf(expectedVolumeMounts))
 }
 
 func (t *cryostatTestInput) expectIdempotence() {
-	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: "default"}}
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
 	t.reconcileCryostatFully()
 
 	obj := &operatorv1beta1.Cryostat{}
@@ -2464,18 +2454,18 @@ func (t *cryostatTestInput) expectIdempotence() {
 
 func (t *cryostatTestInput) expectCryostatFinalizerPresent() {
 	cr := &operatorv1beta1.Cryostat{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, cr)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, cr)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cr.GetFinalizers()).To(ContainElement("operator.cryostat.io/cryostat.finalizer"))
 }
 
 func (t *cryostatTestInput) checkGrafanaService() {
-	t.checkService("cryostat-grafana", test.NewGrafanaService())
+	t.checkService("cryostat-grafana", t.NewGrafanaService())
 }
 
 func (t *cryostatTestInput) checkService(svcName string, expected *corev1.Service) {
 	service := &corev1.Service{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: svcName, Namespace: "default"}, service)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: svcName, Namespace: t.Namespace}, service)
 	Expect(err).ToNot(HaveOccurred())
 
 	checkMetadata(service, expected)
@@ -2486,13 +2476,13 @@ func (t *cryostatTestInput) checkService(svcName string, expected *corev1.Servic
 
 func (t *cryostatTestInput) expectNoService(svcName string) {
 	service := &corev1.Service{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: svcName, Namespace: "default"}, service)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: svcName, Namespace: t.Namespace}, service)
 	Expect(kerrors.IsNotFound(err)).To(BeTrue())
 }
 
 func (t *cryostatTestInput) expectNoReportsDeployment() {
 	deployment := &appsv1.Deployment{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-reports", Namespace: "default"}, deployment)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-reports", Namespace: t.Namespace}, deployment)
 	Expect(kerrors.IsNotFound(err)).To(BeTrue())
 }
 
@@ -2517,7 +2507,7 @@ func (t *cryostatTestInput) setDeploymentConditions(deployName string, available
 	progressing *corev1.ConditionStatus, replicaFailure *corev1.ConditionStatus) {
 	// Update Deployment's "Available" Condition
 	deploy := &appsv1.Deployment{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: deployName, Namespace: "default"}, deploy)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: deployName, Namespace: t.Namespace}, deploy)
 	Expect(err).ToNot(HaveOccurred())
 
 	conditions := []appsv1.DeploymentCondition{}
@@ -2551,7 +2541,7 @@ func (t *cryostatTestInput) setDeploymentConditions(deployName string, available
 	Expect(err).ToNot(HaveOccurred())
 
 	// Reconcile again
-	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: "default"}}
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
 	res, err := t.controller.Reconcile(context.Background(), req)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(res).To(Equal(reconcile.Result{}))
@@ -2559,15 +2549,15 @@ func (t *cryostatTestInput) setDeploymentConditions(deployName string, available
 
 func (t *cryostatTestInput) checkMainDeployment() {
 	deployment := &appsv1.Deployment{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, deployment)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, deployment)
 	Expect(err).ToNot(HaveOccurred())
 
 	cr := &operatorv1beta1.Cryostat{}
-	err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, cr)
+	err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, cr)
 	Expect(err).ToNot(HaveOccurred())
 
 	Expect(deployment.Name).To(Equal("cryostat"))
-	Expect(deployment.Namespace).To(Equal("default"))
+	Expect(deployment.Namespace).To(Equal(t.Namespace))
 	Expect(deployment.Annotations).To(Equal(map[string]string{
 		"app.openshift.io/connects-to": "cryostat-operator-controller-manager",
 	}))
@@ -2578,10 +2568,10 @@ func (t *cryostatTestInput) checkMainDeployment() {
 		"app.kubernetes.io/name": "cryostat",
 	}))
 	Expect(metav1.IsControlledBy(deployment, cr)).To(BeTrue())
-	Expect(deployment.Spec.Selector).To(Equal(test.NewMainDeploymentSelector()))
+	Expect(deployment.Spec.Selector).To(Equal(t.NewMainDeploymentSelector()))
 	Expect(deployment.Spec.Replicas).ToNot(BeNil())
 	Expect(*deployment.Spec.Replicas).To(Equal(int32(1)))
-	Expect(deployment.Spec.Strategy).To(Equal(test.NewMainDeploymentStrategy()))
+	Expect(deployment.Spec.Strategy).To(Equal(t.NewMainDeploymentStrategy()))
 
 	// compare Pod template
 	t.checkMainPodTemplate(deployment, cr)
@@ -2590,14 +2580,14 @@ func (t *cryostatTestInput) checkMainDeployment() {
 func (t *cryostatTestInput) checkMainPodTemplate(deployment *appsv1.Deployment, cr *operatorv1beta1.Cryostat) {
 	template := deployment.Spec.Template
 	Expect(template.Name).To(Equal("cryostat"))
-	Expect(template.Namespace).To(Equal("default"))
+	Expect(template.Namespace).To(Equal(t.Namespace))
 	Expect(template.Labels).To(Equal(map[string]string{
 		"app":       "cryostat",
 		"kind":      "cryostat",
 		"component": "cryostat",
 	}))
-	Expect(template.Spec.Volumes).To(ConsistOf(test.NewVolumes(t.minimal, t.TLS)))
-	Expect(template.Spec.SecurityContext).To(Equal(test.NewPodSecurityContext(cr, t.controller.IsOpenShift)))
+	Expect(template.Spec.Volumes).To(ConsistOf(t.NewVolumes()))
+	Expect(template.Spec.SecurityContext).To(Equal(t.NewPodSecurityContext(cr)))
 
 	// Check that the networking environment variables are set correctly
 	coreContainer := template.Spec.Containers[0]
@@ -2607,33 +2597,31 @@ func (t *cryostatTestInput) checkMainPodTemplate(deployment *appsv1.Deployment, 
 		port = strconv.Itoa(int(*cr.Spec.ServiceOptions.ReportsConfig.HTTPPort))
 	}
 	var reportsUrl string
-	if t.reportReplicas == 0 {
+	if t.ReportReplicas == 0 {
 		reportsUrl = ""
 	} else if t.TLS {
 		reportsUrl = "https://cryostat-reports:" + port
 	} else {
 		reportsUrl = "http://cryostat-reports:" + port
 	}
-	ingress := !t.controller.IsOpenShift &&
+	ingress := !t.OpenShift &&
 		cr.Spec.NetworkOptions != nil && cr.Spec.NetworkOptions.CoreConfig != nil && cr.Spec.NetworkOptions.CoreConfig.IngressSpec != nil
 	emptyDir := cr.Spec.StorageOptions != nil && cr.Spec.StorageOptions.EmptyDir != nil && cr.Spec.StorageOptions.EmptyDir.Enabled
 	builtInDiscoveryDisabled := cr.Spec.TargetDiscoveryOptions != nil && cr.Spec.TargetDiscoveryOptions.BuiltInDiscoveryDisabled
 	dbSecretProvided := cr.Spec.JmxCredentialsDatabaseOptions != nil && cr.Spec.JmxCredentialsDatabaseOptions.DatabaseSecretName != nil
 
-	checkCoreContainer(&coreContainer,
-		t.minimal, t.TLS, t.externalTLS, t.EnvCoreImageTag,
-		t.controller.IsOpenShift, ingress, reportsUrl,
+	t.checkCoreContainer(&coreContainer, ingress, reportsUrl,
 		cr.Spec.AuthProperties != nil, emptyDir, builtInDiscoveryDisabled, dbSecretProvided,
-		test.NewCoreContainerResource(cr), test.NewCoreSecurityContext(cr))
+		t.NewCoreContainerResource(cr), t.NewCoreSecurityContext(cr))
 
-	if !t.minimal {
+	if !t.Minimal {
 		// Check that Grafana is configured properly, depending on the environment
 		grafanaContainer := template.Spec.Containers[1]
-		checkGrafanaContainer(&grafanaContainer, t.TLS, t.EnvGrafanaImageTag, test.NewGrafanaContainerResource(cr), test.NewGrafanaSecurityContext(cr))
+		t.checkGrafanaContainer(&grafanaContainer, t.NewGrafanaContainerResource(cr), t.NewGrafanaSecurityContext(cr))
 
 		// Check that JFR Datasource is configured properly
 		datasourceContainer := template.Spec.Containers[2]
-		checkDatasourceContainer(&datasourceContainer, t.EnvDatasourceImageTag, test.NewDatasourceContainerResource(cr), test.NewDatasourceSecurityContext(cr))
+		t.checkDatasourceContainer(&datasourceContainer, t.NewDatasourceContainerResource(cr), t.NewDatasourceSecurityContext(cr))
 	}
 
 	// Check that the proper Service Account is set
@@ -2653,15 +2641,15 @@ func (t *cryostatTestInput) checkMainPodTemplate(deployment *appsv1.Deployment, 
 
 func (t *cryostatTestInput) checkReportsDeployment() {
 	deployment := &appsv1.Deployment{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-reports", Namespace: "default"}, deployment)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat-reports", Namespace: t.Namespace}, deployment)
 	Expect(err).ToNot(HaveOccurred())
 
 	cr := &operatorv1beta1.Cryostat{}
-	err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, cr)
+	err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, cr)
 	Expect(err).ToNot(HaveOccurred())
 
 	Expect(deployment.Name).To(Equal("cryostat-reports"))
-	Expect(deployment.Namespace).To(Equal("default"))
+	Expect(deployment.Namespace).To(Equal(t.Namespace))
 	Expect(deployment.Annotations).To(Equal(map[string]string{
 		"app.openshift.io/connects-to": "cryostat",
 	}))
@@ -2672,24 +2660,24 @@ func (t *cryostatTestInput) checkReportsDeployment() {
 		"app.kubernetes.io/name": "cryostat-reports",
 	}))
 	Expect(metav1.IsControlledBy(deployment, cr)).To(BeTrue())
-	Expect(deployment.Spec.Selector).To(Equal(test.NewReportsDeploymentSelector()))
+	Expect(deployment.Spec.Selector).To(Equal(t.NewReportsDeploymentSelector()))
 	Expect(deployment.Spec.Replicas).ToNot(BeNil())
-	Expect(*deployment.Spec.Replicas).To(Equal(t.reportReplicas))
+	Expect(*deployment.Spec.Replicas).To(Equal(t.ReportReplicas))
 	Expect(deployment.Spec.Strategy).To(BeZero())
 
 	// compare Pod template
 	template := deployment.Spec.Template
 	Expect(template.Name).To(Equal("cryostat-reports"))
-	Expect(template.Namespace).To(Equal("default"))
+	Expect(template.Namespace).To(Equal(t.Namespace))
 	Expect(template.Labels).To(Equal(map[string]string{
 		"app":       "cryostat",
 		"kind":      "cryostat",
 		"component": "reports",
 	}))
-	Expect(template.Spec.Volumes).To(ConsistOf(test.NewReportsVolumes(t.TLS)))
-	Expect(template.Spec.SecurityContext).To(Equal(test.NewReportPodSecurityContext(cr, t.controller.IsOpenShift)))
+	Expect(template.Spec.Volumes).To(ConsistOf(t.NewReportsVolumes()))
+	Expect(template.Spec.SecurityContext).To(Equal(t.NewReportPodSecurityContext(cr)))
 
-	checkReportsContainer(&template.Spec.Containers[0], t.TLS, t.EnvReportsImageTag, test.NewReportContainerResource(cr), test.NewReportSecurityContext(cr))
+	t.checkReportsContainer(&template.Spec.Containers[0], t.NewReportContainerResource(cr), t.NewReportSecurityContext(cr))
 
 	// Check that the default Service Account is used
 	Expect(template.Spec.ServiceAccountName).To(BeEmpty())
@@ -2709,121 +2697,120 @@ func (t *cryostatTestInput) checkReportsDeployment() {
 
 func (t *cryostatTestInput) checkDeploymentHasTemplates() {
 	deployment := &appsv1.Deployment{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, deployment)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, deployment)
 	Expect(err).ToNot(HaveOccurred())
 
 	volumes := deployment.Spec.Template.Spec.Volumes
-	expectedVolumes := test.NewVolumesWithTemplates(t.TLS)
+	expectedVolumes := t.NewVolumesWithTemplates()
 	Expect(volumes).To(ConsistOf(expectedVolumes))
 
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	expectedVolumeMounts := test.NewVolumeMountsWithTemplates(t.TLS)
+	expectedVolumeMounts := t.NewVolumeMountsWithTemplates()
 	Expect(volumeMounts).To(ConsistOf(expectedVolumeMounts))
 }
 
 func (t *cryostatTestInput) checkDeploymentHasAuthProperties() {
 	deployment := &appsv1.Deployment{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, deployment)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, deployment)
 	Expect(err).ToNot(HaveOccurred())
 
 	volumes := deployment.Spec.Template.Spec.Volumes
-	expectedVolumes := test.NewVolumeWithAuthProperties(t.TLS)
+	expectedVolumes := t.NewVolumeWithAuthProperties()
 	Expect(volumes).To(ConsistOf(expectedVolumes))
 
 	coreContainer := deployment.Spec.Template.Spec.Containers[0]
 
 	volumeMounts := coreContainer.VolumeMounts
-	expectedVolumeMounts := test.NewVolumeMountsWithAuthProperties(t.TLS)
+	expectedVolumeMounts := t.NewVolumeMountsWithAuthProperties()
 	Expect(volumeMounts).To(ConsistOf(expectedVolumeMounts))
-	Expect(coreContainer.Env).To(ConsistOf(test.NewCoreEnvironmentVariables(t.minimal, t.TLS, t.externalTLS, t.controller.IsOpenShift, "", true, false, false, false, false)))
+	Expect(coreContainer.Env).To(ConsistOf(t.NewCoreEnvironmentVariables("", true, false, false, false, false)))
 }
 
 func (t *cryostatTestInput) checkDeploymentHasNoAuthProperties() {
 	deployment := &appsv1.Deployment{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, deployment)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, deployment)
 	Expect(err).ToNot(HaveOccurred())
 
 	volumes := deployment.Spec.Template.Spec.Volumes
-	expectedVolumes := test.NewVolumes(t.minimal, t.TLS)
-	Expect(volumes).ToNot(ContainElements(test.NewAuthPropertiesVolume()))
+	expectedVolumes := t.NewVolumes()
+	Expect(volumes).ToNot(ContainElements(t.NewAuthPropertiesVolume()))
 	Expect(volumes).To(ConsistOf(expectedVolumes))
 
 	coreContainer := deployment.Spec.Template.Spec.Containers[0]
 
 	volumeMounts := coreContainer.VolumeMounts
-	expectedVolumeMounts := test.NewCoreVolumeMounts(t.TLS)
-	Expect(volumeMounts).ToNot(ContainElement(test.NewAuthPropertiesVolumeMount()))
+	expectedVolumeMounts := t.NewCoreVolumeMounts()
+	Expect(volumeMounts).ToNot(ContainElement(t.NewAuthPropertiesVolumeMount()))
 	Expect(volumeMounts).To(ConsistOf(expectedVolumeMounts))
 }
 
-func checkCoreContainer(container *corev1.Container, minimal bool, tls bool, externalTLS bool,
-	tag *string, openshift bool, ingress bool,
+func (t *cryostatTestInput) checkCoreContainer(container *corev1.Container, ingress bool,
 	reportsUrl string, authProps bool,
 	emptyDir bool, builtInDiscoveryDisabled bool, dbSecretProvided bool,
 	resources *corev1.ResourceRequirements,
 	securityContext *corev1.SecurityContext) {
 	Expect(container.Name).To(Equal("cryostat"))
-	if tag == nil {
+	if t.EnvCoreImageTag == nil {
 		Expect(container.Image).To(HavePrefix("quay.io/cryostat/cryostat:"))
 	} else {
-		Expect(container.Image).To(Equal(*tag))
+		Expect(container.Image).To(Equal(*t.EnvCoreImageTag))
 	}
-	Expect(container.Ports).To(ConsistOf(test.NewCorePorts()))
-	Expect(container.Env).To(ConsistOf(test.NewCoreEnvironmentVariables(minimal, tls, externalTLS, openshift, reportsUrl, authProps, ingress, emptyDir, builtInDiscoveryDisabled, dbSecretProvided)))
-	Expect(container.EnvFrom).To(ConsistOf(test.NewCoreEnvFromSource(tls)))
-	Expect(container.VolumeMounts).To(ConsistOf(test.NewCoreVolumeMounts(tls)))
-	Expect(container.LivenessProbe).To(Equal(test.NewCoreLivenessProbe(tls)))
-	Expect(container.StartupProbe).To(Equal(test.NewCoreStartupProbe(tls)))
+	Expect(container.Ports).To(ConsistOf(t.NewCorePorts()))
+	Expect(container.Env).To(ConsistOf(t.NewCoreEnvironmentVariables(reportsUrl, authProps, ingress, emptyDir, builtInDiscoveryDisabled, dbSecretProvided)))
+	Expect(container.EnvFrom).To(ConsistOf(t.NewCoreEnvFromSource()))
+	Expect(container.VolumeMounts).To(ConsistOf(t.NewCoreVolumeMounts()))
+	Expect(container.LivenessProbe).To(Equal(t.NewCoreLivenessProbe()))
+	Expect(container.StartupProbe).To(Equal(t.NewCoreStartupProbe()))
 	Expect(container.SecurityContext).To(Equal(securityContext))
 
 	checkResourceRequirements(&container.Resources, resources)
 }
 
-func checkGrafanaContainer(container *corev1.Container, tls bool, tag *string, resources *corev1.ResourceRequirements, securityContext *corev1.SecurityContext) {
+func (t *cryostatTestInput) checkGrafanaContainer(container *corev1.Container, resources *corev1.ResourceRequirements, securityContext *corev1.SecurityContext) {
 	Expect(container.Name).To(Equal("cryostat-grafana"))
-	if tag == nil {
+	if t.EnvGrafanaImageTag == nil {
 		Expect(container.Image).To(HavePrefix("quay.io/cryostat/cryostat-grafana-dashboard:"))
 	} else {
-		Expect(container.Image).To(Equal(*tag))
+		Expect(container.Image).To(Equal(*t.EnvGrafanaImageTag))
 	}
-	Expect(container.Ports).To(ConsistOf(test.NewGrafanaPorts()))
-	Expect(container.Env).To(ConsistOf(test.NewGrafanaEnvironmentVariables(tls)))
-	Expect(container.EnvFrom).To(ConsistOf(test.NewGrafanaEnvFromSource()))
-	Expect(container.VolumeMounts).To(ConsistOf(test.NewGrafanaVolumeMounts(tls)))
-	Expect(container.LivenessProbe).To(Equal(test.NewGrafanaLivenessProbe(tls)))
+	Expect(container.Ports).To(ConsistOf(t.NewGrafanaPorts()))
+	Expect(container.Env).To(ConsistOf(t.NewGrafanaEnvironmentVariables()))
+	Expect(container.EnvFrom).To(ConsistOf(t.NewGrafanaEnvFromSource()))
+	Expect(container.VolumeMounts).To(ConsistOf(t.NewGrafanaVolumeMounts()))
+	Expect(container.LivenessProbe).To(Equal(t.NewGrafanaLivenessProbe()))
 	Expect(container.SecurityContext).To(Equal(securityContext))
 
 	checkResourceRequirements(&container.Resources, resources)
 }
 
-func checkDatasourceContainer(container *corev1.Container, tag *string, resources *corev1.ResourceRequirements, securityContext *corev1.SecurityContext) {
+func (t *cryostatTestInput) checkDatasourceContainer(container *corev1.Container, resources *corev1.ResourceRequirements, securityContext *corev1.SecurityContext) {
 	Expect(container.Name).To(Equal("cryostat-jfr-datasource"))
-	if tag == nil {
+	if t.EnvDatasourceImageTag == nil {
 		Expect(container.Image).To(HavePrefix("quay.io/cryostat/jfr-datasource:"))
 	} else {
-		Expect(container.Image).To(Equal(*tag))
+		Expect(container.Image).To(Equal(*t.EnvDatasourceImageTag))
 	}
-	Expect(container.Ports).To(ConsistOf(test.NewDatasourcePorts()))
-	Expect(container.Env).To(ConsistOf(test.NewDatasourceEnvironmentVariables()))
+	Expect(container.Ports).To(ConsistOf(t.NewDatasourcePorts()))
+	Expect(container.Env).To(ConsistOf(t.NewDatasourceEnvironmentVariables()))
 	Expect(container.EnvFrom).To(BeEmpty())
 	Expect(container.VolumeMounts).To(BeEmpty())
-	Expect(container.LivenessProbe).To(Equal(test.NewDatasourceLivenessProbe()))
+	Expect(container.LivenessProbe).To(Equal(t.NewDatasourceLivenessProbe()))
 	Expect(container.SecurityContext).To(Equal(securityContext))
 
 	checkResourceRequirements(&container.Resources, resources)
 }
 
-func checkReportsContainer(container *corev1.Container, tls bool, tag *string, resources *corev1.ResourceRequirements, securityContext *corev1.SecurityContext) {
+func (t *cryostatTestInput) checkReportsContainer(container *corev1.Container, resources *corev1.ResourceRequirements, securityContext *corev1.SecurityContext) {
 	Expect(container.Name).To(Equal("cryostat-reports"))
-	if tag == nil {
+	if t.EnvReportsImageTag == nil {
 		Expect(container.Image).To(HavePrefix("quay.io/cryostat/cryostat-reports:"))
 	} else {
-		Expect(container.Image).To(Equal(*tag))
+		Expect(container.Image).To(Equal(*t.EnvReportsImageTag))
 	}
-	Expect(container.Ports).To(ConsistOf(test.NewReportsPorts()))
-	Expect(container.Env).To(ConsistOf(test.NewReportsEnvironmentVariables(tls, resources)))
-	Expect(container.VolumeMounts).To(ConsistOf(test.NewReportsVolumeMounts(tls)))
-	Expect(container.LivenessProbe).To(Equal(test.NewReportsLivenessProbe(tls)))
+	Expect(container.Ports).To(ConsistOf(t.NewReportsPorts()))
+	Expect(container.Env).To(ConsistOf(t.NewReportsEnvironmentVariables(resources)))
+	Expect(container.VolumeMounts).To(ConsistOf(t.NewReportsVolumeMounts()))
+	Expect(container.LivenessProbe).To(Equal(t.NewReportsLivenessProbe()))
 	Expect(container.SecurityContext).To(Equal(securityContext))
 
 	checkResourceRequirements(&container.Resources, resources)
@@ -2831,7 +2818,7 @@ func checkReportsContainer(container *corev1.Container, tls bool, tag *string, r
 
 func (t *cryostatTestInput) checkCoreHasEnvironmentVariables(expectedEnvVars []corev1.EnvVar) {
 	deployment := &appsv1.Deployment{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: "default"}, deployment)
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, deployment)
 	Expect(err).ToNot(HaveOccurred())
 
 	template := deployment.Spec.Template

--- a/internal/test/reconciler.go
+++ b/internal/test/reconciler.go
@@ -48,7 +48,6 @@ import (
 // TestReconcilerConfig groups parameters used to create a test Reconciler
 type TestReconcilerConfig struct {
 	Client                client.Client
-	TLS                   bool
 	EnvDisableTLS         *bool
 	EnvCoreImageTag       *string
 	EnvDatasourceImageTag *string

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -37,6 +37,7 @@
 package test
 
 import (
+	"crypto/sha256"
 	"fmt"
 
 	operatorv1beta1 "github.com/cryostatio/cryostat-operator/api/v1beta1"
@@ -2407,10 +2408,15 @@ func (r *TestResources) OtherRoleBinding() *rbacv1.RoleBinding {
 	}
 }
 
+func (r *TestResources) clusterUniqueSuffix() string {
+	toEncode := r.Namespace + "/cryostat"
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(toEncode)))
+}
+
 func (r *TestResources) NewClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "cryostat-ffc3f6d167f69f78c5882a8f67be7efcc7f2f9062145a98f99f7863922c52b10",
+			Name: "cryostat-" + r.clusterUniqueSuffix(),
 		},
 		Subjects: []rbacv1.Subject{
 			{
@@ -2430,7 +2436,7 @@ func (r *TestResources) NewClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 func (r *TestResources) OtherClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "cryostat-ffc3f6d167f69f78c5882a8f67be7efcc7f2f9062145a98f99f7863922c52b10",
+			Name: "cryostat-" + r.clusterUniqueSuffix(),
 			Labels: map[string]string{
 				"test": "label",
 			},
@@ -2509,7 +2515,7 @@ func (r *TestResources) NewNamespaceWithSCCSupGroups() *corev1.Namespace {
 func (r *TestResources) NewConsoleLink() *consolev1.ConsoleLink {
 	return &consolev1.ConsoleLink{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "cryostat-ffc3f6d167f69f78c5882a8f67be7efcc7f2f9062145a98f99f7863922c52b10",
+			Name: "cryostat-" + r.clusterUniqueSuffix(),
 		},
 		Spec: consolev1.ConsoleLinkSpec{
 			Link: consolev1.Link{
@@ -2527,7 +2533,7 @@ func (r *TestResources) NewConsoleLink() *consolev1.ConsoleLink {
 func (r *TestResources) OtherConsoleLink() *consolev1.ConsoleLink {
 	return &consolev1.ConsoleLink{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "cryostat-ffc3f6d167f69f78c5882a8f67be7efcc7f2f9062145a98f99f7863922c52b10",
+			Name: "cryostat-" + r.clusterUniqueSuffix(),
 			Labels: map[string]string{
 				"my": "label",
 			},

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -60,6 +60,15 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
+type TestResources struct {
+	Namespace      string
+	Minimal        bool
+	TLS            bool
+	ExternalTLS    bool
+	OpenShift      bool
+	ReportReplicas int32
+}
+
 func NewTestScheme() *runtime.Scheme {
 	s := scheme.Scheme
 
@@ -89,31 +98,29 @@ func NewTESTRESTMapper() meta.RESTMapper {
 	return mapper
 }
 
-func NewCryostat() *operatorv1beta1.Cryostat {
+func (r *TestResources) NewCryostat() *operatorv1beta1.Cryostat {
 	certManager := true
+	var reportOptions *operatorv1beta1.ReportConfiguration
+	if r.ReportReplicas > 0 {
+		reportOptions = &operatorv1beta1.ReportConfiguration{
+			Replicas: r.ReportReplicas,
+		}
+	}
 	return &operatorv1beta1.Cryostat{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat",
-			Namespace: "default",
+			Namespace: r.Namespace,
 		},
 		Spec: operatorv1beta1.CryostatSpec{
-			Minimal:            false,
-			EnableCertManager:  &certManager,
-			TrustedCertSecrets: []operatorv1beta1.CertificateSecret{},
+			Minimal:           r.Minimal,
+			EnableCertManager: &certManager,
+			ReportOptions:     reportOptions,
 		},
 	}
 }
 
-func NewCryostatWithReports() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
-	cr.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{
-		Replicas: 1,
-	}
-	return cr
-}
-
-func NewCryostatWithSecrets() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithSecrets() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	key := "test.crt"
 	cr.Spec.TrustedCertSecrets = []operatorv1beta1.CertificateSecret{
 		{
@@ -127,8 +134,8 @@ func NewCryostatWithSecrets() *operatorv1beta1.Cryostat {
 	return cr
 }
 
-func NewCryostatWithTemplates() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithTemplates() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	cr.Spec.EventTemplates = []operatorv1beta1.TemplateConfigMap{
 		{
 			ConfigMapName: "templateCM1",
@@ -142,22 +149,15 @@ func NewCryostatWithTemplates() *operatorv1beta1.Cryostat {
 	return cr
 }
 
-func NewCryostatWithIngress() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
-	networkConfig := NewNetworkConfigurationList(true)
+func (r *TestResources) NewCryostatWithIngress() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
+	networkConfig := r.newNetworkConfigurationList()
 	cr.Spec.NetworkOptions = &networkConfig
 	return cr
 }
 
-func NewCryostatWithIngressNoTLS() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
-	networkConfig := NewNetworkConfigurationList(false)
-	cr.Spec.NetworkOptions = &networkConfig
-	return cr
-}
-
-func NewCryostatWithPVCSpec() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithPVCSpec() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	cr.Spec.StorageOptions = &operatorv1beta1.StorageConfiguration{
 		PVC: &operatorv1beta1.PersistentVolumeClaimConfig{
 			Annotations: map[string]string{
@@ -173,8 +173,8 @@ func NewCryostatWithPVCSpec() *operatorv1beta1.Cryostat {
 	return cr
 }
 
-func NewCryostatWithPVCSpecSomeDefault() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithPVCSpecSomeDefault() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	cr.Spec.StorageOptions = &operatorv1beta1.StorageConfiguration{
 		PVC: &operatorv1beta1.PersistentVolumeClaimConfig{
 			Spec: newPVCSpec("", "1Gi"),
@@ -183,8 +183,8 @@ func NewCryostatWithPVCSpecSomeDefault() *operatorv1beta1.Cryostat {
 	return cr
 }
 
-func NewCryostatWithPVCLabelsOnly() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithPVCLabelsOnly() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	cr.Spec.StorageOptions = &operatorv1beta1.StorageConfiguration{
 		PVC: &operatorv1beta1.PersistentVolumeClaimConfig{
 			Labels: map[string]string{
@@ -195,8 +195,8 @@ func NewCryostatWithPVCLabelsOnly() *operatorv1beta1.Cryostat {
 	return cr
 }
 
-func NewCryostatWithDefaultEmptyDir() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithDefaultEmptyDir() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	cr.Spec.StorageOptions = &operatorv1beta1.StorageConfiguration{
 		EmptyDir: &operatorv1beta1.EmptyDirConfig{
 			Enabled: true,
@@ -205,8 +205,8 @@ func NewCryostatWithDefaultEmptyDir() *operatorv1beta1.Cryostat {
 	return cr
 }
 
-func NewCryostatWithEmptyDirSpec() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithEmptyDirSpec() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	cr.Spec.StorageOptions = &operatorv1beta1.StorageConfiguration{
 		EmptyDir: &operatorv1beta1.EmptyDirConfig{
 			Enabled:   true,
@@ -217,11 +217,11 @@ func NewCryostatWithEmptyDirSpec() *operatorv1beta1.Cryostat {
 	return cr
 }
 
-func NewCryostatWithCoreSvc() *operatorv1beta1.Cryostat {
+func (r *TestResources) NewCryostatWithCoreSvc() *operatorv1beta1.Cryostat {
 	svcType := corev1.ServiceTypeNodePort
 	httpPort := int32(8080)
 	jmxPort := int32(9095)
-	cr := NewCryostat()
+	cr := r.NewCryostat()
 	cr.Spec.ServiceOptions = &operatorv1beta1.ServiceConfigList{
 		CoreConfig: &operatorv1beta1.CoreServiceConfig{
 			HTTPPort: &httpPort,
@@ -241,10 +241,10 @@ func NewCryostatWithCoreSvc() *operatorv1beta1.Cryostat {
 	return cr
 }
 
-func NewCryostatWithGrafanaSvc() *operatorv1beta1.Cryostat {
+func (r *TestResources) NewCryostatWithGrafanaSvc() *operatorv1beta1.Cryostat {
 	svcType := corev1.ServiceTypeNodePort
 	httpPort := int32(8080)
-	cr := NewCryostat()
+	cr := r.NewCryostat()
 	cr.Spec.ServiceOptions = &operatorv1beta1.ServiceConfigList{
 		GrafanaConfig: &operatorv1beta1.GrafanaServiceConfig{
 			HTTPPort: &httpPort,
@@ -263,13 +263,10 @@ func NewCryostatWithGrafanaSvc() *operatorv1beta1.Cryostat {
 	return cr
 }
 
-func NewCryostatWithReportsSvc() *operatorv1beta1.Cryostat {
+func (r *TestResources) NewCryostatWithReportsSvc() *operatorv1beta1.Cryostat {
 	svcType := corev1.ServiceTypeNodePort
 	httpPort := int32(13161)
-	cr := NewCryostat()
-	cr.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{
-		Replicas: 1,
-	}
+	cr := r.NewCryostat()
 	cr.Spec.ServiceOptions = &operatorv1beta1.ServiceConfigList{
 		ReportsConfig: &operatorv1beta1.ReportsServiceConfig{
 			HTTPPort: &httpPort,
@@ -288,8 +285,8 @@ func NewCryostatWithReportsSvc() *operatorv1beta1.Cryostat {
 	return cr
 }
 
-func NewCryostatWithCoreNetworkOptions() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithCoreNetworkOptions() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	cr.Spec.NetworkOptions = &operatorv1beta1.NetworkConfigurationList{
 		CoreConfig: &operatorv1beta1.NetworkConfiguration{
 			Annotations: map[string]string{"custom": "annotation"},
@@ -299,8 +296,8 @@ func NewCryostatWithCoreNetworkOptions() *operatorv1beta1.Cryostat {
 	return cr
 }
 
-func NewCryostatWithGrafanaNetworkOptions() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithGrafanaNetworkOptions() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	cr.Spec.NetworkOptions = &operatorv1beta1.NetworkConfigurationList{
 		GrafanaConfig: &operatorv1beta1.NetworkConfiguration{
 			Annotations: map[string]string{"grafana": "annotation"},
@@ -310,8 +307,8 @@ func NewCryostatWithGrafanaNetworkOptions() *operatorv1beta1.Cryostat {
 	return cr
 }
 
-func NewCryostatWithReportsResources() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithReportsResources() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	cr.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{
 		Replicas: 1,
 		Resources: corev1.ResourceRequirements{
@@ -328,8 +325,8 @@ func NewCryostatWithReportsResources() *operatorv1beta1.Cryostat {
 	return cr
 }
 
-func NewCryostatWithReportLowResourceLimit() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithReportLowResourceLimit() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	cr.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{
 		Replicas: 1,
 		Resources: corev1.ResourceRequirements{
@@ -394,14 +391,14 @@ func populateCryostatWithScheduling() *operatorv1beta1.SchedulingConfiguration {
 
 }
 
-func NewCryostatWithScheduling() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithScheduling() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	cr.Spec.SchedulingOptions = populateCryostatWithScheduling()
 	return cr
 }
 
-func NewCryostatWithReportsScheduling() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithReportsScheduling() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	cr.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{
 		Replicas:          1,
 		SchedulingOptions: populateCryostatWithScheduling(),
@@ -410,21 +407,21 @@ func NewCryostatWithReportsScheduling() *operatorv1beta1.Cryostat {
 	return cr
 }
 
-func NewCryostatCertManagerDisabled() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatCertManagerDisabled() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	certManager := false
 	cr.Spec.EnableCertManager = &certManager
 	return cr
 }
 
-func NewCryostatCertManagerUndefined() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatCertManagerUndefined() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	cr.Spec.EnableCertManager = nil
 	return cr
 }
 
-func NewCryostatWithResources() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithResources() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	cr.Spec.Resources = &operatorv1beta1.ResourceConfigList{
 		CoreResources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
@@ -460,8 +457,8 @@ func NewCryostatWithResources() *operatorv1beta1.Cryostat {
 	return cr
 }
 
-func NewCryostatWithLowResourceLimit() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithLowResourceLimit() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	cr.Spec.Resources = &operatorv1beta1.ResourceConfigList{
 		CoreResources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
@@ -485,8 +482,8 @@ func NewCryostatWithLowResourceLimit() *operatorv1beta1.Cryostat {
 	return cr
 }
 
-func NewCryostatWithAuthProperties() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithAuthProperties() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	cr.Spec.AuthProperties = &operatorv1beta1.AuthorizationProperties{
 		ConfigMapName:   "authConfigMapName",
 		Filename:        "auth.properties",
@@ -495,8 +492,8 @@ func NewCryostatWithAuthProperties() *operatorv1beta1.Cryostat {
 	return cr
 }
 
-func NewCryostatWithBuiltInDiscoveryDisabled() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithBuiltInDiscoveryDisabled() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	cr.Spec.TargetDiscoveryOptions = &operatorv1beta1.TargetDiscoveryOptions{
 		BuiltInDiscoveryDisabled: true,
 	}
@@ -516,14 +513,8 @@ func newPVCSpec(storageClass string, storageRequest string,
 	}
 }
 
-func NewMinimalCryostat() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
-	cr.Spec.Minimal = true
-	return cr
-}
-
-func NewCryostatWithJmxCacheOptionsSpec() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithJmxCacheOptionsSpec() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	cr.Spec.JmxCacheOptions = &operatorv1beta1.JmxCacheOptions{
 		TargetCacheSize: 10,
 		TargetCacheTTL:  20,
@@ -531,22 +522,23 @@ func NewCryostatWithJmxCacheOptionsSpec() *operatorv1beta1.Cryostat {
 	return cr
 }
 
-func NewCryostatWithWsConnectionsSpec() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithWsConnectionsSpec() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	cr.Spec.MaxWsConnections = 10
 	return cr
 }
 
-func NewCryostatWithReportSubprocessHeapSpec() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
-	cr.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{
-		SubProcessMaxHeapSize: 500,
+func (r *TestResources) NewCryostatWithReportSubprocessHeapSpec() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
+	if cr.Spec.ReportOptions == nil {
+		cr.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{}
 	}
+	cr.Spec.ReportOptions.SubProcessMaxHeapSize = 500
 	return cr
 }
 
-func NewCryostatWithSecurityOptions() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithSecurityOptions() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	privEscalation := true
 	nonRoot := false
 	runAsUser := int64(0)
@@ -584,25 +576,26 @@ func NewCryostatWithSecurityOptions() *operatorv1beta1.Cryostat {
 	return cr
 }
 
-func NewCryostatWithReportSecurityOptions() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithReportSecurityOptions() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	nonRoot := true
 	privEscalation := false
 	runAsUser := int64(1002)
-	cr.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{
-		SecurityOptions: &operatorv1beta1.ReportsSecurityOptions{
-			PodSecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot: &nonRoot,
-				SeccompProfile: &corev1.SeccompProfile{
-					Type: corev1.SeccompProfileTypeRuntimeDefault,
-				},
+	if cr.Spec.ReportOptions == nil {
+		cr.Spec.ReportOptions = &operatorv1beta1.ReportConfiguration{}
+	}
+	cr.Spec.ReportOptions.SecurityOptions = &operatorv1beta1.ReportsSecurityOptions{
+		PodSecurityContext: &corev1.PodSecurityContext{
+			RunAsNonRoot: &nonRoot,
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
 			},
-			ReportsSecurityContext: &corev1.SecurityContext{
-				AllowPrivilegeEscalation: &privEscalation,
-				RunAsUser:                &runAsUser,
-				Capabilities: &corev1.Capabilities{
-					Drop: []corev1.Capability{"ALL"},
-				},
+		},
+		ReportsSecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: &privEscalation,
+			RunAsUser:                &runAsUser,
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
 			},
 		},
 	}
@@ -611,20 +604,20 @@ func NewCryostatWithReportSecurityOptions() *operatorv1beta1.Cryostat {
 
 var providedDatabaseSecretName string = "credentials-database-secret"
 
-func NewCryostatWithDatabaseSecretProvided() *operatorv1beta1.Cryostat {
-	cr := NewCryostat()
+func (r *TestResources) NewCryostatWithDatabaseSecretProvided() *operatorv1beta1.Cryostat {
+	cr := r.NewCryostat()
 	cr.Spec.JmxCredentialsDatabaseOptions = &operatorv1beta1.JmxCredentialsDatabaseOptions{
 		DatabaseSecretName: &providedDatabaseSecretName,
 	}
 	return cr
 }
 
-func NewCryostatService() *corev1.Service {
+func (r *TestResources) NewCryostatService() *corev1.Service {
 	c := true
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat",
-			Namespace: "default",
+			Namespace: r.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: operatorv1beta1.GroupVersion.String(),
@@ -661,12 +654,12 @@ func NewCryostatService() *corev1.Service {
 	}
 }
 
-func NewGrafanaService() *corev1.Service {
+func (r *TestResources) NewGrafanaService() *corev1.Service {
 	c := true
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat-grafana",
-			Namespace: "default",
+			Namespace: r.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: operatorv1beta1.GroupVersion.String(),
@@ -698,12 +691,12 @@ func NewGrafanaService() *corev1.Service {
 	}
 }
 
-func NewReportsService() *corev1.Service {
+func (r *TestResources) NewReportsService() *corev1.Service {
 	c := true
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat-reports",
-			Namespace: "default",
+			Namespace: r.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: operatorv1beta1.GroupVersion.String(),
@@ -735,8 +728,8 @@ func NewReportsService() *corev1.Service {
 	}
 }
 
-func NewCustomizedCoreService() *corev1.Service {
-	svc := NewCryostatService()
+func (r *TestResources) NewCustomizedCoreService() *corev1.Service {
+	svc := r.NewCryostatService()
 	svc.Spec.Type = corev1.ServiceTypeNodePort
 	svc.Spec.Ports[0].Port = 8080
 	svc.Spec.Ports[1].Port = 9095
@@ -751,8 +744,8 @@ func NewCustomizedCoreService() *corev1.Service {
 	return svc
 }
 
-func NewCustomizedGrafanaService() *corev1.Service {
-	svc := NewGrafanaService()
+func (r *TestResources) NewCustomizedGrafanaService() *corev1.Service {
+	svc := r.NewGrafanaService()
 	svc.Spec.Type = corev1.ServiceTypeNodePort
 	svc.Spec.Ports[0].Port = 8080
 	svc.Annotations = map[string]string{
@@ -766,8 +759,8 @@ func NewCustomizedGrafanaService() *corev1.Service {
 	return svc
 }
 
-func NewCustomizedReportsService() *corev1.Service {
-	svc := NewReportsService()
+func (r *TestResources) NewCustomizedReportsService() *corev1.Service {
+	svc := r.NewReportsService()
 	svc.Spec.Type = corev1.ServiceTypeNodePort
 	svc.Spec.Ports[0].Port = 13161
 	svc.Annotations = map[string]string{
@@ -781,11 +774,11 @@ func NewCustomizedReportsService() *corev1.Service {
 	return svc
 }
 
-func NewTestService() *corev1.Service {
+func (r *TestResources) NewTestService() *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-svc",
-			Namespace: "default",
+			Namespace: r.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
 			ClusterIP: "1.2.3.4",
@@ -799,11 +792,11 @@ func NewTestService() *corev1.Service {
 	}
 }
 
-func NewGrafanaSecret() *corev1.Secret {
+func (r *TestResources) NewGrafanaSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat-grafana-basic",
-			Namespace: "default",
+			Namespace: r.Namespace,
 		},
 		StringData: map[string]string{
 			"GF_SECURITY_ADMIN_USER":     "admin",
@@ -812,11 +805,11 @@ func NewGrafanaSecret() *corev1.Secret {
 	}
 }
 
-func OtherGrafanaSecret() *corev1.Secret {
+func (r *TestResources) OtherGrafanaSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat-grafana-basic",
-			Namespace: "default",
+			Namespace: r.Namespace,
 		},
 		StringData: map[string]string{
 			"GF_SECURITY_ADMIN_USER":     "user",
@@ -825,11 +818,11 @@ func OtherGrafanaSecret() *corev1.Secret {
 	}
 }
 
-func NewCredentialsDatabaseSecret() *corev1.Secret {
+func (r *TestResources) NewCredentialsDatabaseSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat-jmx-credentials-db",
-			Namespace: "default",
+			Namespace: r.Namespace,
 		},
 		StringData: map[string]string{
 			"CRYOSTAT_JMX_CREDENTIALS_DB_PASSWORD": "credentials_database",
@@ -837,11 +830,11 @@ func NewCredentialsDatabaseSecret() *corev1.Secret {
 	}
 }
 
-func OtherCredentialsDatabaseSecret() *corev1.Secret {
+func (r *TestResources) OtherCredentialsDatabaseSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat-jmx-credentials-db",
-			Namespace: "default",
+			Namespace: r.Namespace,
 		},
 		StringData: map[string]string{
 			"CRYOSTAT_JMX_CREDENTIALS_DB_PASSWORD": "other-pass",
@@ -849,11 +842,11 @@ func OtherCredentialsDatabaseSecret() *corev1.Secret {
 	}
 }
 
-func NewJMXSecret() *corev1.Secret {
+func (r *TestResources) NewJMXSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat-jmx-auth",
-			Namespace: "default",
+			Namespace: r.Namespace,
 		},
 		StringData: map[string]string{
 			"CRYOSTAT_RJMX_USER": "cryostat",
@@ -862,11 +855,11 @@ func NewJMXSecret() *corev1.Secret {
 	}
 }
 
-func NewKeystoreSecret() *corev1.Secret {
+func (r *TestResources) NewKeystoreSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat-keystore",
-			Namespace: "default",
+			Namespace: r.Namespace,
 		},
 		StringData: map[string]string{
 			"KEYSTORE_PASS": "keystore",
@@ -874,11 +867,11 @@ func NewKeystoreSecret() *corev1.Secret {
 	}
 }
 
-func OtherJMXSecret() *corev1.Secret {
+func (r *TestResources) OtherJMXSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat-jmx-auth",
-			Namespace: "default",
+			Namespace: r.Namespace,
 		},
 		StringData: map[string]string{
 			"CRYOSTAT_RJMX_USER": "not-cryostat",
@@ -887,18 +880,18 @@ func OtherJMXSecret() *corev1.Secret {
 	}
 }
 
-func NewCryostatCert() *certv1.Certificate {
+func (r *TestResources) NewCryostatCert() *certv1.Certificate {
 	return &certv1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat",
-			Namespace: "default",
+			Namespace: r.Namespace,
 		},
 		Spec: certv1.CertificateSpec{
-			CommonName: "cryostat.default.svc",
+			CommonName: fmt.Sprintf("cryostat.%s.svc", r.Namespace),
 			DNSNames: []string{
 				"cryostat",
-				"cryostat.default.svc",
-				"cryostat.default.svc.cluster.local",
+				fmt.Sprintf("cryostat.%s.svc", r.Namespace),
+				fmt.Sprintf("cryostat.%s.svc.cluster.local", r.Namespace),
 			},
 			SecretName: "cryostat-tls",
 			Keystores: &certv1.CertificateKeystores{
@@ -925,18 +918,18 @@ func NewCryostatCert() *certv1.Certificate {
 	}
 }
 
-func NewGrafanaCert() *certv1.Certificate {
+func (r *TestResources) NewGrafanaCert() *certv1.Certificate {
 	return &certv1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat-grafana",
-			Namespace: "default",
+			Namespace: r.Namespace,
 		},
 		Spec: certv1.CertificateSpec{
-			CommonName: "cryostat-grafana.default.svc",
+			CommonName: fmt.Sprintf("cryostat-grafana.%s.svc", r.Namespace),
 			DNSNames: []string{
 				"cryostat-grafana",
-				"cryostat-grafana.default.svc",
-				"cryostat-grafana.default.svc.cluster.local",
+				fmt.Sprintf("cryostat-grafana.%s.svc", r.Namespace),
+				fmt.Sprintf("cryostat-grafana.%s.svc.cluster.local", r.Namespace),
 				"cryostat-health.local",
 			},
 			SecretName: "cryostat-grafana-tls",
@@ -952,18 +945,18 @@ func NewGrafanaCert() *certv1.Certificate {
 	}
 }
 
-func NewReportsCert() *certv1.Certificate {
+func (r *TestResources) NewReportsCert() *certv1.Certificate {
 	return &certv1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat-reports",
-			Namespace: "default",
+			Namespace: r.Namespace,
 		},
 		Spec: certv1.CertificateSpec{
-			CommonName: "cryostat-reports.default.svc",
+			CommonName: fmt.Sprintf("cryostat-reports.%s.svc", r.Namespace),
 			DNSNames: []string{
 				"cryostat-reports",
-				"cryostat-reports.default.svc",
-				"cryostat-reports.default.svc.cluster.local",
+				fmt.Sprintf("cryostat-reports.%s.svc", r.Namespace),
+				fmt.Sprintf("cryostat-reports.%s.svc.cluster.local", r.Namespace),
 			},
 			SecretName: "cryostat-reports-tls",
 			IssuerRef: certMeta.ObjectReference{
@@ -978,11 +971,11 @@ func NewReportsCert() *certv1.Certificate {
 	}
 }
 
-func NewCACert() *certv1.Certificate {
+func (r *TestResources) NewCACert() *certv1.Certificate {
 	return &certv1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat-ca",
-			Namespace: "default",
+			Namespace: r.Namespace,
 		},
 		Spec: certv1.CertificateSpec{
 			CommonName: "ca.cryostat.cert-manager",
@@ -995,23 +988,11 @@ func NewCACert() *certv1.Certificate {
 	}
 }
 
-func newCASecret(certData []byte) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cryostat-ca",
-			Namespace: "default",
-		},
-		Data: map[string][]byte{
-			corev1.TLSCertKey: certData,
-		},
-	}
-}
-
-func NewSelfSignedIssuer() *certv1.Issuer {
+func (r *TestResources) NewSelfSignedIssuer() *certv1.Issuer {
 	return &certv1.Issuer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat-self-signed",
-			Namespace: "default",
+			Namespace: r.Namespace,
 		},
 		Spec: certv1.IssuerSpec{
 			IssuerConfig: certv1.IssuerConfig{
@@ -1021,11 +1002,11 @@ func NewSelfSignedIssuer() *certv1.Issuer {
 	}
 }
 
-func NewCryostatCAIssuer() *certv1.Issuer {
+func (r *TestResources) NewCryostatCAIssuer() *certv1.Issuer {
 	return &certv1.Issuer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat-ca",
-			Namespace: "default",
+			Namespace: r.Namespace,
 		},
 		Spec: certv1.IssuerSpec{
 			IssuerConfig: certv1.IssuerConfig{
@@ -1037,12 +1018,12 @@ func NewCryostatCAIssuer() *certv1.Issuer {
 	}
 }
 
-func newPVC(spec *corev1.PersistentVolumeClaimSpec, labels map[string]string,
+func (r *TestResources) newPVC(spec *corev1.PersistentVolumeClaimSpec, labels map[string]string,
 	annotations map[string]string) *corev1.PersistentVolumeClaim {
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "cryostat",
-			Namespace:   "default",
+			Namespace:   r.Namespace,
 			Annotations: annotations,
 			Labels:      labels,
 		},
@@ -1050,8 +1031,8 @@ func newPVC(spec *corev1.PersistentVolumeClaimSpec, labels map[string]string,
 	}
 }
 
-func NewDefaultPVC() *corev1.PersistentVolumeClaim {
-	return newPVC(&corev1.PersistentVolumeClaimSpec{
+func (r *TestResources) NewDefaultPVC() *corev1.PersistentVolumeClaim {
+	return r.newPVC(&corev1.PersistentVolumeClaimSpec{
 		AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
@@ -1063,9 +1044,9 @@ func NewDefaultPVC() *corev1.PersistentVolumeClaim {
 	}, nil)
 }
 
-func NewCustomPVC() *corev1.PersistentVolumeClaim {
+func (r *TestResources) NewCustomPVC() *corev1.PersistentVolumeClaim {
 	storageClass := "cool-storage"
-	return newPVC(&corev1.PersistentVolumeClaimSpec{
+	return r.newPVC(&corev1.PersistentVolumeClaimSpec{
 		StorageClassName: &storageClass,
 		AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
 		Resources: corev1.ResourceRequirements{
@@ -1081,9 +1062,9 @@ func NewCustomPVC() *corev1.PersistentVolumeClaim {
 	})
 }
 
-func NewCustomPVCSomeDefault() *corev1.PersistentVolumeClaim {
+func (r *TestResources) NewCustomPVCSomeDefault() *corev1.PersistentVolumeClaim {
 	storageClass := ""
-	return newPVC(&corev1.PersistentVolumeClaimSpec{
+	return r.newPVC(&corev1.PersistentVolumeClaimSpec{
 		StorageClassName: &storageClass,
 		AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 		Resources: corev1.ResourceRequirements{
@@ -1096,8 +1077,8 @@ func NewCustomPVCSomeDefault() *corev1.PersistentVolumeClaim {
 	}, nil)
 }
 
-func NewDefaultPVCWithLabel() *corev1.PersistentVolumeClaim {
-	return newPVC(&corev1.PersistentVolumeClaimSpec{
+func (r *TestResources) NewDefaultPVCWithLabel() *corev1.PersistentVolumeClaim {
+	return r.newPVC(&corev1.PersistentVolumeClaimSpec{
 		AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
@@ -1110,14 +1091,14 @@ func NewDefaultPVCWithLabel() *corev1.PersistentVolumeClaim {
 	}, nil)
 }
 
-func NewDefaultEmptyDir() *corev1.EmptyDirVolumeSource {
+func (r *TestResources) NewDefaultEmptyDir() *corev1.EmptyDirVolumeSource {
 	sizeLimit := resource.MustParse("0")
 	return &corev1.EmptyDirVolumeSource{
 		SizeLimit: &sizeLimit,
 	}
 }
 
-func NewEmptyDirWithSpec() *corev1.EmptyDirVolumeSource {
+func (r *TestResources) NewEmptyDirWithSpec() *corev1.EmptyDirVolumeSource {
 	sizeLimit := resource.MustParse("200Mi")
 	return &corev1.EmptyDirVolumeSource{
 		Medium:    "Memory",
@@ -1125,7 +1106,7 @@ func NewEmptyDirWithSpec() *corev1.EmptyDirVolumeSource {
 	}
 }
 
-func NewCorePorts() []corev1.ContainerPort {
+func (r *TestResources) NewCorePorts() []corev1.ContainerPort {
 	return []corev1.ContainerPort{
 		{
 			ContainerPort: 8181,
@@ -1136,7 +1117,7 @@ func NewCorePorts() []corev1.ContainerPort {
 	}
 }
 
-func NewGrafanaPorts() []corev1.ContainerPort {
+func (r *TestResources) NewGrafanaPorts() []corev1.ContainerPort {
 	return []corev1.ContainerPort{
 		{
 			ContainerPort: 3000,
@@ -1144,7 +1125,7 @@ func NewGrafanaPorts() []corev1.ContainerPort {
 	}
 }
 
-func NewDatasourcePorts() []corev1.ContainerPort {
+func (r *TestResources) NewDatasourcePorts() []corev1.ContainerPort {
 	return []corev1.ContainerPort{
 		{
 			ContainerPort: 8080,
@@ -1152,7 +1133,7 @@ func NewDatasourcePorts() []corev1.ContainerPort {
 	}
 }
 
-func NewReportsPorts() []corev1.ContainerPort {
+func (r *TestResources) NewReportsPorts() []corev1.ContainerPort {
 	return []corev1.ContainerPort{
 		{
 			ContainerPort: 10000,
@@ -1160,9 +1141,7 @@ func NewReportsPorts() []corev1.ContainerPort {
 	}
 }
 
-func NewCoreEnvironmentVariables(
-	minimal bool, tls bool, externalTLS bool, openshift bool,
-	reportsUrl string, authProps bool, ingress bool,
+func (r *TestResources) NewCoreEnvironmentVariables(reportsUrl string, authProps bool, ingress bool,
 	emptyDir bool, builtInDiscoveryDisabled bool, dbSecretProvided bool) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{
@@ -1211,11 +1190,11 @@ func NewCoreEnvironmentVariables(
 	}
 
 	if !emptyDir {
-		envs = append(envs, DatabaseConfigEnvironmentVariables()...)
+		envs = append(envs, r.DatabaseConfigEnvironmentVariables()...)
 	}
 
 	optional := false
-	secretName := NewCredentialsDatabaseSecret().Name
+	secretName := r.NewCredentialsDatabaseSecret().Name
 	if dbSecretProvided {
 		secretName = providedDatabaseSecretName
 	}
@@ -1232,20 +1211,20 @@ func NewCoreEnvironmentVariables(
 		},
 	})
 
-	if !minimal {
+	if !r.Minimal {
 		envs = append(envs,
 			corev1.EnvVar{
 				Name:  "GRAFANA_DATASOURCE_URL",
 				Value: "http://127.0.0.1:8080",
 			})
 	}
-	if !tls {
+	if !r.TLS {
 		envs = append(envs,
 			corev1.EnvVar{
 				Name:  "CRYOSTAT_DISABLE_SSL",
 				Value: "true",
 			})
-		if externalTLS {
+		if r.ExternalTLS {
 			envs = append(envs,
 				corev1.EnvVar{
 					Name:  "CRYOSTAT_SSL_PROXIED",
@@ -1259,7 +1238,7 @@ func NewCoreEnvironmentVariables(
 		})
 	}
 
-	if openshift {
+	if r.OpenShift {
 		envs = append(envs,
 			corev1.EnvVar{
 				Name:  "CRYOSTAT_PLATFORM",
@@ -1284,9 +1263,9 @@ func NewCoreEnvironmentVariables(
 				Value: "custom-auth-cluster-role",
 			})
 		}
-		envs = append(envs, newNetworkEnvironmentVariables(minimal, tls, externalTLS)...)
+		envs = append(envs, r.newNetworkEnvironmentVariables()...)
 	} else if ingress { // On Kubernetes
-		envs = append(envs, newNetworkEnvironmentVariables(minimal, tls, externalTLS)...)
+		envs = append(envs, r.newNetworkEnvironmentVariables()...)
 	}
 
 	if reportsUrl != "" {
@@ -1305,7 +1284,7 @@ func NewCoreEnvironmentVariables(
 	return envs
 }
 
-func DatabaseConfigEnvironmentVariables() []corev1.EnvVar {
+func (r *TestResources) DatabaseConfigEnvironmentVariables() []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
 			Name:  "CRYOSTAT_JDBC_URL",
@@ -1334,14 +1313,14 @@ func DatabaseConfigEnvironmentVariables() []corev1.EnvVar {
 	}
 }
 
-func newNetworkEnvironmentVariables(minimal, tls, externalTLS bool) []corev1.EnvVar {
+func (r *TestResources) newNetworkEnvironmentVariables() []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{
 			Name:  "CRYOSTAT_WEB_HOST",
 			Value: "cryostat.example.com",
 		},
 	}
-	if externalTLS {
+	if r.ExternalTLS {
 		envs = append(envs,
 			corev1.EnvVar{
 				Name:  "CRYOSTAT_EXT_WEB_PORT",
@@ -1354,8 +1333,8 @@ func newNetworkEnvironmentVariables(minimal, tls, externalTLS bool) []corev1.Env
 				Value: "80",
 			})
 	}
-	if !minimal {
-		if externalTLS {
+	if !r.Minimal {
+		if r.ExternalTLS {
 			envs = append(envs,
 				corev1.EnvVar{
 					Name:  "GRAFANA_DASHBOARD_EXT_URL",
@@ -1368,7 +1347,7 @@ func newNetworkEnvironmentVariables(minimal, tls, externalTLS bool) []corev1.Env
 					Value: "http://cryostat-grafana.example.com",
 				})
 		}
-		if tls {
+		if r.TLS {
 			envs = append(envs,
 				corev1.EnvVar{
 					Name:  "GRAFANA_DASHBOARD_URL",
@@ -1384,14 +1363,15 @@ func newNetworkEnvironmentVariables(minimal, tls, externalTLS bool) []corev1.Env
 	}
 	return envs
 }
-func NewGrafanaEnvironmentVariables(tls bool) []corev1.EnvVar {
+
+func (r *TestResources) NewGrafanaEnvironmentVariables() []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{
 			Name:  "JFR_DATASOURCE_URL",
 			Value: "http://127.0.0.1:8080",
 		},
 	}
-	if tls {
+	if r.TLS {
 		envs = append(envs, corev1.EnvVar{
 			Name:  "GF_SERVER_PROTOCOL",
 			Value: "https",
@@ -1406,7 +1386,7 @@ func NewGrafanaEnvironmentVariables(tls bool) []corev1.EnvVar {
 	return envs
 }
 
-func NewDatasourceEnvironmentVariables() []corev1.EnvVar {
+func (r *TestResources) NewDatasourceEnvironmentVariables() []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
 			Name:  "LISTEN_HOST",
@@ -1415,7 +1395,7 @@ func NewDatasourceEnvironmentVariables() []corev1.EnvVar {
 	}
 }
 
-func NewReportsEnvironmentVariables(tls bool, resources *corev1.ResourceRequirements) []corev1.EnvVar {
+func (r *TestResources) NewReportsEnvironmentVariables(resources *corev1.ResourceRequirements) []corev1.EnvVar {
 	cpus := resources.Requests.Cpu().Value()
 	if limit := resources.Limits; limit != nil {
 		if cpu := limit.Cpu(); limit != nil {
@@ -1433,7 +1413,7 @@ func NewReportsEnvironmentVariables(tls bool, resources *corev1.ResourceRequirem
 			Value: opts,
 		},
 	}
-	if tls {
+	if r.TLS {
 		envs = append(envs, corev1.EnvVar{
 			Name:  "QUARKUS_HTTP_SSL_PORT",
 			Value: "10000",
@@ -1456,7 +1436,7 @@ func NewReportsEnvironmentVariables(tls bool, resources *corev1.ResourceRequirem
 	return envs
 }
 
-func NewCoreEnvFromSource(tls bool) []corev1.EnvFromSource {
+func (r *TestResources) NewCoreEnvFromSource() []corev1.EnvFromSource {
 	envsFrom := []corev1.EnvFromSource{
 		{
 			SecretRef: &corev1.SecretEnvSource{
@@ -1466,7 +1446,7 @@ func NewCoreEnvFromSource(tls bool) []corev1.EnvFromSource {
 			},
 		},
 	}
-	if tls {
+	if r.TLS {
 		envsFrom = append(envsFrom, corev1.EnvFromSource{
 			SecretRef: &corev1.SecretEnvSource{
 				LocalObjectReference: corev1.LocalObjectReference{
@@ -1478,7 +1458,7 @@ func NewCoreEnvFromSource(tls bool) []corev1.EnvFromSource {
 	return envsFrom
 }
 
-func NewGrafanaEnvFromSource() []corev1.EnvFromSource {
+func (r *TestResources) NewGrafanaEnvFromSource() []corev1.EnvFromSource {
 	return []corev1.EnvFromSource{
 		{
 			SecretRef: &corev1.SecretEnvSource{
@@ -1490,7 +1470,7 @@ func NewGrafanaEnvFromSource() []corev1.EnvFromSource {
 	}
 }
 
-func NewWsConnectionsEnv() []corev1.EnvVar {
+func (r *TestResources) NewWsConnectionsEnv() []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
 			Name:  "CRYOSTAT_MAX_WS_CONNECTIONS",
@@ -1499,7 +1479,7 @@ func NewWsConnectionsEnv() []corev1.EnvVar {
 	}
 }
 
-func NewReportSubprocessHeapEnv() []corev1.EnvVar {
+func (r *TestResources) NewReportSubprocessHeapEnv() []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
 			Name:  "CRYOSTAT_REPORT_GENERATION_MAX_HEAP",
@@ -1508,7 +1488,7 @@ func NewReportSubprocessHeapEnv() []corev1.EnvVar {
 	}
 }
 
-func NewJmxCacheOptionsEnv() []corev1.EnvVar {
+func (r *TestResources) NewJmxCacheOptionsEnv() []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
 			Name:  "CRYOSTAT_TARGET_CACHE_SIZE",
@@ -1521,7 +1501,7 @@ func NewJmxCacheOptionsEnv() []corev1.EnvVar {
 	}
 }
 
-func NewCoreVolumeMounts(tls bool) []corev1.VolumeMount {
+func (r *TestResources) NewCoreVolumeMounts() []corev1.VolumeMount {
 	mounts := []corev1.VolumeMount{
 		{
 			Name:      "cryostat",
@@ -1565,7 +1545,7 @@ func NewCoreVolumeMounts(tls bool) []corev1.VolumeMount {
 			MountPath: "/truststore/operator",
 		},
 	}
-	if tls {
+	if r.TLS {
 		mounts = append(mounts,
 			corev1.VolumeMount{
 				Name:      "keystore",
@@ -1576,9 +1556,9 @@ func NewCoreVolumeMounts(tls bool) []corev1.VolumeMount {
 	return mounts
 }
 
-func NewGrafanaVolumeMounts(tls bool) []corev1.VolumeMount {
+func (r *TestResources) NewGrafanaVolumeMounts() []corev1.VolumeMount {
 	mounts := []corev1.VolumeMount{}
-	if tls {
+	if r.TLS {
 		mounts = append(mounts,
 			corev1.VolumeMount{
 				Name:      "grafana-tls-secret",
@@ -1589,9 +1569,9 @@ func NewGrafanaVolumeMounts(tls bool) []corev1.VolumeMount {
 	return mounts
 }
 
-func NewReportsVolumeMounts(tls bool) []corev1.VolumeMount {
+func (r *TestResources) NewReportsVolumeMounts() []corev1.VolumeMount {
 	mounts := []corev1.VolumeMount{}
-	if tls {
+	if r.TLS {
 		mounts = append(mounts,
 			corev1.VolumeMount{
 				Name:      "reports-tls-secret",
@@ -1602,8 +1582,8 @@ func NewReportsVolumeMounts(tls bool) []corev1.VolumeMount {
 	return mounts
 }
 
-func NewVolumeMountsWithTemplates(tls bool) []corev1.VolumeMount {
-	return append(NewCoreVolumeMounts(tls),
+func (r *TestResources) NewVolumeMountsWithTemplates() []corev1.VolumeMount {
+	return append(r.NewCoreVolumeMounts(),
 		corev1.VolumeMount{
 			Name:      "template-templateCM1",
 			ReadOnly:  true,
@@ -1618,11 +1598,11 @@ func NewVolumeMountsWithTemplates(tls bool) []corev1.VolumeMount {
 		})
 }
 
-func NewVolumeMountsWithAuthProperties(tls bool) []corev1.VolumeMount {
-	return append(NewCoreVolumeMounts(tls), NewAuthPropertiesVolumeMount())
+func (r *TestResources) NewVolumeMountsWithAuthProperties() []corev1.VolumeMount {
+	return append(r.NewCoreVolumeMounts(), r.NewAuthPropertiesVolumeMount())
 }
 
-func NewAuthPropertiesVolumeMount() corev1.VolumeMount {
+func (r *TestResources) NewAuthPropertiesVolumeMount() corev1.VolumeMount {
 	return corev1.VolumeMount{
 		Name:      "auth-properties-authConfigMapName",
 		ReadOnly:  true,
@@ -1631,22 +1611,22 @@ func NewAuthPropertiesVolumeMount() corev1.VolumeMount {
 	}
 }
 
-func NewCoreLivenessProbe(tls bool) *corev1.Probe {
+func (r *TestResources) NewCoreLivenessProbe() *corev1.Probe {
 	return &corev1.Probe{
-		ProbeHandler: newCoreProbeHandler(tls),
+		ProbeHandler: r.newCoreProbeHandler(),
 	}
 }
 
-func NewCoreStartupProbe(tls bool) *corev1.Probe {
+func (r *TestResources) NewCoreStartupProbe() *corev1.Probe {
 	return &corev1.Probe{
-		ProbeHandler:     newCoreProbeHandler(tls),
+		ProbeHandler:     r.newCoreProbeHandler(),
 		FailureThreshold: 18,
 	}
 }
 
-func newCoreProbeHandler(tls bool) corev1.ProbeHandler {
+func (r *TestResources) newCoreProbeHandler() corev1.ProbeHandler {
 	protocol := corev1.URISchemeHTTPS
-	if !tls {
+	if !r.TLS {
 		protocol = corev1.URISchemeHTTP
 	}
 	return corev1.ProbeHandler{
@@ -1658,9 +1638,9 @@ func newCoreProbeHandler(tls bool) corev1.ProbeHandler {
 	}
 }
 
-func NewGrafanaLivenessProbe(tls bool) *corev1.Probe {
+func (r *TestResources) NewGrafanaLivenessProbe() *corev1.Probe {
 	protocol := corev1.URISchemeHTTPS
-	if !tls {
+	if !r.TLS {
 		protocol = corev1.URISchemeHTTP
 	}
 	return &corev1.Probe{
@@ -1674,7 +1654,7 @@ func NewGrafanaLivenessProbe(tls bool) *corev1.Probe {
 	}
 }
 
-func NewDatasourceLivenessProbe() *corev1.Probe {
+func (r *TestResources) NewDatasourceLivenessProbe() *corev1.Probe {
 	return &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			Exec: &corev1.ExecAction{
@@ -1684,9 +1664,9 @@ func NewDatasourceLivenessProbe() *corev1.Probe {
 	}
 }
 
-func NewReportsLivenessProbe(tls bool) *corev1.Probe {
+func (r *TestResources) NewReportsLivenessProbe() *corev1.Probe {
 	protocol := corev1.URISchemeHTTPS
-	if !tls {
+	if !r.TLS {
 		protocol = corev1.URISchemeHTTP
 	}
 	return &corev1.Probe{
@@ -1700,7 +1680,7 @@ func NewReportsLivenessProbe(tls bool) *corev1.Probe {
 	}
 }
 
-func NewMainDeploymentSelector() *metav1.LabelSelector {
+func (r *TestResources) NewMainDeploymentSelector() *metav1.LabelSelector {
 	return &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"app":       "cryostat",
@@ -1710,7 +1690,7 @@ func NewMainDeploymentSelector() *metav1.LabelSelector {
 	}
 }
 
-func NewReportsDeploymentSelector() *metav1.LabelSelector {
+func (r *TestResources) NewReportsDeploymentSelector() *metav1.LabelSelector {
 	return &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"app":       "cryostat",
@@ -1720,18 +1700,18 @@ func NewReportsDeploymentSelector() *metav1.LabelSelector {
 	}
 }
 
-func NewMainDeploymentStrategy() appsv1.DeploymentStrategy {
+func (r *TestResources) NewMainDeploymentStrategy() appsv1.DeploymentStrategy {
 	return appsv1.DeploymentStrategy{
 		Type: appsv1.RecreateDeploymentStrategyType,
 	}
 }
 
-func OtherDeployment() *appsv1.Deployment {
+func (r *TestResources) OtherDeployment() *appsv1.Deployment {
 	replicas := int32(2)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat",
-			Namespace: "default",
+			Namespace: r.Namespace,
 			Labels: map[string]string{
 				"app":   "something-else",
 				"other": "label",
@@ -1745,7 +1725,7 @@ func OtherDeployment() *appsv1.Deployment {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cryostat",
-					Namespace: "default",
+					Namespace: r.Namespace,
 					Labels: map[string]string{
 						"app": "something-app",
 					},
@@ -1759,19 +1739,19 @@ func OtherDeployment() *appsv1.Deployment {
 					},
 				},
 			},
-			Selector: NewMainDeploymentSelector(),
+			Selector: r.NewMainDeploymentSelector(),
 			Replicas: &replicas,
 		},
 	}
 }
 
-func NewVolumes(minimal bool, tls bool) []corev1.Volume {
-	return newVolumes(minimal, tls, nil)
+func (r *TestResources) NewVolumes() []corev1.Volume {
+	return r.newVolumes(nil)
 }
 
-func NewVolumesWithSecrets(tls bool) []corev1.Volume {
+func (r *TestResources) NewVolumesWithSecrets() []corev1.Volume {
 	mode := int32(0440)
-	return newVolumes(false, tls, []corev1.VolumeProjection{
+	return r.newVolumes([]corev1.VolumeProjection{
 		{
 			Secret: &corev1.SecretProjection{
 				LocalObjectReference: corev1.LocalObjectReference{
@@ -1803,9 +1783,9 @@ func NewVolumesWithSecrets(tls bool) []corev1.Volume {
 	})
 }
 
-func NewVolumesWithTemplates(tls bool) []corev1.Volume {
+func (r *TestResources) NewVolumesWithTemplates() []corev1.Volume {
 	mode := int32(0440)
-	return append(NewVolumes(false, tls),
+	return append(r.NewVolumes(),
 		corev1.Volume{
 			Name: "template-templateCM1",
 			VolumeSource: corev1.VolumeSource{
@@ -1842,11 +1822,11 @@ func NewVolumesWithTemplates(tls bool) []corev1.Volume {
 		})
 }
 
-func NewVolumeWithAuthProperties(tls bool) []corev1.Volume {
-	return append(NewVolumes(false, tls), NewAuthPropertiesVolume())
+func (r *TestResources) NewVolumeWithAuthProperties() []corev1.Volume {
+	return append(r.NewVolumes(), r.NewAuthPropertiesVolume())
 }
 
-func NewAuthPropertiesVolume() corev1.Volume {
+func (r *TestResources) NewAuthPropertiesVolume() corev1.Volume {
 	readOnlyMode := int32(0440)
 	return corev1.Volume{
 		Name: "auth-properties-authConfigMapName",
@@ -1867,7 +1847,7 @@ func NewAuthPropertiesVolume() corev1.Volume {
 	}
 }
 
-func newVolumes(minimal bool, tls bool, certProjections []corev1.VolumeProjection) []corev1.Volume {
+func (r *TestResources) newVolumes(certProjections []corev1.VolumeProjection) []corev1.Volume {
 	readOnlymode := int32(0440)
 	volumes := []corev1.Volume{
 		{
@@ -1881,7 +1861,7 @@ func newVolumes(minimal bool, tls bool, certProjections []corev1.VolumeProjectio
 		},
 	}
 	projs := append([]corev1.VolumeProjection{}, certProjections...)
-	if tls {
+	if r.TLS {
 		projs = append(projs, corev1.VolumeProjection{
 			Secret: &corev1.SecretProjection{
 				LocalObjectReference: corev1.LocalObjectReference{
@@ -1913,7 +1893,7 @@ func newVolumes(minimal bool, tls bool, certProjections []corev1.VolumeProjectio
 					},
 				},
 			})
-		if !minimal {
+		if !r.Minimal {
 			volumes = append(volumes,
 				corev1.Volume{
 					Name: "grafana-tls-secret",
@@ -1939,8 +1919,8 @@ func newVolumes(minimal bool, tls bool, certProjections []corev1.VolumeProjectio
 	return volumes
 }
 
-func NewReportsVolumes(tls bool) []corev1.Volume {
-	if !tls {
+func (r *TestResources) NewReportsVolumes() []corev1.Volume {
+	if !r.TLS {
 		return nil
 	}
 	return []corev1.Volume{
@@ -1955,10 +1935,10 @@ func NewReportsVolumes(tls bool) []corev1.Volume {
 	}
 }
 
-func commonDefaultPodSecurityContext(openshift bool, fsGroup *int64) *corev1.PodSecurityContext {
+func (r *TestResources) commonDefaultPodSecurityContext(fsGroup *int64) *corev1.PodSecurityContext {
 	nonRoot := true
 	var seccompProfile *corev1.SeccompProfile
-	if !openshift {
+	if !r.OpenShift {
 		seccompProfile = &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		}
@@ -1970,7 +1950,7 @@ func commonDefaultPodSecurityContext(openshift bool, fsGroup *int64) *corev1.Pod
 	}
 }
 
-func commonDefaultSecurityContext() *corev1.SecurityContext {
+func (r *TestResources) commonDefaultSecurityContext() *corev1.SecurityContext {
 	privEscalation := false
 	return &corev1.SecurityContext{
 		Capabilities: &corev1.Capabilities{
@@ -1982,74 +1962,74 @@ func commonDefaultSecurityContext() *corev1.SecurityContext {
 	}
 }
 
-func NewPodSecurityContext(cr *operatorv1beta1.Cryostat, openshift bool) *corev1.PodSecurityContext {
+func (r *TestResources) NewPodSecurityContext(cr *operatorv1beta1.Cryostat) *corev1.PodSecurityContext {
 	if cr.Spec.SecurityOptions != nil && cr.Spec.SecurityOptions.PodSecurityContext != nil {
 		return cr.Spec.SecurityOptions.PodSecurityContext
 	}
 	fsGroup := int64(18500)
-	return commonDefaultPodSecurityContext(openshift, &fsGroup)
+	return r.commonDefaultPodSecurityContext(&fsGroup)
 }
 
-func NewReportPodSecurityContext(cr *operatorv1beta1.Cryostat, openshift bool) *corev1.PodSecurityContext {
+func (r *TestResources) NewReportPodSecurityContext(cr *operatorv1beta1.Cryostat) *corev1.PodSecurityContext {
 	if cr.Spec.ReportOptions != nil && cr.Spec.ReportOptions.SecurityOptions != nil && cr.Spec.ReportOptions.SecurityOptions.PodSecurityContext != nil {
 		return cr.Spec.ReportOptions.SecurityOptions.PodSecurityContext
 	}
-	return commonDefaultPodSecurityContext(openshift, nil)
+	return r.commonDefaultPodSecurityContext(nil)
 }
 
-func NewCoreSecurityContext(cr *operatorv1beta1.Cryostat) *corev1.SecurityContext {
+func (r *TestResources) NewCoreSecurityContext(cr *operatorv1beta1.Cryostat) *corev1.SecurityContext {
 	if cr.Spec.SecurityOptions != nil && cr.Spec.SecurityOptions.CoreSecurityContext != nil {
 		return cr.Spec.SecurityOptions.CoreSecurityContext
 	}
-	return commonDefaultSecurityContext()
+	return r.commonDefaultSecurityContext()
 }
 
-func NewGrafanaSecurityContext(cr *operatorv1beta1.Cryostat) *corev1.SecurityContext {
+func (r *TestResources) NewGrafanaSecurityContext(cr *operatorv1beta1.Cryostat) *corev1.SecurityContext {
 	if cr.Spec.SecurityOptions != nil && cr.Spec.SecurityOptions.GrafanaSecurityContext != nil {
 		return cr.Spec.SecurityOptions.GrafanaSecurityContext
 	}
-	return commonDefaultSecurityContext()
+	return r.commonDefaultSecurityContext()
 }
 
-func NewDatasourceSecurityContext(cr *operatorv1beta1.Cryostat) *corev1.SecurityContext {
+func (r *TestResources) NewDatasourceSecurityContext(cr *operatorv1beta1.Cryostat) *corev1.SecurityContext {
 	if cr.Spec.SecurityOptions != nil && cr.Spec.SecurityOptions.DataSourceSecurityContext != nil {
 		return cr.Spec.SecurityOptions.DataSourceSecurityContext
 	}
-	return commonDefaultSecurityContext()
+	return r.commonDefaultSecurityContext()
 }
 
-func NewReportSecurityContext(cr *operatorv1beta1.Cryostat) *corev1.SecurityContext {
+func (r *TestResources) NewReportSecurityContext(cr *operatorv1beta1.Cryostat) *corev1.SecurityContext {
 	if cr.Spec.ReportOptions != nil && cr.Spec.ReportOptions.SecurityOptions != nil && cr.Spec.ReportOptions.SecurityOptions.ReportsSecurityContext != nil {
 		return cr.Spec.ReportOptions.SecurityOptions.ReportsSecurityContext
 	}
-	return commonDefaultSecurityContext()
+	return r.commonDefaultSecurityContext()
 }
 
-func NewCoreRoute(tls bool) *routev1.Route {
-	return newRoute("cryostat", 8181, tls)
+func (r *TestResources) NewCoreRoute() *routev1.Route {
+	return r.newRoute("cryostat", 8181)
 }
 
-func NewCustomCoreRoute(tls bool) *routev1.Route {
-	route := NewCoreRoute(tls)
+func (r *TestResources) NewCustomCoreRoute() *routev1.Route {
+	route := r.NewCoreRoute()
 	route.Annotations = map[string]string{"custom": "annotation"}
 	route.Labels = map[string]string{"custom": "label"}
 	return route
 }
 
-func NewGrafanaRoute(tls bool) *routev1.Route {
-	return newRoute("cryostat-grafana", 3000, tls)
+func (r *TestResources) NewGrafanaRoute() *routev1.Route {
+	return r.newRoute("cryostat-grafana", 3000)
 }
 
-func NewCustomGrafanaRoute(tls bool) *routev1.Route {
-	route := NewGrafanaRoute(tls)
+func (r *TestResources) NewCustomGrafanaRoute() *routev1.Route {
+	route := r.NewGrafanaRoute()
 	route.Annotations = map[string]string{"grafana": "annotation"}
 	route.Labels = map[string]string{"grafana": "label"}
 	return route
 }
 
-func newRoute(name string, port int, tls bool) *routev1.Route {
+func (r *TestResources) newRoute(name string, port int) *routev1.Route {
 	var routeTLS *routev1.TLSConfig
-	if !tls {
+	if !r.TLS {
 		routeTLS = &routev1.TLSConfig{
 			Termination:                   routev1.TLSTerminationEdge,
 			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
@@ -2063,7 +2043,7 @@ func newRoute(name string, port int, tls bool) *routev1.Route {
 	return &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: "default",
+			Namespace: r.Namespace,
 		},
 		Spec: routev1.RouteSpec{
 			To: routev1.RouteTargetReference{
@@ -2078,11 +2058,11 @@ func newRoute(name string, port int, tls bool) *routev1.Route {
 	}
 }
 
-func OtherCoreRoute() *routev1.Route {
+func (r *TestResources) OtherCoreRoute() *routev1.Route {
 	return &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "cryostat",
-			Namespace:   "default",
+			Namespace:   r.Namespace,
 			Annotations: map[string]string{"custom": "annotation"},
 			Labels:      map[string]string{"custom": "label"},
 		},
@@ -2104,11 +2084,11 @@ func OtherCoreRoute() *routev1.Route {
 	}
 }
 
-func OtherGrafanaRoute() *routev1.Route {
+func (r *TestResources) OtherGrafanaRoute() *routev1.Route {
 	return &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "cryostat-grafana",
-			Namespace:   "default",
+			Namespace:   r.Namespace,
 			Annotations: map[string]string{"grafana": "annotation"},
 			Labels:      map[string]string{"grafana": "label"},
 		},
@@ -2124,12 +2104,12 @@ func OtherGrafanaRoute() *routev1.Route {
 	}
 }
 
-func OtherCoreIngress() *netv1.Ingress {
+func (r *TestResources) OtherCoreIngress() *netv1.Ingress {
 	pathtype := netv1.PathTypePrefix
 	return &netv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "cryostat",
-			Namespace:   "default",
+			Namespace:   r.Namespace,
 			Annotations: map[string]string{"custom": "annotation"},
 			Labels:      map[string]string{"custom": "label"},
 		},
@@ -2161,12 +2141,12 @@ func OtherCoreIngress() *netv1.Ingress {
 	}
 }
 
-func OtherGrafanaIngress() *netv1.Ingress {
+func (r *TestResources) OtherGrafanaIngress() *netv1.Ingress {
 	pathtype := netv1.PathTypePrefix
 	return &netv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "cryostat-grafana",
-			Namespace:   "default",
+			Namespace:   r.Namespace,
 			Annotations: map[string]string{"grafana": "annotation"},
 			Labels:      map[string]string{"grafana": "label"},
 		},
@@ -2198,12 +2178,12 @@ func OtherGrafanaIngress() *netv1.Ingress {
 	}
 }
 
-func NewNetworkConfigurationList(tls bool) operatorv1beta1.NetworkConfigurationList {
-	coreSVC := NewCryostatService()
-	coreIng := NewNetworkConfiguration(coreSVC.Name, coreSVC.Spec.Ports[0].Port, tls)
+func (r *TestResources) newNetworkConfigurationList() operatorv1beta1.NetworkConfigurationList {
+	coreSVC := r.NewCryostatService()
+	coreIng := r.newNetworkConfiguration(coreSVC.Name, coreSVC.Spec.Ports[0].Port)
 
-	grafanaSVC := NewGrafanaService()
-	grafanaIng := NewNetworkConfiguration(grafanaSVC.Name, grafanaSVC.Spec.Ports[0].Port, tls)
+	grafanaSVC := r.NewGrafanaService()
+	grafanaIng := r.newNetworkConfiguration(grafanaSVC.Name, grafanaSVC.Spec.Ports[0].Port)
 
 	return operatorv1beta1.NetworkConfigurationList{
 		CoreConfig:    &coreIng,
@@ -2211,12 +2191,12 @@ func NewNetworkConfigurationList(tls bool) operatorv1beta1.NetworkConfigurationL
 	}
 }
 
-func NewNetworkConfiguration(svcName string, svcPort int32, tls bool) operatorv1beta1.NetworkConfiguration {
+func (r *TestResources) newNetworkConfiguration(svcName string, svcPort int32) operatorv1beta1.NetworkConfiguration {
 	pathtype := netv1.PathTypePrefix
 	host := svcName + ".example.com"
 
 	var ingressTLS []netv1.IngressTLS
-	if tls {
+	if r.ExternalTLS {
 		ingressTLS = []netv1.IngressTLS{{}}
 	}
 	return operatorv1beta1.NetworkConfiguration{
@@ -2251,9 +2231,9 @@ func NewNetworkConfiguration(svcName string, svcPort int32, tls bool) operatorv1
 	}
 }
 
-func NewServiceAccount(isOpenShift bool) *corev1.ServiceAccount {
+func (r *TestResources) NewServiceAccount() *corev1.ServiceAccount {
 	var annotations map[string]string
-	if isOpenShift {
+	if r.OpenShift {
 		annotations = map[string]string{
 			"serviceaccounts.openshift.io/oauth-redirectreference.route": `{"metadata":{"creationTimestamp":null},"reference":{"group":"","kind":"Route","name":"cryostat"}}`,
 		}
@@ -2262,7 +2242,7 @@ func NewServiceAccount(isOpenShift bool) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat",
-			Namespace: "default",
+			Namespace: r.Namespace,
 			Labels: map[string]string{
 				"app": "cryostat",
 			},
@@ -2271,12 +2251,12 @@ func NewServiceAccount(isOpenShift bool) *corev1.ServiceAccount {
 	}
 }
 
-func OtherServiceAccount() *corev1.ServiceAccount {
+func (r *TestResources) OtherServiceAccount() *corev1.ServiceAccount {
 	disable := false
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat",
-			Namespace: "default",
+			Namespace: r.Namespace,
 			Labels: map[string]string{
 				"app":   "not-cryostat",
 				"other": "label",
@@ -2302,7 +2282,7 @@ func OtherServiceAccount() *corev1.ServiceAccount {
 	}
 }
 
-func NewRole() *rbacv1.Role {
+func (r *TestResources) NewRole() *rbacv1.Role {
 	rules := []rbacv1.PolicyRule{
 		{
 			Verbs:     []string{"get", "list", "watch"},
@@ -2333,17 +2313,17 @@ func NewRole() *rbacv1.Role {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat",
-			Namespace: "default",
+			Namespace: r.Namespace,
 		},
 		Rules: rules,
 	}
 }
 
-func OtherRole() *rbacv1.Role {
+func (r *TestResources) OtherRole() *rbacv1.Role {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat",
-			Namespace: "default",
+			Namespace: r.Namespace,
 			Labels: map[string]string{
 				"test": "label",
 			},
@@ -2358,7 +2338,7 @@ func OtherRole() *rbacv1.Role {
 	}
 }
 
-func NewAuthClusterRole() *rbacv1.ClusterRole {
+func (r *TestResources) NewAuthClusterRole() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "custom-auth-cluster-role",
@@ -2378,17 +2358,17 @@ func NewAuthClusterRole() *rbacv1.ClusterRole {
 	}
 }
 
-func NewRoleBinding() *rbacv1.RoleBinding {
+func (r *TestResources) NewRoleBinding() *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat",
-			Namespace: "default",
+			Namespace: r.Namespace,
 		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      rbacv1.ServiceAccountKind,
 				Name:      "cryostat",
-				Namespace: "default",
+				Namespace: r.Namespace,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -2399,11 +2379,11 @@ func NewRoleBinding() *rbacv1.RoleBinding {
 	}
 }
 
-func OtherRoleBinding() *rbacv1.RoleBinding {
+func (r *TestResources) OtherRoleBinding() *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cryostat",
-			Namespace: "default",
+			Namespace: r.Namespace,
 			Labels: map[string]string{
 				"test": "label",
 			},
@@ -2412,7 +2392,7 @@ func OtherRoleBinding() *rbacv1.RoleBinding {
 			{
 				Kind:      rbacv1.ServiceAccountKind,
 				Name:      "not-cryostat",
-				Namespace: "default",
+				Namespace: r.Namespace,
 			},
 			{
 				Kind: rbacv1.UserKind,
@@ -2427,16 +2407,16 @@ func OtherRoleBinding() *rbacv1.RoleBinding {
 	}
 }
 
-func NewClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+func (r *TestResources) NewClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "cryostat-9ecd5050500c2566765bc593edfcce12434283e5da32a27476bc4a1569304a02",
+			Name: "cryostat-ffc3f6d167f69f78c5882a8f67be7efcc7f2f9062145a98f99f7863922c52b10",
 		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      rbacv1.ServiceAccountKind,
 				Name:      "cryostat",
-				Namespace: "default",
+				Namespace: r.Namespace,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -2447,10 +2427,10 @@ func NewClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	}
 }
 
-func OtherClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+func (r *TestResources) OtherClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "cryostat-9ecd5050500c2566765bc593edfcce12434283e5da32a27476bc4a1569304a02",
+			Name: "cryostat-ffc3f6d167f69f78c5882a8f67be7efcc7f2f9062145a98f99f7863922c52b10",
 			Labels: map[string]string{
 				"test": "label",
 			},
@@ -2459,7 +2439,7 @@ func OtherClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 			{
 				Kind:      rbacv1.ServiceAccountKind,
 				Name:      "not-cryostat",
-				Namespace: "default",
+				Namespace: r.Namespace,
 			},
 			{
 				Kind: rbacv1.UserKind,
@@ -2474,11 +2454,11 @@ func OtherClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	}
 }
 
-func NewTemplateConfigMap() *corev1.ConfigMap {
+func (r *TestResources) NewTemplateConfigMap() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "templateCM1",
-			Namespace: "default",
+			Namespace: r.Namespace,
 		},
 		Data: map[string]string{
 			"template.jfc": "XML template data",
@@ -2486,11 +2466,11 @@ func NewTemplateConfigMap() *corev1.ConfigMap {
 	}
 }
 
-func NewOtherTemplateConfigMap() *corev1.ConfigMap {
+func (r *TestResources) NewOtherTemplateConfigMap() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "templateCM2",
-			Namespace: "default",
+			Namespace: r.Namespace,
 		},
 		Data: map[string]string{
 			"other-template.jfc": "more XML template data",
@@ -2498,11 +2478,11 @@ func NewOtherTemplateConfigMap() *corev1.ConfigMap {
 	}
 }
 
-func NewAuthPropertiesConfigMap() *corev1.ConfigMap {
+func (r *TestResources) NewAuthPropertiesConfigMap() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "authConfigMapName",
-			Namespace: "default",
+			Namespace: r.Namespace,
 		},
 		Data: map[string]string{
 			"auth.properties": "CRYOSTAT_RESOURCE=resources.group\nANOTHER_CRYOSTAT_RESOURCE=another_resources.another_group",
@@ -2510,26 +2490,26 @@ func NewAuthPropertiesConfigMap() *corev1.ConfigMap {
 	}
 }
 
-func NewNamespace() *corev1.Namespace {
+func (r *TestResources) NewNamespace() *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "default",
+			Name: r.Namespace,
 		},
 	}
 }
 
-func NewNamespaceWithSCCSupGroups() *corev1.Namespace {
-	ns := NewNamespace()
+func (r *TestResources) NewNamespaceWithSCCSupGroups() *corev1.Namespace {
+	ns := r.NewNamespace()
 	ns.Annotations = map[string]string{
 		securityv1.SupplementalGroupsAnnotation: "1000130000/10000",
 	}
 	return ns
 }
 
-func NewConsoleLink() *consolev1.ConsoleLink {
+func (r *TestResources) NewConsoleLink() *consolev1.ConsoleLink {
 	return &consolev1.ConsoleLink{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "cryostat-9ecd5050500c2566765bc593edfcce12434283e5da32a27476bc4a1569304a02",
+			Name: "cryostat-ffc3f6d167f69f78c5882a8f67be7efcc7f2f9062145a98f99f7863922c52b10",
 		},
 		Spec: consolev1.ConsoleLinkSpec{
 			Link: consolev1.Link{
@@ -2538,16 +2518,16 @@ func NewConsoleLink() *consolev1.ConsoleLink {
 			},
 			Location: consolev1.NamespaceDashboard,
 			NamespaceDashboard: &consolev1.NamespaceDashboardSpec{
-				Namespaces: []string{"default"},
+				Namespaces: []string{r.Namespace},
 			},
 		},
 	}
 }
 
-func OtherConsoleLink() *consolev1.ConsoleLink {
+func (r *TestResources) OtherConsoleLink() *consolev1.ConsoleLink {
 	return &consolev1.ConsoleLink{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "cryostat-9ecd5050500c2566765bc593edfcce12434283e5da32a27476bc4a1569304a02",
+			Name: "cryostat-ffc3f6d167f69f78c5882a8f67be7efcc7f2f9062145a98f99f7863922c52b10",
 			Labels: map[string]string{
 				"my": "label",
 			},
@@ -2568,7 +2548,7 @@ func OtherConsoleLink() *consolev1.ConsoleLink {
 	}
 }
 
-func NewApiServer() *configv1.APIServer {
+func (r *TestResources) NewApiServer() *configv1.APIServer {
 	return &configv1.APIServer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cluster",
@@ -2588,7 +2568,7 @@ func newCoreContainerDefaultResource() *corev1.ResourceRequirements {
 	}
 }
 
-func NewCoreContainerResource(cr *operatorv1beta1.Cryostat) *corev1.ResourceRequirements {
+func (r *TestResources) NewCoreContainerResource(cr *operatorv1beta1.Cryostat) *corev1.ResourceRequirements {
 	requests := newCoreContainerDefaultResource().Requests
 	var limits corev1.ResourceList
 	if cr.Spec.Resources != nil && cr.Spec.Resources.CoreResources.Requests != nil {
@@ -2616,7 +2596,7 @@ func newDatasourceContainerDefaultResource() *corev1.ResourceRequirements {
 	}
 }
 
-func NewDatasourceContainerResource(cr *operatorv1beta1.Cryostat) *corev1.ResourceRequirements {
+func (r *TestResources) NewDatasourceContainerResource(cr *operatorv1beta1.Cryostat) *corev1.ResourceRequirements {
 	requests := newDatasourceContainerDefaultResource().Requests
 	var limits corev1.ResourceList
 	if cr.Spec.Resources != nil && cr.Spec.Resources.DataSourceResources.Requests != nil {
@@ -2644,7 +2624,7 @@ func newGrafanaContainerDefaultResource() *corev1.ResourceRequirements {
 	}
 }
 
-func NewGrafanaContainerResource(cr *operatorv1beta1.Cryostat) *corev1.ResourceRequirements {
+func (r *TestResources) NewGrafanaContainerResource(cr *operatorv1beta1.Cryostat) *corev1.ResourceRequirements {
 	requests := newGrafanaContainerDefaultResource().Requests
 	var limits corev1.ResourceList
 	if cr.Spec.Resources != nil && cr.Spec.Resources.GrafanaResources.Requests != nil {
@@ -2672,7 +2652,7 @@ func newReportContainerDefaultResource() *corev1.ResourceRequirements {
 	}
 }
 
-func NewReportContainerResource(cr *operatorv1beta1.Cryostat) *corev1.ResourceRequirements {
+func (r *TestResources) NewReportContainerResource(cr *operatorv1beta1.Cryostat) *corev1.ResourceRequirements {
 	requests := newReportContainerDefaultResource().Requests
 	var limits corev1.ResourceList
 


### PR DESCRIPTION
This PR is long, but a lot of the changes are a result of changing functions to methods. I've added a `TestResources` struct that is embedded into the `cryostatTestInput` used by the controller tests. Several fields have moved to the `TestResources` type where it makes sense: `minimal`, `tls`, etc. These would be fields that have some effect on the creation of the test objects. In addition to this, a new `namespace` field is added. Modifying this field affects the namespace of all subsequently created test objects.

By changing the test object creation from functions to methods, I've been able to reduce the parameter bloat, which hopefully results in more readable tests. I've tried quite a few iterations of this refactoring, before settling on this approach. Let me know what you think.

Fixes: #506 