### PR TITLE
test(scorecard): log workload conditions/events upon failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ ifneq ($(SKIP_TESTS), true)
 	operator-sdk run bundle -n $(SCORECARD_NAMESPACE) $(BUNDLE_IMG)
 	$(call scorecard-cleanup); \
 	trap cleanup EXIT; \
-	operator-sdk scorecard -n $(SCORECARD_NAMESPACE) -s cryostat-scorecard -w 10m $(BUNDLE_IMG) --pod-security=restricted
+	operator-sdk scorecard -n $(SCORECARD_NAMESPACE) -s cryostat-scorecard -w 20m $(BUNDLE_IMG) --pod-security=restricted
 endif
 
 .PHONY: clean-scorecard

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -54,7 +54,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:2.4.0-dev
-    createdAt: "2023-04-25T14:37:03Z"
+    createdAt: "2023-04-26T20:43:23Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -69,7 +69,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - operator-install
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230425143552
+    image: quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230426204317
     labels:
       suite: cryostat
       test: operator-install
@@ -79,7 +79,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-cr
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230425143552
+    image: quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230426204317
     labels:
       suite: cryostat
       test: cryostat-cr

--- a/config/scorecard/patches/custom.config.yaml
+++ b/config/scorecard/patches/custom.config.yaml
@@ -8,7 +8,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - operator-install
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230425143552"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230426204317"
     labels:
       suite: cryostat
       test: operator-install
@@ -18,7 +18,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-cr
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230425143552"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230426204317"
     labels:
       suite: cryostat
       test: cryostat-cr

--- a/internal/images/custom-scorecard-tests/rbac/scorecard_role.yaml
+++ b/internal/images/custom-scorecard-tests/rbac/scorecard_role.yaml
@@ -42,11 +42,21 @@ metadata:
   namespace: placeholder
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  - events
+  verbs:
+  - get
+  - list
+- apiGroups:
   - apps
   resources:
   - deployments
+  - replicasets
   verbs:
   - get
+  - list
 - apiGroups:
   - operator.cryostat.io
   resources:

--- a/internal/test/scorecard/tests.go
+++ b/internal/test/scorecard/tests.go
@@ -49,14 +49,16 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 const (
 	OperatorInstallTestName string        = "operator-install"
 	CryostatCRTestName      string        = "cryostat-cr"
 	operatorDeploymentName  string        = "cryostat-operator-controller-manager"
-	testTimeout             time.Duration = time.Minute * 10
+	testTimeout             time.Duration = time.Minute * 2 // FIXME
 )
 
 // OperatorInstallTest checks that the operator installed correctly
