### PR TITLE
build(go): upgrade to Golang 1.20

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.19.*'
+        go-version: '1.20.*'
     - uses: actions/cache@v2
       with:
         path: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/library/golang:1.19 as builder
+FROM docker.io/library/golang:1.20 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ kubectl get secret ${CRYOSTAT_NAME}-jmx-auth -o jsonpath='{$.data.CRYOSTAT_RJMX_
 
 # Building
 ## Requirements
-- `go` v1.19
+- `go` v1.20
 - [`operator-sdk`](https://github.com/operator-framework/operator-sdk) v1.28.0
 - [`cert-manager`](https://github.com/jetstack/cert-manager) v1.7.1+ (Recommended)
 - `podman` or `docker`

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -54,7 +54,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:2.4.0-dev
-    createdAt: "2023-04-27T17:44:16Z"
+    createdAt: "2023-05-01T14:54:37Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -69,7 +69,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - operator-install
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230426204317
+    image: quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230501145243
     labels:
       suite: cryostat
       test: operator-install
@@ -79,7 +79,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-cr
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230426204317
+    image: quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230501145243
     labels:
       suite: cryostat
       test: cryostat-cr

--- a/config/scorecard/patches/custom.config.yaml
+++ b/config/scorecard/patches/custom.config.yaml
@@ -8,7 +8,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - operator-install
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230426204317"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230501145243"
     labels:
       suite: cryostat
       test: operator-install
@@ -18,7 +18,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-cr
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230426204317"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230501145243"
     labels:
       suite: cryostat
       test: cryostat-cr

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cryostatio/cryostat-operator
 
-go 1.19
+go 1.20
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/internal/images/custom-scorecard-tests/Dockerfile
+++ b/internal/images/custom-scorecard-tests/Dockerfile
@@ -35,7 +35,7 @@
 # SOFTWARE.
 
 # Build the manager binary
-FROM docker.io/library/golang:1.19 as builder
+FROM docker.io/library/golang:1.20 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #568 

## Description of the change:
Modifies Dockerfiles, Makefile, go.mod and GitHub workflow to use Golang 1.20.

## Motivation for the change:
This ensures that the Golang version used to build the Cryostat Operator remains supported throughout the lifecycle of Cryostat 2.3.

## How to manually test:
1. `make deploy create_cryostat_cr OPERATOR_IMG=quay.io/ebaron/cryostat-operator:golang-1.20`
2. `make test-scorecard BUNDLE_IMG=quay.io/ebaron/cryostat-operator-bundle:golang-1.20`
