### PR TITLE
test(reconcile): simulate controllers with custom client

### DIFF
--- a/internal/controllers/cryostat_controller.go
+++ b/internal/controllers/cryostat_controller.go
@@ -235,13 +235,6 @@ func (r *CryostatReconciler) Reconcile(ctx context.Context, request ctrl.Request
 			return reconcile.Result{}, err
 		}
 
-		// Get CA certificate from secret and set as destination CA in route
-		caCert, err := r.GetCryostatCABytes(ctx, instance)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		tlsConfig.CACert = caCert
-
 		err = r.updateCondition(ctx, instance, operatorv1beta1.ConditionTypeTLSSetupComplete, metav1.ConditionTrue,
 			reasonAllCertsReady, "All certificates for Cryostat components are ready.")
 		if err != nil {

--- a/internal/controllers/cryostat_controller_test.go
+++ b/internal/controllers/cryostat_controller_test.go
@@ -90,9 +90,9 @@ var _ = Describe("CryostatController", func() {
 		// TODO When using envtest instead of fake client, this is probably no longer needed
 		err := test.SetCreationTimestamp(t.objs...)
 		Expect(err).ToNot(HaveOccurred())
-		t.Client = test.NewClientWithTimestamp(test.NewTestClient(fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(t.objs...).Build(), t.TestResources))
+		t.Client = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(t.objs...).Build()
 		t.controller = &controllers.CryostatReconciler{
-			Client:        t.Client,
+			Client:        test.NewClientWithTimestamp(test.NewTestClient(t.Client, t.TestResources)),
 			Scheme:        s,
 			IsOpenShift:   t.OpenShift,
 			EventRecorder: record.NewFakeRecorder(1024),
@@ -286,7 +286,6 @@ var _ = Describe("CryostatController", func() {
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
-
 			})
 			It("should update the Deployment", func() {
 				deploy := &appsv1.Deployment{}
@@ -563,9 +562,7 @@ var _ = Describe("CryostatController", func() {
 				err = t.Client.Status().Update(context.Background(), cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
-				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
-				_, err = t.controller.Reconcile(context.Background(), req)
-				Expect(err).ToNot(HaveOccurred())
+				t.reconcileCryostatFully()
 			})
 			It("should delete Grafana network resources", func() {
 				service := &corev1.Service{}
@@ -696,10 +693,7 @@ var _ = Describe("CryostatController", func() {
 				err = t.Client.Status().Update(context.Background(), cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
-				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
-				result, err := t.controller.Reconcile(context.Background(), req)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(result).To(Equal(reconcile.Result{}))
+				t.reconcileCryostatFully()
 			})
 			It("should configure deployment appropriately", func() {
 				t.checkMainDeployment()
@@ -724,10 +718,7 @@ var _ = Describe("CryostatController", func() {
 				err = t.Client.Status().Update(context.Background(), cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
-				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
-				result, err := t.controller.Reconcile(context.Background(), req)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(result).To(Equal(reconcile.Result{}))
+				t.reconcileCryostatFully()
 			})
 			It("should configure deployment appropriately", func() {
 				t.checkMainDeployment()
@@ -752,10 +743,7 @@ var _ = Describe("CryostatController", func() {
 				err = t.Client.Status().Update(context.Background(), cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
-				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
-				result, err := t.controller.Reconcile(context.Background(), req)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(result).To(Equal(reconcile.Result{}))
+				t.reconcileCryostatFully()
 			})
 			It("should configure deployment appropriately", func() {
 				t.checkMainDeployment()
@@ -781,10 +769,7 @@ var _ = Describe("CryostatController", func() {
 				err = t.Client.Status().Update(context.Background(), cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
-				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
-				result, err := t.controller.Reconcile(context.Background(), req)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(result).To(Equal(reconcile.Result{}))
+				t.reconcileCryostatFully()
 			})
 			It("should configure deployment appropriately", func() {
 				t.checkMainDeployment()
@@ -837,10 +822,7 @@ var _ = Describe("CryostatController", func() {
 				err = t.Client.Update(context.Background(), cr)
 				Expect(err).ToNot(HaveOccurred())
 
-				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
-				result, err := t.controller.Reconcile(context.Background(), req)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(result).To(Equal(reconcile.Result{}))
+				t.reconcileCryostatFully()
 
 				deployment := &appsv1.Deployment{}
 				err = t.Client.Get(context.Background(), types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}, deployment)
@@ -898,11 +880,7 @@ var _ = Describe("CryostatController", func() {
 				err = t.Client.Update(context.Background(), cr)
 				Expect(err).ToNot(HaveOccurred())
 
-				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
-				result, err := t.controller.Reconcile(context.Background(), req)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(result).To(Equal(reconcile.Result{}))
-
+				t.reconcileCryostatFully()
 				t.checkDeploymentHasTemplates()
 			})
 		})
@@ -1327,9 +1305,7 @@ var _ = Describe("CryostatController", func() {
 				err = t.Client.Status().Update(context.Background(), cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
-				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
-				_, err = t.controller.Reconcile(context.Background(), req)
-				Expect(err).ToNot(HaveOccurred())
+				t.reconcileCryostatFully()
 			})
 			It("should update the deployment", func() {
 				t.checkMainDeployment()
@@ -1360,12 +1336,7 @@ var _ = Describe("CryostatController", func() {
 				err = t.Client.Status().Update(context.Background(), cryostat)
 				Expect(err).ToNot(HaveOccurred())
 
-				req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
-				_, err = t.controller.Reconcile(context.Background(), req)
-				Expect(err).ToNot(HaveOccurred())
-
-				_, err = t.controller.Reconcile(context.Background(), req)
-				Expect(err).ToNot(HaveOccurred())
+				t.reconcileCryostatFully()
 			})
 			It("should update the deployment", func() {
 				t.checkMainDeployment()
@@ -1472,10 +1443,7 @@ var _ = Describe("CryostatController", func() {
 					err = t.Client.Update(context.Background(), current)
 					Expect(err).ToNot(HaveOccurred())
 
-					// Reconcile again
-					result, err := t.controller.Reconcile(context.Background(), reconcile.Request{NamespacedName: namespacedName})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(result).To(Equal(reconcile.Result{}))
+					t.reconcileCryostatFully()
 				})
 				Context("containing core config", func() {
 					BeforeEach(func() {
@@ -2034,10 +2002,7 @@ func (t *cryostatTestInput) reconcileDeletedCryostat() {
 	Expect(err).ToNot(HaveOccurred())
 
 	// Reconcile again
-	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
-	result, err := t.controller.Reconcile(context.Background(), req)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(result).To(Equal(reconcile.Result{}))
+	t.reconcileCryostatFully()
 }
 
 func checkMetadata(object metav1.Object, expected metav1.Object) {
@@ -2373,9 +2338,7 @@ func (t *cryostatTestInput) expectIdempotence() {
 	Expect(err).ToNot(HaveOccurred())
 
 	// Reconcile again
-	result, err := t.controller.Reconcile(context.Background(), req)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(result).To(Equal(reconcile.Result{}))
+	t.reconcileCryostatFully()
 
 	obj2 := &operatorv1beta1.Cryostat{}
 	err = t.Client.Get(context.Background(), req.NamespacedName, obj2)
@@ -2473,10 +2436,7 @@ func (t *cryostatTestInput) setDeploymentConditions(deployName string, available
 	Expect(err).ToNot(HaveOccurred())
 
 	// Reconcile again
-	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cryostat", Namespace: t.Namespace}}
-	res, err := t.controller.Reconcile(context.Background(), req)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(res).To(Equal(reconcile.Result{}))
+	t.reconcileCryostatFully()
 }
 
 func (t *cryostatTestInput) checkMainDeployment() {

--- a/internal/controllers/cryostat_controller_test.go
+++ b/internal/controllers/cryostat_controller_test.go
@@ -786,8 +786,8 @@ var _ = Describe("CryostatController", func() {
 			var cr *operatorv1beta1.Cryostat
 			BeforeEach(func() {
 				cr = t.NewCryostatWithSecrets()
-				t.objs = append(t.objs, cr,
-					t.newFakeSecret("testCert1"), t.newFakeSecret("testCert2"))
+				t.objs = append(t.objs, cr, t.NewTestCertSecret("testCert1"),
+					t.NewTestCertSecret("testCert2"))
 			})
 			It("Should add volumes and volumeMounts to deployment", func() {
 				t.expectDeploymentHasCertSecrets()
@@ -805,8 +805,8 @@ var _ = Describe("CryostatController", func() {
 		})
 		Context("Adding a certificate to the TrustedCertSecrets list", func() {
 			BeforeEach(func() {
-				t.objs = append(t.objs, t.NewCryostat(), t.newFakeSecret("testCert1"),
-					t.newFakeSecret("testCert2"))
+				t.objs = append(t.objs, t.NewCryostat(), t.NewTestCertSecret("testCert1"),
+					t.NewTestCertSecret("testCert2"))
 			})
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
@@ -1928,19 +1928,6 @@ var _ = Describe("CryostatController", func() {
 		})
 	})
 })
-
-// TODO Refactor
-func (t *cryostatTestInput) newFakeSecret(name string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: t.Namespace,
-		},
-		Data: map[string][]byte{
-			corev1.TLSCertKey: []byte(name + "-bytes"),
-		},
-	}
-}
 
 func (t *cryostatTestInput) checkRoutes() {
 	if !t.Minimal {

--- a/internal/test/clients.go
+++ b/internal/test/clients.go
@@ -40,6 +40,11 @@ import (
 	"context"
 	"time"
 
+	certv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	certMeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	"github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,14 +52,108 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+type commonTestClient struct {
+	ctrlclient.Client
+}
+
+func newCommonTestClient(client ctrlclient.Client) *commonTestClient {
+	return &commonTestClient{
+		Client: client,
+	}
+}
+
+type testClient struct {
+	*commonTestClient
+	*TestResources
+}
+
+func NewTestClient(client ctrlclient.Client, resources *TestResources) ctrlclient.Client {
+	return &testClient{
+		commonTestClient: newCommonTestClient(client),
+		TestResources:    resources,
+	}
+}
+
+func (c *testClient) Create(ctx context.Context, obj ctrlclient.Object, opts ...ctrlclient.CreateOption) error {
+	err := c.Client.Create(ctx, obj, opts...)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *testClient) Update(ctx context.Context, obj ctrlclient.Object, opts ...ctrlclient.UpdateOption) error {
+	err := c.Client.Update(ctx, obj, opts...)
+	if err != nil {
+		return err
+	}
+	//copy := obj.DeepCopyObject()
+	//c.makeCertificatesReady(ctx, copy)
+	//c.updateRouteStatus(ctx, copy)
+	return nil
+}
+
+func (c *testClient) Get(ctx context.Context, key ctrlclient.ObjectKey, obj ctrlclient.Object) error {
+	err := c.Client.Get(ctx, key, obj)
+	if err != nil {
+		return err
+	}
+	//copy := obj.DeepCopyObject()
+	c.makeCertificatesReady(ctx, obj)
+	c.updateRouteStatus(ctx, obj)
+	return nil
+}
+
+func (c *testClient) makeCertificatesReady(ctx context.Context, obj runtime.Object) {
+	cert, ok := obj.(*certv1.Certificate)
+	if ok && c.matchesName(cert, c.NewCryostatCert(), c.NewCACert(), c.NewGrafanaCert(), c.NewReportsCert()) &&
+		len(cert.Status.Conditions) == 0 {
+		// Create certificate secret
+		c.createCertSecret(ctx, cert)
+		// Mark certificate as ready
+		cert.Status.Conditions = append(cert.Status.Conditions, certv1.CertificateCondition{
+			Type:   certv1.CertificateConditionReady,
+			Status: certMeta.ConditionTrue,
+		})
+		err := c.Status().Update(context.Background(), cert)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	}
+}
+
+func (c *testClient) createCertSecret(ctx context.Context, cert *certv1.Certificate) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cert.Spec.SecretName,
+			Namespace: cert.Namespace,
+		},
+		Data: map[string][]byte{
+			corev1.TLSCertKey: []byte(cert.Name + "-bytes"),
+		},
+	}
+	err := c.Create(ctx, secret)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+}
+
+func (c *testClient) updateRouteStatus(ctx context.Context, obj runtime.Object) {
+	route, ok := obj.(*routev1.Route)
+	if ok && c.matchesName(route, c.NewGrafanaRoute(), c.NewCoreRoute()) &&
+		len(route.Status.Ingress) == 0 {
+		route.Status.Ingress = append(route.Status.Ingress, routev1.RouteIngress{
+			Host: route.Name + ".example.com",
+		})
+		err := c.Status().Update(context.Background(), route)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	}
+}
+
 // TODO When using envtest instead of fake client, this is probably no longer needed
 type timestampClient struct {
-	ctrlclient.Client
+	*commonTestClient
 }
 
 func NewClientWithTimestamp(client ctrlclient.Client) ctrlclient.Client {
 	return &timestampClient{
-		Client: client,
+		commonTestClient: newCommonTestClient(client),
 	}
 }
 
@@ -80,7 +179,7 @@ func SetCreationTimestamp(objs ...runtime.Object) error {
 }
 
 type clientUpdateError struct {
-	ctrlclient.Client
+	*commonTestClient
 	failObj ctrlclient.Object
 	err     *kerrors.StatusError
 }
@@ -90,9 +189,9 @@ type clientUpdateError struct {
 func NewClientWithUpdateError(client ctrlclient.Client, failObj ctrlclient.Object,
 	err *kerrors.StatusError) ctrlclient.Client {
 	return &clientUpdateError{
-		Client:  client,
-		failObj: failObj,
-		err:     err,
+		commonTestClient: newCommonTestClient(client),
+		failObj:          failObj,
+		err:              err,
 	}
 }
 
@@ -100,7 +199,7 @@ func (c *clientUpdateError) Update(ctx context.Context, obj ctrlclient.Object,
 	opts ...ctrlclient.UpdateOption) error {
 	if obj.GetName() == c.failObj.GetName() && obj.GetNamespace() == c.failObj.GetNamespace() {
 		// Look up Kind and compare against object to fail on
-		match, err := c.matchesKind(obj)
+		match, err := c.matchesKind(obj, c.failObj)
 		if err != nil {
 			return err
 		}
@@ -111,9 +210,9 @@ func (c *clientUpdateError) Update(ctx context.Context, obj ctrlclient.Object,
 	return c.Client.Update(ctx, obj, opts...)
 }
 
-func (c *clientUpdateError) matchesKind(obj ctrlclient.Object) (*bool, error) {
+func (c *commonTestClient) matchesKind(obj, expected ctrlclient.Object) (*bool, error) {
 	match := false
-	failKinds, _, err := c.Scheme().ObjectKinds(c.failObj)
+	expectKinds, _, err := c.Scheme().ObjectKinds(expected)
 	if err != nil {
 		return nil, err
 	}
@@ -122,13 +221,22 @@ func (c *clientUpdateError) matchesKind(obj ctrlclient.Object) (*bool, error) {
 		return nil, err
 	}
 
-	for _, failKind := range failKinds {
+	for _, expectKind := range expectKinds {
 		for _, kind := range kinds {
-			if failKind == kind {
+			if expectKind == kind {
 				match = true
 				return &match, nil
 			}
 		}
 	}
 	return &match, nil
+}
+
+func (c *commonTestClient) matchesName(obj ctrlclient.Object, expectedObjs ...ctrlclient.Object) bool {
+	for _, expected := range expectedObjs {
+		if obj.GetName() == expected.GetName() {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -881,6 +881,18 @@ func (r *TestResources) OtherJMXSecret() *corev1.Secret {
 	}
 }
 
+func (r *TestResources) NewTestCertSecret(name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: r.Namespace,
+		},
+		Data: map[string][]byte{
+			corev1.TLSCertKey: []byte(name + "-bytes"),
+		},
+	}
+}
+
 func (r *TestResources) NewCryostatCert() *certv1.Certificate {
 	return &certv1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This PR moves the logic for updating certificate and route statuses from `reconcileCryostatFully` to a custom client implementation. This client triggers the update upon the first successful `Get` call. This happens after the object has been created, so we're still exercising the `RequeueAfter` code paths.

The advantage here is that we can simplify how we do reconciles in the tests themselves. I've changed `reconcileCryostatFully` to use Gomega's `Eventually` to call `Reconcile` asynchronously until it no longer re-queues or times out. This allows us to use `reconcileCryostatFully` in more places.

I also removed an unnecessary `Get` call for the certificate in `common/tls.go`. We already have the certificate in memory, and this was triggering the certificate update logic earlier than desired.

Fixes: #509 