### PR TITLE
build(make): update Makefile targets to support ClusterCryostat

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ kubectl get secret ${CRYOSTAT_NAME}-jmx-auth -o jsonpath='{$.data.CRYOSTAT_RJMX_
 - [`operator-sdk`](https://github.com/operator-framework/operator-sdk) v1.22.2
 - [`cert-manager`](https://github.com/jetstack/cert-manager) v1.7.1+ (Recommended)
 - `podman` or `docker`
+- [`jq`](https://stedolan.github.io/jq/) v1.6+
 - `ginkgo` (Optional)
 
 ## Instructions

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -860,11 +860,46 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - configmaps
+          - endpoints
+          - events
+          - persistentvolumeclaims
+          - pods
+          - secrets
+          - serviceaccounts
+          - services
+          - services/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
           - namespaces
           verbs:
           - get
           - list
           - watch
+        - apiGroups:
+          - ""
+          resources:
+          - replicationcontrollers
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
         - apiGroups:
           - authentication.k8s.io
           resources:
@@ -877,6 +912,18 @@ spec:
           - selfsubjectaccessreviews
           verbs:
           - create
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - certificates
+          - issuers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
         - apiGroups:
           - config.openshift.io
           resources:
@@ -896,6 +943,12 @@ spec:
           - get
           - list
           - update
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          verbs:
+          - '*'
         - apiGroups:
           - oauth.openshift.io
           resources:
@@ -924,6 +977,26 @@ spec:
           - patch
           - update
         - apiGroups:
+          - operator.cryostat.io
+          resources:
+          - cryostats
+          verbs:
+          - '*'
+        - apiGroups:
+          - operator.cryostat.io
+          resources:
+          - cryostats/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - operator.cryostat.io
+          resources:
+          - cryostats/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - clusterrolebindings
@@ -934,6 +1007,25 @@ spec:
           - list
           - update
           - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          - routes/custom-host
+          verbs:
+          - '*'
         serviceAccountName: cryostat-operator-service-account
       deployments:
       - label:
@@ -1037,104 +1129,12 @@ spec:
           - create
           - patch
         - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          - endpoints
-          - events
-          - persistentvolumeclaims
-          - pods
-          - secrets
-          - serviceaccounts
-          - services
-          - services/finalizers
-          verbs:
-          - '*'
-        - apiGroups:
-          - ""
-          resources:
-          - replicationcontrollers
-          verbs:
-          - get
-        - apiGroups:
-          - apps
-          resources:
-          - daemonsets
-          - deployments
-          - replicasets
-          - statefulsets
-          verbs:
-          - '*'
-        - apiGroups:
-          - apps.openshift.io
-          resources:
-          - deploymentconfigs
-          verbs:
-          - get
-        - apiGroups:
-          - cert-manager.io
-          resources:
-          - certificates
-          - issuers
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - update
-          - watch
-        - apiGroups:
           - monitoring.coreos.com
           resources:
           - servicemonitors
           verbs:
           - create
           - get
-        - apiGroups:
-          - networking.k8s.io
-          resources:
-          - ingresses
-          verbs:
-          - '*'
-        - apiGroups:
-          - operator.cryostat.io
-          resources:
-          - cryostats
-          verbs:
-          - '*'
-        - apiGroups:
-          - operator.cryostat.io
-          resources:
-          - cryostats/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - operator.cryostat.io
-          resources:
-          - cryostats/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
-          - rolebindings
-          - roles
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - update
-          - watch
-        - apiGroups:
-          - route.openshift.io
-          resources:
-          - routes
-          - routes/custom-host
-          verbs:
-          - '*'
         serviceAccountName: cryostat-operator-service-account
     strategy: deployment
   installModes:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -48,9 +48,7 @@ spec:
           periodSeconds: 10
         env:
         - name: WATCH_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          value: ""
         resources:
           limits:
             cpu: 1000m

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,11 +8,46 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  - endpoints
+  - events
+  - persistentvolumeclaims
+  - pods
+  - secrets
+  - serviceaccounts
+  - services
+  - services/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
 - apiGroups:
   - authentication.k8s.io
   resources:
@@ -25,6 +60,18 @@ rules:
   - selfsubjectaccessreviews
   verbs:
   - create
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  - issuers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - config.openshift.io
   resources:
@@ -44,6 +91,12 @@ rules:
   - get
   - list
   - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - '*'
 - apiGroups:
   - oauth.openshift.io
   resources:
@@ -72,85 +125,6 @@ rules:
   - patch
   - update
 - apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterrolebindings
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  creationTimestamp: null
-  name: role
-  namespace: system
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - endpoints
-  - events
-  - persistentvolumeclaims
-  - pods
-  - secrets
-  - serviceaccounts
-  - services
-  - services/finalizers
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - replicationcontrollers
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  - statefulsets
-  verbs:
-  - '*'
-- apiGroups:
-  - apps.openshift.io
-  resources:
-  - deploymentconfigs
-  verbs:
-  - get
-- apiGroups:
-  - cert-manager.io
-  resources:
-  - certificates
-  - issuers
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - create
-  - get
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - '*'
-- apiGroups:
   - operator.cryostat.io
   resources:
   - cryostats
@@ -173,6 +147,17 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
   - rolebindings
   - roles
   verbs:
@@ -189,3 +174,18 @@ rules:
   - routes/custom-host
   verbs:
   - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: role
+  namespace: system
+rules:
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - get

--- a/internal/controllers/clustercryostat_controller.go
+++ b/internal/controllers/clustercryostat_controller.go
@@ -69,25 +69,25 @@ func NewClusterCryostatReconciler(config *ReconcilerConfig) *ClusterCryostatReco
 	}
 }
 
-// +kubebuilder:rbac:namespace=system,groups="",resources=pods;services;services/finalizers;endpoints;persistentvolumeclaims;events;configmaps;secrets;serviceaccounts,verbs=*
-// +kubebuilder:rbac:namespace=system,groups="",resources=replicationcontrollers,verbs=get
-// +kubebuilder:rbac:namespace=system,groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=create;get;list;update;watch;delete
+// +kubebuilder:rbac:groups="",resources=pods;services;services/finalizers;endpoints;persistentvolumeclaims;events;configmaps;secrets;serviceaccounts,verbs=*
+// +kubebuilder:rbac:groups="",resources=replicationcontrollers,verbs=get
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=create;get;list;update;watch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create;get;list;update;watch;delete
 // +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=selfsubjectaccessreviews,verbs=create
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=oauth.openshift.io,resources=oauthaccesstokens,verbs=list;delete
 // +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;update;watch
-// +kubebuilder:rbac:namespace=system,groups=route.openshift.io,resources=routes;routes/custom-host,verbs=*
-// +kubebuilder:rbac:namespace=system,groups=apps.openshift.io,resources=deploymentconfigs,verbs=get
-// +kubebuilder:rbac:namespace=system,groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=*
+// +kubebuilder:rbac:groups=route.openshift.io,resources=routes;routes/custom-host,verbs=*
+// +kubebuilder:rbac:groups=apps.openshift.io,resources=deploymentconfigs,verbs=get
+// +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=*
 // +kubebuilder:rbac:namespace=system,groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create
-// +kubebuilder:rbac:namespace=system,groups=cert-manager.io,resources=issuers;certificates,verbs=create;get;list;update;watch;delete
+// +kubebuilder:rbac:groups=cert-manager.io,resources=issuers;certificates,verbs=create;get;list;update;watch;delete
 // +kubebuilder:rbac:groups=operator.cryostat.io,resources=clustercryostats,verbs=*
 // +kubebuilder:rbac:groups=operator.cryostat.io,resources=clustercryostats/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=operator.cryostat.io,resources=clustercryostats/finalizers,verbs=update
 // +kubebuilder:rbac:groups=console.openshift.io,resources=consolelinks,verbs=get;create;list;update;delete
-// +kubebuilder:rbac:namespace=system,groups=networking.k8s.io,resources=ingresses,verbs=*
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=*
 
 // Reconcile processes a ClusterCryostat CR and manages a Cryostat installation accordingly
 func (r *ClusterCryostatReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {

--- a/internal/controllers/cryostat_controller.go
+++ b/internal/controllers/cryostat_controller.go
@@ -66,9 +66,9 @@ func NewCryostatReconciler(config *ReconcilerConfig) *CryostatReconciler {
 	}
 }
 
-// +kubebuilder:rbac:namespace=system,groups=operator.cryostat.io,resources=cryostats,verbs=*
-// +kubebuilder:rbac:namespace=system,groups=operator.cryostat.io,resources=cryostats/status,verbs=get;update;patch
-// +kubebuilder:rbac:namespace=system,groups=operator.cryostat.io,resources=cryostats/finalizers,verbs=update
+// +kubebuilder:rbac:groups=operator.cryostat.io,resources=cryostats,verbs=*
+// +kubebuilder:rbac:groups=operator.cryostat.io,resources=cryostats/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=operator.cryostat.io,resources=cryostats/finalizers,verbs=update
 
 // Reconcile processes a Cryostat CR and manages a Cryostat installation accordingly
 func (r *CryostatReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
This fixes `make deploy` to work across multiple namespaces. Permissions for resources created by the operator are converted from single-namespace to cluster-wide permissions. It also adds `make create_clustercryostat` and `destroy_clustercryostat` analogues to the existing targets for the Cryostat CR. `WATCH_NAMESPACE` is set to the empty string, which signals the manager to watch all namespaces.

Fixes: #522 