### PR TITLE
feat(csv): enable AllNamespaces install mode

### DIFF
--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -704,7 +704,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - flightrecorder

--- a/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
@@ -433,7 +433,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - flightrecorder

--- a/internal/controllers/cryostat_controller_test.go
+++ b/internal/controllers/cryostat_controller_test.go
@@ -38,6 +38,7 @@ package controllers_test
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -125,10 +126,7 @@ var _ = Describe("CryostatController", func() {
 	})
 
 	Describe("reconciling a request in OpenShift", func() {
-		Context("successfully creates required resources", func() {
-			BeforeEach(func() {
-				t.objs = append(t.objs, t.NewCryostat())
-			})
+		expectSuccessful := func() {
 			It("should create certificates", func() {
 				t.expectCertificates()
 			})
@@ -213,6 +211,33 @@ var _ = Describe("CryostatController", func() {
 					})
 				})
 			})
+		}
+		Context("successfully creates required resources", func() {
+			BeforeEach(func() {
+				t.objs = append(t.objs, t.NewCryostat())
+			})
+
+			expectSuccessful()
+		})
+		Context("with multiple namespaces", func() {
+			namespaces := []string{"test-one", "test-two"}
+			BeforeEach(func() {
+				for _, ns := range namespaces {
+					t.Namespace = ns
+					t.objs = append(t.objs, t.NewNamespace(), t.NewCryostat())
+				}
+			})
+
+			for _, ns := range namespaces {
+				ns := ns // capture value
+				Context(fmt.Sprintf("successfully creates required resources in namespace %s", ns), func() {
+					BeforeEach(func() {
+						t.Namespace = ns
+					})
+
+					expectSuccessful()
+				})
+			}
 		})
 		Context("succesfully creates required resources for minimal deployment", func() {
 			BeforeEach(func() {


### PR DESCRIPTION
The implementation change is just setting the install mode to `true`. I've updated the tests to create two Cryostat instances in different namespaces and check that the proper resources are created for each.

I created a catalog image to test this change. You can use it by creating the following catalog source.
```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: cryostat-all-ns
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/ebaron/cryostat-operator-catalog:all-ns-01
  displayName: Cryostat Test
  publisher: grpc
```

The all namespaces install mode should be set as default:
![Screenshot 2023-01-13 at 18-06-42 Operator Installation · Red Hat OpenShift](https://user-images.githubusercontent.com/4326090/212435097-e2e5555a-d2c4-4ec3-8946-a4954ace7c35.png)

Try creating Cryostat CRs in different namespaces:
![Screenshot 2023-01-13 at 18-05-53 cryostat-operator v2 3 0-dev · Details · Red Hat OpenShift](https://user-images.githubusercontent.com/4326090/212435111-8c94dc6d-25e0-43cc-98ed-d78e6cef31b5.png)

I noticed some difficulty with Cryostat missing targets. I'm not sure if that's related to this PR or not.

Fixes: #502 