@@ -152,7 +154,7 @@ func CryostatCRTest(bundle *apimanifests.Bundle, namespace string, openShiftCert
 
 func waitForDeploymentAvailability(ctx context.Context, client *CryostatClientset, namespace string,
 	name string, r *scapiv1alpha3.TestResult) error {
-	return wait.PollImmediateUntilWithContext(ctx, time.Second, func(ctx context.Context) (done bool, err error) {
+	err := wait.PollImmediateUntilWithContext(ctx, time.Second, func(ctx context.Context) (done bool, err error) {
 		deploy, err := client.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			if kerrors.IsNotFound(err) {
@@ -168,10 +170,22 @@ func waitForDeploymentAvailability(ctx context.Context, client *CryostatClientse
 				r.Log += fmt.Sprintf("deployment %s is available\n", deploy.Name)
 				return true, nil
 			}
+			if condition.Type == appsv1.DeploymentReplicaFailure &&
+				condition.Status == corev1.ConditionTrue {
+				r.Log += fmt.Sprintf("deployment %s is failing, %s: %s\n", deploy.Name,
+					condition.Reason, condition.Message)
+			}
 		}
 		r.Log += fmt.Sprintf("deployment %s is not yet available\n", deploy.Name)
 		return false, nil
 	})
+	if err != nil {
+		logErr := logErrors(r, client, namespace, name)
+		if logErr != nil {
+			r.Log += fmt.Sprintf("failed to look up deployment errors: %s\n", logErr.Error())
+		}
+	}
+	return err
 }
 
 func fail(r scapiv1alpha3.TestResult, message string) scapiv1alpha3.TestResult {
@@ -193,4 +207,84 @@ func cleanupCryostat(r *scapiv1alpha3.TestResult, client *CryostatClientset, nam
 	if err != nil {
 		r.Log += fmt.Sprintf("failed to delete Cryostat: %s\n", err.Error())
 	}
+}
+
+func logErrors(r *scapiv1alpha3.TestResult, client *CryostatClientset, namespace string, name string) error {
+	ctx := context.Background()
+	deploy, err := client.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	// Log deployment conditions and events
+	r.Log += fmt.Sprintf("deployment %s conditions:\n", deploy.Name)
+	for _, condition := range deploy.Status.Conditions {
+		r.Log += fmt.Sprintf("\t%s == %s, %s: %s\n", condition.Type,
+			condition.Status, condition.Reason, condition.Message)
+	}
+
+	r.Log += fmt.Sprintf("deployment %s warning events:\n", deploy.Name)
+	err = logEvents(r, client, namespace, scheme.Scheme, deploy)
+	if err != nil {
+		return err
+	}
+
+	// Look up replica sets for deployment and log conditions and events
+	selector, err := metav1.LabelSelectorAsSelector(deploy.Spec.Selector)
+	if err != nil {
+		return err
+	}
+	replicaSets, err := client.AppsV1().ReplicaSets(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: selector.String(),
+	})
+	if err != nil {
+		return err
+	}
+	for _, rs := range replicaSets.Items {
+		r.Log += fmt.Sprintf("replica set %s conditions:\n", rs.Name)
+		for _, condition := range rs.Status.Conditions {
+			r.Log += fmt.Sprintf("\t%s == %s, %s: %s\n", condition.Type, condition.Status,
+				condition.Reason, condition.Message)
+		}
+		r.Log += fmt.Sprintf("replica set %s warning events:\n", rs.Name)
+		err = logEvents(r, client, namespace, scheme.Scheme, &rs)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Look up pods for deployment and log conditions and events
+	pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: selector.String(),
+	})
+	if err != nil {
+		return err
+	}
+	for _, pod := range pods.Items {
+		r.Log += fmt.Sprintf("pod %s phase: %s\n", pod.Name, pod.Status.Phase)
+		r.Log += fmt.Sprintf("pod %s conditions:\n", pod.Name)
+		for _, condition := range pod.Status.Conditions {
+			r.Log += fmt.Sprintf("\t%s == %s, %s: %s\n", condition.Type, condition.Status,
+				condition.Reason, condition.Message)
+		}
+		r.Log += fmt.Sprintf("pod %s warning events:\n", pod.Name)
+		err = logEvents(r, client, namespace, scheme.Scheme, &pod)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func logEvents(r *scapiv1alpha3.TestResult, client *CryostatClientset, namespace string,
+	scheme *runtime.Scheme, obj runtime.Object) error {
+	events, err := client.CoreV1().Events(namespace).Search(scheme, obj)
+	if err != nil {
+		return err
+	}
+	for _, event := range events.Items {
+		if event.Type == corev1.EventTypeWarning {
+			r.Log += fmt.Sprintf("\t%s: %s\n", event.Reason, event.Message)
+		}
+	}
+	return nil
 }

--- a/internal/test/scorecard/tests.go
+++ b/internal/test/scorecard/tests.go
@@ -58,7 +58,7 @@ const (
 	OperatorInstallTestName string        = "operator-install"
 	CryostatCRTestName      string        = "cryostat-cr"
 	operatorDeploymentName  string        = "cryostat-operator-controller-manager"
-	testTimeout             time.Duration = time.Minute * 2 // FIXME
+	testTimeout             time.Duration = time.Minute * 10
 )
 
 // OperatorInstallTest checks that the operator installed correctly


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #559 

## Description of the change:
If an expected deployment doesn't become available within the time limit (10m), log the conditions and warning events of the deployment, its replica sets and pods.

I also increased the timeout for the scorecard tests since we use timeouts for blocking operations inside the tests themselves and I've found that if the Scorecard timeout occurs then we lose logs.

## Motivation for the change:
If Scorecard tests are run on a cluster where we don't have access to logs, it would be helpful to include as much output as possible for why the tests failed.

## How to manually test:
I built a test bundle and scorecard image from this PR. I also set the `CORE_IMG` to `quay.io/ebaron/cryostat:does-not-exist` in order to cause an error during the test.
`make test-scorecard BUNDLE_IMG=quay.io/ebaron/cryostat-operator-bundle:replica-failure-03`

Here's a sample of the output upon deployment failure:
```
--------------------------------------------------------------------------------
Image:      quay.io/ebaron/cryostat-operator-scorecard:replica-failure-03
Entrypoint: [cryostat-scorecard-tests cryostat-cr]
Labels:
	"suite":"cryostat"
	"test":"cryostat-cr"
Results:
	Name: cryostat-cr
	State: fail

	Errors:
		Cryostat main deployment did not become available: timed out waiting for the condition
	Log:
		deployment cryostat-cr-test is not yet found
		deployment cryostat-cr-test is not yet found
		deployment cryostat-cr-test is not yet found
		deployment cryostat-cr-test is not yet found
		deployment cryostat-cr-test is not yet found
		deployment cryostat-cr-test is not yet found
		deployment cryostat-cr-test is not yet found
		deployment cryostat-cr-test is not yet available
		deployment cryostat-cr-test is not yet available
		[...]		
		deployment cryostat-cr-test is not yet available
		deployment cryostat-cr-test is not yet available
		deployment cryostat-cr-test conditions:
			Available == False, MinimumReplicasUnavailable: Deployment does not have minimum availability.
			Progressing == True, ReplicaSetUpdated: ReplicaSet "cryostat-cr-test-69bc79d7df" is progressing.
		deployment cryostat-cr-test warning events:
		replica set cryostat-cr-test-69bc79d7df conditions:
		replica set cryostat-cr-test-69bc79d7df warning events:
		pod cryostat-cr-test-69bc79d7df-b4vjz phase: Pending
		pod cryostat-cr-test-69bc79d7df-b4vjz conditions:
			Initialized == True, : 
			Ready == False, ContainersNotReady: containers with unready status: [cryostat-cr-test]
			ContainersReady == False, ContainersNotReady: containers with unready status: [cryostat-cr-test]
			PodScheduled == True, : 
		pod cryostat-cr-test-69bc79d7df-b4vjz warning events:
			Failed: Failed to pull image "quay.io/ebaron/cryostat:does-not-exist": rpc error: code = Unknown desc = reading manifest does-not-exist in quay.io/ebaron/cryostat: manifest unknown: manifest unknown
			Failed: Error: ErrImagePull
			Failed: Error: ImagePullBackOff
```