### PR TITLE
fix(api): add multi-tenancy warning to description

### DIFF
--- a/api/v1beta1/clustercryostat_types.go
+++ b/api/v1beta1/clustercryostat_types.go
@@ -48,7 +48,9 @@ type ClusterCryostatSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=1,xDescriptors={"urn:alm:descriptor:io.kubernetes:Namespace"}
 	InstallNamespace string `json:"installNamespace"`
 	// List of namespaces whose workloads Cryostat should be
-	// permitted to access and profile.
+	// permitted to access and profile. Warning: All Cryostat users will be able to create and manage
+	// recordings for workloads in the listed namespaces.
+	// More details: https://github.com/cryostatio/cryostat-operator/blob/v2.3.0/docs/multi-namespace.md#data-isolation
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=2
 	TargetNamespaces []string `json:"targetNamespaces,omitempty"`

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -118,8 +118,10 @@ spec:
         path: installNamespace
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Namespace
-      - description: List of namespaces whose workloads Cryostat should be permitted
-          to access and profile.
+      - description: 'List of namespaces whose workloads Cryostat should be permitted
+          to access and profile. Warning: All Cryostat users will be able to create
+          and manage recordings for workloads in the listed namespaces. More details:
+          https://github.com/cryostatio/cryostat-operator/blob/v2.3.0/docs/multi-namespace.md#data-isolation'
         displayName: Target Namespaces
         path: targetNamespaces
       - description: Use cert-manager to secure in-cluster communication between Cryostat

--- a/bundle/manifests/operator.cryostat.io_clustercryostats.yaml
+++ b/bundle/manifests/operator.cryostat.io_clustercryostats.yaml
@@ -4397,8 +4397,10 @@ spec:
                     type: boolean
                 type: object
               targetNamespaces:
-                description: List of namespaces whose workloads Cryostat should be
-                  permitted to access and profile.
+                description: 'List of namespaces whose workloads Cryostat should be
+                  permitted to access and profile. Warning: All Cryostat users will
+                  be able to create and manage recordings for workloads in the listed
+                  namespaces. More details: https://github.com/cryostatio/cryostat-operator/blob/v2.3.0/docs/multi-namespace.md#data-isolation'
                 items:
                   type: string
                 type: array

--- a/config/crd/bases/operator.cryostat.io_clustercryostats.yaml
+++ b/config/crd/bases/operator.cryostat.io_clustercryostats.yaml
@@ -4398,8 +4398,10 @@ spec:
                     type: boolean
                 type: object
               targetNamespaces:
-                description: List of namespaces whose workloads Cryostat should be
-                  permitted to access and profile.
+                description: 'List of namespaces whose workloads Cryostat should be
+                  permitted to access and profile. Warning: All Cryostat users will
+                  be able to create and manage recordings for workloads in the listed
+                  namespaces. More details: https://github.com/cryostatio/cryostat-operator/blob/v2.3.0/docs/multi-namespace.md#data-isolation'
                 items:
                   type: string
                 type: array

--- a/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
@@ -69,8 +69,10 @@ spec:
         path: installNamespace
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Namespace
-      - description: List of namespaces whose workloads Cryostat should be permitted
-          to access and profile.
+      - description: 'List of namespaces whose workloads Cryostat should be permitted
+          to access and profile. Warning: All Cryostat users will be able to create
+          and manage recordings for workloads in the listed namespaces. More details:
+          https://github.com/cryostatio/cryostat-operator/blob/v2.3.0/docs/multi-namespace.md#data-isolation'
         displayName: Target Namespaces
         path: targetNamespaces
       - description: Use cert-manager to secure in-cluster communication between Cryostat


### PR DESCRIPTION
This adds a warning about multi-tenancy to the target namespaces field. It links to the documentation in this repo for more details. The tag does not exist yet, but will upon 2.3.0 release. For now you can replace `v2.3.0` with `main` to test it out.
![Screenshot 2023-04-11 at 16-45-16 Create ClusterCryostat · Red Hat OpenShift](https://user-images.githubusercontent.com/4326090/231285211-2c22409a-15d3-45a8-9e5d-68aa322b2cdc.png)


Fixes: #542 