### PR TITLE
fix(crd): remove mentions of JMX in credential database

### DIFF
--- a/api/v1beta1/cryostat_types.go
+++ b/api/v1beta1/cryostat_types.go
@@ -106,9 +106,9 @@ type CryostatSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	TargetDiscoveryOptions *TargetDiscoveryOptions `json:"targetDiscoveryOptions,omitempty"`
-	// Options to configure the Cryostat application's JMX credentials database.
+	// Options to configure the Cryostat application's credentials database.
 	// +optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="JMX Credentials Database Options"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Credentials Database Options"
 	JmxCredentialsDatabaseOptions *JmxCredentialsDatabaseOptions `json:"jmxCredentialsDatabaseOptions,omitempty"`
 }
 
@@ -522,9 +522,9 @@ type TargetDiscoveryOptions struct {
 	BuiltInDiscoveryDisabled bool `json:"builtInDiscoveryDisabled,omitempty"`
 }
 
-// JmxCredentialsDatabaseOptions provides configuration options to the Cryostat application's JMX credentials database.
+// JmxCredentialsDatabaseOptions provides configuration options to the Cryostat application's credentials database.
 type JmxCredentialsDatabaseOptions struct {
-	// Name of the secret containing the password to encrypt JMX credentials database.
+	// Name of the secret containing the password to encrypt credentials database.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:io.kubernetes:Secret"}
 	DatabaseSecretName *string `json:"databaseSecretName,omitempty"`

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -54,7 +54,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:2.4.0-dev
-    createdAt: "2023-05-01T14:54:37Z"
+    createdAt: "2023-05-02T15:53:41Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {
@@ -182,11 +182,10 @@ spec:
         path: jmxCacheOptions.targetCacheTTL
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - description: Options to configure the Cryostat application's JMX credentials
-          database.
-        displayName: JMX Credentials Database Options
+      - description: Options to configure the Cryostat application's credentials database.
+        displayName: Credentials Database Options
         path: jmxCredentialsDatabaseOptions
-      - description: Name of the secret containing the password to encrypt JMX credentials
+      - description: Name of the secret containing the password to encrypt credentials
           database.
         displayName: Database Secret Name
         path: jmxCredentialsDatabaseOptions.databaseSecretName
@@ -566,11 +565,10 @@ spec:
         path: jmxCacheOptions.targetCacheTTL
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - description: Options to configure the Cryostat application's JMX credentials
-          database.
-        displayName: JMX Credentials Database Options
+      - description: Options to configure the Cryostat application's credentials database.
+        displayName: Credentials Database Options
         path: jmxCredentialsDatabaseOptions
-      - description: Name of the secret containing the password to encrypt JMX credentials
+      - description: Name of the secret containing the password to encrypt credentials
           database.
         displayName: Database Secret Name
         path: jmxCredentialsDatabaseOptions.databaseSecretName

--- a/bundle/manifests/operator.cryostat.io_clustercryostats.yaml
+++ b/bundle/manifests/operator.cryostat.io_clustercryostats.yaml
@@ -112,12 +112,12 @@ spec:
                     type: integer
                 type: object
               jmxCredentialsDatabaseOptions:
-                description: Options to configure the Cryostat application's JMX credentials
+                description: Options to configure the Cryostat application's credentials
                   database.
                 properties:
                   databaseSecretName:
                     description: Name of the secret containing the password to encrypt
-                      JMX credentials database.
+                      credentials database.
                     type: string
                 type: object
               maxWsConnections:

--- a/bundle/manifests/operator.cryostat.io_cryostats.yaml
+++ b/bundle/manifests/operator.cryostat.io_cryostats.yaml
@@ -108,12 +108,12 @@ spec:
                     type: integer
                 type: object
               jmxCredentialsDatabaseOptions:
-                description: Options to configure the Cryostat application's JMX credentials
+                description: Options to configure the Cryostat application's credentials
                   database.
                 properties:
                   databaseSecretName:
                     description: Name of the secret containing the password to encrypt
-                      JMX credentials database.
+                      credentials database.
                     type: string
                 type: object
               maxWsConnections:

--- a/config/crd/bases/operator.cryostat.io_clustercryostats.yaml
+++ b/config/crd/bases/operator.cryostat.io_clustercryostats.yaml
@@ -113,12 +113,12 @@ spec:
                     type: integer
                 type: object
               jmxCredentialsDatabaseOptions:
-                description: Options to configure the Cryostat application's JMX credentials
+                description: Options to configure the Cryostat application's credentials
                   database.
                 properties:
                   databaseSecretName:
                     description: Name of the secret containing the password to encrypt
-                      JMX credentials database.
+                      credentials database.
                     type: string
                 type: object
               maxWsConnections:

--- a/config/crd/bases/operator.cryostat.io_cryostats.yaml
+++ b/config/crd/bases/operator.cryostat.io_cryostats.yaml
@@ -109,12 +109,12 @@ spec:
                     type: integer
                 type: object
               jmxCredentialsDatabaseOptions:
-                description: Options to configure the Cryostat application's JMX credentials
+                description: Options to configure the Cryostat application's credentials
                   database.
                 properties:
                   databaseSecretName:
                     description: Name of the secret containing the password to encrypt
-                      JMX credentials database.
+                      credentials database.
                     type: string
                 type: object
               maxWsConnections:

--- a/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
@@ -133,11 +133,10 @@ spec:
         path: jmxCacheOptions.targetCacheTTL
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - description: Options to configure the Cryostat application's JMX credentials
-          database.
-        displayName: JMX Credentials Database Options
+      - description: Options to configure the Cryostat application's credentials database.
+        displayName: Credentials Database Options
         path: jmxCredentialsDatabaseOptions
-      - description: Name of the secret containing the password to encrypt JMX credentials
+      - description: Name of the secret containing the password to encrypt credentials
           database.
         displayName: Database Secret Name
         path: jmxCredentialsDatabaseOptions.databaseSecretName
@@ -505,11 +504,10 @@ spec:
         path: jmxCacheOptions.targetCacheTTL
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - description: Options to configure the Cryostat application's JMX credentials
-          database.
-        displayName: JMX Credentials Database Options
+      - description: Options to configure the Cryostat application's credentials database.
+        displayName: Credentials Database Options
         path: jmxCredentialsDatabaseOptions
-      - description: Name of the secret containing the password to encrypt JMX credentials
+      - description: Name of the secret containing the password to encrypt credentials
           database.
         displayName: Database Secret Name
         path: jmxCredentialsDatabaseOptions.databaseSecretName

--- a/internal/controllers/secrets.go
+++ b/internal/controllers/secrets.go
@@ -129,10 +129,10 @@ func (r *Reconciler) reconcileJMXSecret(ctx context.Context, cr *model.CryostatI
 }
 
 // databaseSecretNameSuffix is the suffix to be appended to the name of a
-// Cryostat CR to name its JMX credentials database secret
+// Cryostat CR to name its credentials database secret
 const databaseSecretNameSuffix = "-jmx-credentials-db"
 
-// dbSecretUserKey indexes the password within the Cryostat JMX credentials database Secret
+// dbSecretUserKey indexes the password within the Cryostat credentials database Secret
 const databaseSecretPassKey = "CRYOSTAT_JMX_CREDENTIALS_DB_PASSWORD"
 
 func (r *Reconciler) reconcileDatabaseSecret(ctx context.Context, cr *model.CryostatInstance) error {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to #573 

## Description of the change:

Update user displayName and description of the credential database option field. 

![Screenshot from 2023-05-02 11-53-12](https://user-images.githubusercontent.com/68053619/235719449-73c58aed-b357-45b6-8421-bba89f0ef195.png)

Though, with users creating or inspecting Cryostat with CLI. This descriptions are updated but the old field is visible.

```bash
$ oc explain cryostat.spec.jmxCredentialsDatabaseOptions
KIND:     Cryostat
VERSION:  operator.cryostat.io/v1beta1

RESOURCE: jmxCredentialsDatabaseOptions <Object>

DESCRIPTION:
     Options to configure the Cryostat application's credentials database.

FIELDS:
   databaseSecretName	<string>
     Name of the secret containing the password to encrypt credentials database.

```

## Motivation for the change:

See #573 