### PR TITLE
chore(github): add pr and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,53 @@
+name: 🐞 Bug report
+description: File a report to help us improve Cryostat.
+title: '[Bug] <title>'
+labels: [bug, needs-triage]
+
+body:
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: A concise description of what you're experiencing.
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A concise description of what you expected to happen.
+      placeholder: Tell us what you expected to see!
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. In this environment...
+        2. With this config...
+        3. Run '...'
+        4. See error...
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Environment
+      description: |
+        examples:
+          - **OS**: Ubuntu 20.04
+          - **Environment**: OpenShift 4.11
+          - **Version**: Cryostat 2.2.0
+      value: |
+          - OS: 
+          - Environment: 
+          - Version: 
+      render: Markdown
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Screenshots? Links? References? Anything that will give us more context about the issue you are encountering!
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: enabled
+contact_links:
+  - name: Cryostat Community Support
+    url: https://github.com/cryostatio/cryostat/discussions
+    about: Ask general questions about Cryostat here!

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,18 @@
+name: ✨ Feature request
+description: Improve an existing feature or add a new one.
+title: '[Request] <title>'
+labels: [feat, needs-triage]
+
+body:
+  - type: textarea
+    attributes:
+      label: Describe the feature
+      description: A clear and concise description of what the feature is. 
+      placeholder: A feature that would be nice is...
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Anything other information?
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+# Welcome to Cryostat! 👋
+## Before contributing, make sure you have:
+* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
+* [ ] Linked a relevant issue which this PR resolves
+* [ ] Linked any other relevant issues, PR's, or documentation, if any
+* [ ] Resolved all conflicts, if any
+* [ ] Rebased your branch PR on top of the latest upstream `main` branch
+* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
+* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
+_______________________________________________
+
+Fixes: #<issue number>
+
+## Description of the change:
+*This change adds allows the users to provide...*
+
+## Motivation for the change:
+*This change is helpful because users may want to...*
+
+## How to manually test:
+1. *Insert steps here...*
+2. *...*


### PR DESCRIPTION
Fixes #553 

See https://github.com/maxcao13/cryostat-operator/issues/new/choose for Issue templates
See https://github.com/maxcao13/cryostat-operator/compare/main...maxcao13:cryostat-operator:cryostat-v2.1 and press `Create Pull Request` to see the PR template

This uses the new Beta Github [Issue Forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) 

cryostat and cryostat-web do not use this yet, but I decided to try it since this is a different repo. One thing that isn't that great is that I can't change the issue template `labels` to be 
## H2 headings 
like the other repos. They are stuck at 
### H3
for now until or if Github decides to change this.