### PR TITLE
fix(api): prevent overwriting objects when names conflict

### DIFF
--- a/internal/controllers/clustercryostat_controller_test.go
+++ b/internal/controllers/clustercryostat_controller_test.go
@@ -75,6 +75,10 @@ var _ = Describe("ClusterCryostatController", func() {
 			c.commonJustBeforeEach(t)
 		})
 
+		JustAfterEach(func() {
+			c.commonJustAfterEach(t)
+		})
+
 		It("should create the expected main deployment", func() {
 			t.expectDeployment()
 		})

--- a/internal/controllers/cryostat_controller.go
+++ b/internal/controllers/cryostat_controller.go
@@ -91,9 +91,6 @@ func (r *CryostatReconciler) Reconcile(ctx context.Context, request ctrl.Request
 		return reconcile.Result{}, err
 	}
 
-	// TODO Consider potential name conflicts.
-	// For namespaced, look up cluster-scoped with same name. If it exists, check the list of target namespaces.
-	// If there's a match, don't process the CR. Emit an event warning the user of the conflict.
 	instance := model.FromCryostat(cr)
 	return r.delegate.reconcileCryostat(ctx, instance)
 }

--- a/internal/controllers/openshift.go
+++ b/internal/controllers/openshift.go
@@ -79,7 +79,8 @@ func newConsoleLink(cr *model.CryostatInstance) *consolev1.ConsoleLink {
 	// Cluster scoped, so use a unique name to avoid conflicts
 	return &consolev1.ConsoleLink{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: common.ClusterUniqueName(cr.Name, cr.InstallNamespace),
+			Name: common.ClusterUniqueName(cr.Object.GetObjectKind().GroupVersionKind().Kind,
+				cr.Name, cr.InstallNamespace),
 		},
 	}
 }

--- a/internal/controllers/rbac.go
+++ b/internal/controllers/rbac.go
@@ -173,7 +173,8 @@ func (r *Reconciler) reconcileRoleBinding(ctx context.Context, cr *model.Cryosta
 func newClusterRoleBinding(cr *model.CryostatInstance) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: common.ClusterUniqueName(cr.Name, cr.InstallNamespace),
+			Name: common.ClusterUniqueName(cr.Object.GetObjectKind().GroupVersionKind().Kind,
+				cr.Name, cr.InstallNamespace),
 		},
 	}
 }

