### PR TITLE
fix(deploy): lower default Grafana CPU request

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -168,9 +168,9 @@ By default, the operator deploys Cryostat with pre-configured resource requests:
 | Cryostat container CPU | 100m |
 | Cryostat container Memory | 384Mi |
 | JFR Data Source container CPU | 100m |
-|	JFR Data Source container Memory | 512Mi |
-|	Grafana container CPU | 1000m |
-|	Grafana container Memory | 256Mi |
+| JFR Data Source container Memory | 512Mi |
+| Grafana container CPU | 100m |
+| Grafana container Memory | 256Mi |
 
 Using the Cryostat custom resource, you can define resources requests and/or limits for each of the three containers in Cryostat's main pod:
 - the `core` container running the Cryostat backend and web application. If setting a memory limit for this container, we recommend at least 768MiB.

--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -86,7 +86,7 @@ const (
 	defaultCoreMemoryRequest          string = "384Mi"
 	defaultJfrDatasourceCpuRequest    string = "100m"
 	defaultJfrDatasourceMemoryRequest string = "512Mi"
-	defaultGrafanaCpuRequest          string = "1000m"
+	defaultGrafanaCpuRequest          string = "100m"
 	defaultGrafanaMemoryRequest       string = "256Mi"
 	defaultReportCpuRequest           string = "128m"
 	defaultReportMemoryRequest        string = "256Mi"

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -2695,7 +2695,7 @@ func (r *TestResources) NewDatasourceContainerResource(cr *model.CryostatInstanc
 func newGrafanaContainerDefaultResource() *corev1.ResourceRequirements {
 	return &corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("1000m"),
+			corev1.ResourceCPU:    resource.MustParse("100m"),
 			corev1.ResourceMemory: resource.MustParse("256Mi"),
 		},
 	}


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #564 

## Description of the change:
Lowers the default CPU resource request for the Grafana container from 1 CPU to 0.1 CPU.

## Motivation for the change:
This brings the Grafana container in line with what's deployed by the [Grafana Operator](https://github.com/grafana-operator/grafana-operator) by default. It allows Cryostat to run on more resource constrained clusters without manually lowering the resource requests when creating the Cryostat CR.

## How to manually test:
1. Deploy operator
2. Create a CR with all defaults
3. Inspect Grafana container's resource requests. It should be `100m` for CPU.
