### PR TITLE
test(scorecard): clean up CR after test finishes

### DIFF
--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -54,7 +54,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:2.4.0-dev
-    createdAt: "2023-04-19T18:33:40Z"
+    createdAt: "2023-04-25T14:37:03Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -69,7 +69,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - operator-install
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230419181134
+    image: quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230425143552
     labels:
       suite: cryostat
       test: operator-install
@@ -79,7 +79,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-cr
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230419181134
+    image: quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230425143552
     labels:
       suite: cryostat
       test: cryostat-cr

--- a/config/scorecard/patches/custom.config.yaml
+++ b/config/scorecard/patches/custom.config.yaml
@@ -8,7 +8,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - operator-install
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230419181134"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230425143552"
     labels:
       suite: cryostat
       test: operator-install
@@ -18,7 +18,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-cr
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230419181134"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230425143552"
     labels:
       suite: cryostat
       test: cryostat-cr


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #556 

## Description of the change:
This change cleans up the Cryostat CR created by our Scorecard test.

## Motivation for the change:
If the Scorecard tests are run more than once without using our Makefile targets, they may fail due to the CR not being cleaned up.

## How to manually test:
1. `kubectl create namespace cryostat-operator-scorecard`
2. `./bin/kustomize build internal/images/custom-scorecard-tests/rbac/ | kubectl apply -f -`
3. `operator-sdk run bundle -n cryostat-operator-scorecard quay.io/ebaron/cryostat-operator-bundle:cr-cleanup-01`
4. `operator-sdk scorecard -n cryostat-operator-scorecard -s cryostat-scorecard -w 10m quay.io/ebaron/cryostat-operator-bundle:cr-cleanup-01 --pod-security=restricted`
5. `operator-sdk scorecard -n cryostat-operator-scorecard -s cryostat-scorecard -w 10m quay.io/ebaron/cryostat-operator-bundle:cr-cleanup-01 --pod-security=restricted`
