### PR TITLE
chore(api): capitalize JMX credentials DB display name

### DIFF
--- a/api/v1beta1/cryostat_types.go
+++ b/api/v1beta1/cryostat_types.go
@@ -108,7 +108,7 @@ type CryostatSpec struct {
 	TargetDiscoveryOptions *TargetDiscoveryOptions `json:"targetDiscoveryOptions,omitempty"`
 	// Options to configure the Cryostat application's JMX credentials database.
 	// +optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="JMX Credentials Database Options"
 	JmxCredentialsDatabaseOptions *JmxCredentialsDatabaseOptions `json:"jmxCredentialsDatabaseOptions,omitempty"`
 }
 

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -141,7 +141,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: Options to configure the Cryostat application's JMX credentials
           database.
-        displayName: Jmx Credentials Database Options
+        displayName: JMX Credentials Database Options
         path: jmxCredentialsDatabaseOptions
       - description: Name of the secret containing the password to encrypt JMX credentials
           database.

--- a/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
@@ -129,7 +129,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: Options to configure the Cryostat application's JMX credentials
           database.
-        displayName: Jmx Credentials Database Options
+        displayName: JMX Credentials Database Options
         path: jmxCredentialsDatabaseOptions
       - description: Name of the secret containing the password to encrypt JMX credentials
           database.


### PR DESCRIPTION
This manually specifies the `displayName` for `JmxCredentialsDatabaseOptions` option. I have built a bundle image for checking these changes here: 

```
quay.io/thvo/cryostat-operator-bundle:2.3.0-pr517
```

![Screenshot from 2023-02-01 02-09-58](https://user-images.githubusercontent.com/68053619/215975288-82245a2e-8bfa-4a6f-ae3e-9be49fb54b7e.png)

Fixes #516 