--- a/internal/test/clients.go
+++ b/internal/test/clients.go
@@ -156,7 +156,7 @@ func (c *timestampClient) Create(ctx context.Context, obj ctrlclient.Object, opt
 
 var creationTimestamp = metav1.NewTime(time.Unix(1664573254, 0))
 
-func SetCreationTimestamp(objs ...runtime.Object) error {
+func SetCreationTimestamp(objs ...ctrlclient.Object) error {
 	for _, obj := range objs {
 		metaObj, err := meta.Accessor(obj)
 		if err != nil {

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -2487,7 +2487,7 @@ func (r *TestResources) clusterUniqueSuffix() string {
 func (r *TestResources) NewClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "cryostat-" + r.clusterUniqueSuffix(),
+			Name: r.getClusterUniqueName(),
 		},
 		Subjects: []rbacv1.Subject{
 			{
@@ -2507,7 +2507,7 @@ func (r *TestResources) NewClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 func (r *TestResources) OtherClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "cryostat-" + r.clusterUniqueSuffix(),
+			Name: r.getClusterUniqueName(),
 			Labels: map[string]string{
 				"test": "label",
 			},
@@ -2586,7 +2586,7 @@ func (r *TestResources) NewNamespaceWithSCCSupGroups() *corev1.Namespace {
 func (r *TestResources) NewConsoleLink() *consolev1.ConsoleLink {
 	return &consolev1.ConsoleLink{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "cryostat-" + r.clusterUniqueSuffix(),
+			Name: r.getClusterUniqueName(),
 		},
 		Spec: consolev1.ConsoleLinkSpec{
 			Link: consolev1.Link{
@@ -2604,7 +2604,7 @@ func (r *TestResources) NewConsoleLink() *consolev1.ConsoleLink {
 func (r *TestResources) OtherConsoleLink() *consolev1.ConsoleLink {
 	return &consolev1.ConsoleLink{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "cryostat-" + r.clusterUniqueSuffix(),
+			Name: r.getClusterUniqueName(),
 			Labels: map[string]string{
 				"my": "label",
 			},
@@ -2758,4 +2758,21 @@ func checkWithLimit(requests, limits corev1.ResourceList) {
 			requests[corev1.ResourceMemory] = limitMemory.DeepCopy()
 		}
 	}
+}
+
+func (r *TestResources) NewLockConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      r.Name + "-lock",
+			Namespace: r.Namespace,
+		},
+	}
+}
+
+func (r *TestResources) getClusterUniqueName() string {
+	prefix := "cryostat-"
+	if r.ClusterScoped {
+		prefix = "clustercryostat-"
+	}
+	return prefix + r.clusterUniqueSuffix()
 }


### PR DESCRIPTION
This PR addresses potential conflicts between the Cryostat and ClusterCryostat CRDs when they refer to the same name and namespaces. To handle the majority of objects managed by the respective controllers, they now create a Config Map at the beginning of their reconcile method which acts as a lock. Whichever controller creates and owns this Config Map first gets to proceed. This works for anything created in the installation namespace.

For the target namespaces, the only objects that are created are role bindings. These will reject updates since they can only be controlled by one owner object.

In both of these cases, we detect if we attempt to control an already controlled object and emit a warning Event that should give the user enough information as to why their CR can't proceed.

In the case of cluster-scoped objects, they can't be owned by the namespaced Cryostat CR. These however are guarded by the lock config map, and I've also changed the prefix used for these object names to differ between those managed by a Cryostat and those managed by a ClusterCryostat.

On the test side of things, I've had to change the `expectSuccessful` test cases to handle a situation where the objects already exist. Because of this, I had to remove some expectations that the objects did not exist before reconciling. This will always be the case with the fake client, but in an envtest cluster, this isn't true. To avoid problems where tests don't clean up after themselves, I've added a `JustAfterEach` block that deletes all input objects, including the namespaces used by the tests. I've also extracted the `expectSuccessful` method outside of the `Context` closure in `reconciler_test.go` so that it can be used by the individual controller test files as well. I didn't end up needing this, but kept this change as it could be useful in the future.

To test, there are 4 cases I can think of that this PR should cover:

1. Create a Cryostat CR first, then a ClusterCryostat CR with the same name, whose `spec.installNamespace` is the same as the Cryostat CR's namespace.

    ```
    $ oc describe clustercryostats.operator.cryostat.io cryostat-sample 
    Name:         cryostat-sample
    Namespace:    
    Labels:       <none>
    Annotations:  <none>
    API Version:  operator.cryostat.io/v1beta1
    Kind:         ClusterCryostat
    [...]
    Events:
      Type     Reason                Age                 From                        Message
      ----     ------                ----                ----                        -------
      Warning  CryostatNameConflict  10s (x12 over 21s)  clustercryostat-controller  This instance needs to manage the ConfigMap cryostat-sample-lock in namespace cryostat-operator-system, but it is already owned by Cryostat cryostat-sample. Please choose a different name for your instance.
    ```

2. Create a ClusterCryostat CR first, then a Cryostat CR with the same name, whose namespace is the same as the ClusterCryostat's `spec.installNamespace`.

    ```
    $ oc describe cryostats.operator.cryostat.io clustercryostat-sample 
    Name:         clustercryostat-sample
    Namespace:    cryostat-operator-system
    Labels:       <none>
    Annotations:  <none>
    API Version:  operator.cryostat.io/v1beta1
    Kind:         Cryostat
    [...]
    Events:
      Type     Reason                Age                From                 Message
      ----     ------                ----               ----                 -------
      Warning  CryostatNameConflict  5s (x12 over 15s)  cryostat-controller  This instance needs to manage the ConfigMap clustercryostat-sample-lock in namespace cryostat-operator-system, but it is already owned by ClusterCryostat clustercryostat-sample. Please choose a different name for your instance.
    ```

3. Create a Cryostat CR first, then a ClusterCryostat CR with the same name, whose `spec.targetNamespaces` includes the Cryostat CR's namespace.
     
    ```
    $ oc describe clustercryostats.operator.cryostat.io cryostat-sample 
    Name:         cryostat-sample
    Namespace:    
    Labels:       <none>
    Annotations:  <none>
    API Version:  operator.cryostat.io/v1beta1
    Kind:         ClusterCryostat
    [...]
    Events:
      Type     Reason                Age                From                        Message
      ----     ------                ----               ----                        -------
      Warning  CryostatNameConflict  4s (x12 over 14s)  clustercryostat-controller  This instance needs to manage the RoleBinding cryostat-sample in namespace cryostat-operator-system, but it is already owned by Cryostat cryostat-sample. Please choose a different name for your instance.
    ```
    
4. Create a ClusterCryostat CR first, then a Cryostat CR with the same name, whose namespace is the same as one of the ClusterCryostat's `spec.targetNamespaces`.
    
    ```
    $ oc describe cryostats.operator.cryostat.io clustercryostat-sample 
    Name:         clustercryostat-sample
    Namespace:    cryostat-operator-system
    Labels:       <none>
    Annotations:  <none>
    API Version:  operator.cryostat.io/v1beta1
    Kind:         Cryostat
    [...]
    Events:
      Type     Reason                Age                From                 Message
      ----     ------                ----               ----                 -------
      Warning  CryostatNameConflict  5s (x11 over 10s)  cryostat-controller  This instance needs to manage the RoleBinding clustercryostat-sample in namespace cryostat-operator-system, but it is already owned by ClusterCryostat clustercryostat-sample. Please choose a different name for your instance.
    ```

Fixes: #524 