### PR TITLE
fix(csv): use Cryostat CR as initialization resource

### DIFF
--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -54,14 +54,14 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:2.4.0-dev
-    createdAt: "2023-04-26T20:43:23Z"
+    createdAt: "2023-04-27T17:44:16Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {
         "apiVersion": "operator.cryostat.io/v1beta1",
-        "kind": "ClusterCryostat",
+        "kind": "Cryostat",
         "metadata": {
-          "name": "clustercryostat-sample"
+          "name": "cryostat-sample"
         },
         "spec": {
           "enableCertManager": true,

--- a/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
@@ -10,9 +10,9 @@ metadata:
     operatorframework.io/initialization-resource: |-
       {
         "apiVersion": "operator.cryostat.io/v1beta1",
-        "kind": "ClusterCryostat",
+        "kind": "Cryostat",
         "metadata": {
-          "name": "clustercryostat-sample"
+          "name": "cryostat-sample"
         },
         "spec": {
           "enableCertManager": true,


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #562 

## Description of the change:
Changes the `initialization-resource` annotation back to the Cryostat CRD, as it was in 2.2.

## Motivation for the change:
We have to choose one of the two CRDs, and at this time, the old Cryostat CRD makes more sense as a default case.

## How to manually test:
1. Build a bundle image.
2. Deploy the bundle image.
3. Visit the installed operator in OpenShift Console.
4. You should be prompted to create a Cryostat CR.
