### PR TITLE
feat(ci): setup CI to push scorecard, bundle images and run scorecard

### DIFF
--- a/.github/kind-config.yaml
+++ b/.github/kind-config.yaml
@@ -1,0 +1,10 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,9 @@
 name: CI
 
+concurrency:
+  group: ci-${{ github.run_id }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:
@@ -107,7 +111,7 @@ jobs:
             printf -- "      kubeletExtraArgs:\n"
             printf -- "        node-labels: \"ingress-ready=true\"\n"
         } > kind-config.yaml
-        kind create cluster --config=kind-config.yaml -n ci-${{ github.repository_owner }}
+        kind create cluster --config=kind-config.yaml -n ci-${{ github.run_id }}
         # Enabling Ingress
         kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
         kubectl rollout status -w deployment/ingress-nginx-controller -n ingress-nginx --timeout 5m
@@ -144,7 +148,7 @@ jobs:
       run: |
         operator-sdk scorecard -n $SCORECARD_NAMESPACE -s $SCORECARD_SA_NAME -w 20m --pod-security=restricted ./bundle
     - name: Clean up Kind cluster 
-      run: kind delete cluster -n ci-${{ github.repository_owner }}
+      run: kind delete cluster -n ci-${{ github.run_id }}
   build-operator:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,7 @@ jobs:
     - name: Build scorecard image for test
       id: build-scorecard
       run: |
-        make scorecard-build CUSTOM_SCORECARD_IMG=ghcr.io/${{ github.repository_owner }}/cryostat-operator-scorecard:ci-$GITHUB_SHA
+        CUSTOM_SCORECARD_IMG=ghcr.io/${{ github.repository_owner }}/cryostat-operator-scorecard:ci-$GITHUB_SHA make scorecard-build
         echo "tag=ci-$GITHUB_SHA" >> $GITHUB_OUTPUT
     - name: Push scorecard image to ghcr.io for test
       id: push-scorecard-to-ghcr
@@ -77,10 +77,29 @@ jobs:
         registry: ghcr.io/${{ github.repository_owner }}
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GHCR_PR_TOKEN }}
+    - name: Build operator image for test
+      id: build-operator
+      run: |
+        OPERATOR_IMG=ghcr.io/${{ github.repository_owner }}/cryostat-operator:ci-$GITHUB_SHA \
+        SKIP_TESTS=true \
+        make oci-build
+        echo "tag=ci-$GITHUB_SHA" >> $GITHUB_OUTPUT
+    - name: Push operator image to ghcr.io for test
+      id: push-operator-to-ghcr
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: cryostat-operator
+        tags: ${{ steps.build-operator.outputs.tag }}
+        registry: ghcr.io/${{ github.repository_owner }}
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GHCR_PR_TOKEN }}
     - name: Build bundle image for test
       id: build-bundle
       run: |
-        make bundle bundle-build BUNDLE_IMG=ghcr.io/${{ github.repository_owner }}/cryostat-operator-bundle:ci-$GITHUB_SHA
+        yq -i '.spec.template.spec.imagePullSecrets = [{"name": "registry-key"}]' config/manager/manager.yaml
+        OPERATOR_IMG=${{ steps.push-operator-to-ghcr.outputs.registry-path }} \
+        BUNDLE_IMG=ghcr.io/${{ github.repository_owner }}/cryostat-operator-bundle:ci-$GITHUB_SHA \
+        make bundle bundle-build 
         echo "tag=ci-$GITHUB_SHA" >> $GITHUB_OUTPUT
     - name: Push bundle image to ghcr.io for test
       id: push-bundle-to-ghcr

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,14 +105,14 @@ jobs:
       run: curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.24.0/install.sh | bash -s v0.24.0
     - name: Install Cert Manager
       run: make cert_manager
-    - uses: docker/login-action@v2
+    - uses: redhat-actions/podman-login@v1
       with:
         registry: ${{ env.GHCR_SERVER }}
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GHCR_PR_TOKEN }}
+        auth_file_path: ${{ env.HOME }}/.docker/config.json
     - name: Run scorecard tests
       run: |
-        BUNDLE_SOURCE="./bundle" \
         SCORECARD_REGISTRY_SERVER="$GHCR_SERVER" \
         SCORECARD_REGISTRY_USERNAME="${{ github.repository_owner }}" \
         SCORECARD_REGISTRY_PASSWORD="${{ secrets.GHCR_PR_TOKEN }}" \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,9 +55,7 @@ jobs:
   scorecard-test:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'cryostatio' }}
-    env: 
-      SCORECARD_NAMESPACE: cryostat-operator-scorecard
-      SCORECARD_SA_NAME: cryostat-scorecard
+    env:
       GHCR_USERNAME: ${{ github.repository_owner }}
       GHCR_PASSWORD: ${{ secrets.GHCR_PR_TOKEN }}
       GHCR_SERVER: ghcr.io
@@ -112,29 +110,14 @@ jobs:
         registry: ${{ env.GHCR_SERVER }}
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GHCR_PR_TOKEN }}
-    - name: Set up scorecard environment
-      run: |
-        KUSTOMIZE=$PWD/bin/kustomize
-        make kustomize
-
-        # Create a test namespace
-        kubectl create namespace $SCORECARD_NAMESPACE
-
-        # Generate rbacs
-        pushd internal/images/custom-scorecard-tests/rbac/ && $KUSTOMIZE edit set namespace $SCORECARD_NAMESPACE
-        popd && $KUSTOMIZE build internal/images/custom-scorecard-tests/rbac/ | kubectl apply -f -
-
-        # Define credentials to pull from ghcr.io
-        kubectl create -n $SCORECARD_NAMESPACE secret docker-registry ghcr-key --docker-server="$GHCR_SERVER" \
-          --docker-username="$GHCR_USERNAME" --docker-password="$GHCR_PASSWORD"
-        kubectl patch sa $SCORECARD_SA_NAME -n $SCORECARD_NAMESPACE -p '{"imagePullSecrets": [{"name": "ghcr-key"}]}'
-
-        # Deploy the operator
-        operator-sdk run bundle -n $SCORECARD_NAMESPACE \
-          --timeout 20m --pull-secret-name ghcr-key --service-account $SCORECARD_SA_NAME ${{ steps.push-bundle-to-ghcr.outputs.registry-path }}
     - name: Run scorecard tests
       run: |
-        operator-sdk scorecard -n $SCORECARD_NAMESPACE -s $SCORECARD_SA_NAME -w 20m --pod-security=restricted ./bundle
+        BUNDLE_SOURCE="./bundle" \
+        SCORECARD_REGISTRY_SERVER="$GHCR_SERVER" \
+        SCORECARD_REGISTRY_USERNAME="${{ github.repository_owner }}" \
+        SCORECARD_REGISTRY_PASSWORD="${{ secrets.GHCR_PR_TOKEN }}" \
+        BUNDLE_IMG="${{ steps.push-bundle-to-ghcr.outputs.registry-path }}" \
+        make test-scorecard
     - name: Clean up Kind cluster 
       run: kind delete cluster -n ci-${{ github.run_id }}
   build-operator:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,10 +55,6 @@ jobs:
   scorecard-test:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'cryostatio' }}
-    env:
-      GHCR_USERNAME: ${{ github.repository_owner }}
-      GHCR_PASSWORD: ${{ secrets.GHCR_PR_TOKEN }}
-      GHCR_SERVER: ghcr.io
     steps:
     - name: Fail if safe-to-test label NOT applied
       if: ${{ github.event_name == 'pull_request_target' && !contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
@@ -107,13 +103,13 @@ jobs:
       run: make cert_manager
     - uses: redhat-actions/podman-login@v1
       with:
-        registry: ${{ env.GHCR_SERVER }}
+        registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GHCR_PR_TOKEN }}
-        auth_file_path: ${{ env.HOME }}/.docker/config.json
+        auth_file_path: $HOME/.docker/config.json
     - name: Run scorecard tests
       run: |
-        SCORECARD_REGISTRY_SERVER="$GHCR_SERVER" \
+        SCORECARD_REGISTRY_SERVER="ghcr.io" \
         SCORECARD_REGISTRY_USERNAME="${{ github.repository_owner }}" \
         SCORECARD_REGISTRY_PASSWORD="${{ secrets.GHCR_PR_TOKEN }}" \
         BUNDLE_IMG="${{ steps.push-bundle-to-ghcr.outputs.registry-path }}" \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,19 +99,7 @@ jobs:
         password: ${{ secrets.GHCR_PR_TOKEN }}
     - name: Set up Kind cluster
       run: |
-        {
-            printf -- "kind: Cluster\n"
-            printf -- "apiVersion: kind.x-k8s.io/v1alpha4\n"
-            printf -- "nodes:\n"
-            printf -- "- role: control-plane\n"
-            printf -- "  kubeadmConfigPatches:\n"
-            printf -- "  - |\n"
-            printf -- "    kind: InitConfiguration\n"
-            printf -- "    nodeRegistration:\n"
-            printf -- "      kubeletExtraArgs:\n"
-            printf -- "        node-labels: \"ingress-ready=true\"\n"
-        } > kind-config.yaml
-        kind create cluster --config=kind-config.yaml -n ci-${{ github.run_id }}
+        kind create cluster --config=".github/kind-config.yaml" -n ci-${{ github.run_id }}
         # Enabling Ingress
         kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
         kubectl rollout status -w deployment/ingress-nginx-controller -n ingress-nginx --timeout 5m

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: CI build
+name: CI
 
 on:
   push:
@@ -8,19 +8,32 @@ on:
       - v[0-9]+.[0-9]+
       - cryostat-v[0-9]+.[0-9]+
 
-  pull_request:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
     branches:
       - main
       - v[0-9]+
       - v[0-9]+.[0-9]+
       - cryostat-v[0-9]+.[0-9]+
 
+env:
+  CI_OPERATOR_IMG: quay.io/cryostat/cryostat-operator
+  CI_BUNDLE_IMG: quay.io/cryostat/cryostat-operator-bundle
+  CI_SCORECARD_IMG: quay.io/cryostat/cryostat-operator-scorecard
+
 jobs:
-  build:
+  controller-test:
     runs-on: ubuntu-latest
-    env:
-      CI_OPERATOR_IMG: quay.io/cryostat/cryostat-operator
+    if: ${{ github.repository_owner == 'cryostatio' }}
     steps:
+    - name: Fail if safe-to-test label NOT applied
+      if: ${{ github.event_name == 'pull_request_target' && !contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
+      run: exit 1
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
@@ -33,13 +46,112 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
+    - name: Run controller tests
+      run: make test-envtest
+  scorecard-test:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'cryostatio' }}
+    env: 
+      SCORECARD_NAMESPACE: cryostat-operator-scorecard
+      SCORECARD_SA_NAME: cryostat-scorecard
+      GHCR_USERNAME: ${{ github.repository_owner }}
+      GHCR_PASSWORD: ${{ secrets.GHCR_PR_TOKEN }}
+      GHCR_SERVER: ghcr.io
+    steps:
+    - name: Fail if safe-to-test label NOT applied
+      if: ${{ github.event_name == 'pull_request_target' && !contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
+      run: exit 1
+    - uses: actions/checkout@v2
     - uses: jpkrohling/setup-operator-sdk@v1.1.0
       with:
         operator-sdk-version: v1.28.0
-    - run: make generate manifests manager test-envtest
-      if: ${{ github.event_name == 'pull_request' }}
-    - run: make oci-build
-      if: ${{ github.event_name == 'push' }}
+    - name: Build scorecard image for test
+      id: build-scorecard
+      run: |
+        make scorecard-build CUSTOM_SCORECARD_IMG=ghcr.io/${{ github.repository_owner }}/cryostat-operator-scorecard:ci-$GITHUB_SHA
+        echo "tag=ci-$GITHUB_SHA" >> $GITHUB_OUTPUT
+    - name: Push scorecard image to ghcr.io for test
+      id: push-scorecard-to-ghcr
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: cryostat-operator-scorecard
+        tags: ${{ steps.build-scorecard.outputs.tag }}
+        registry: ghcr.io/${{ github.repository_owner }}
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GHCR_PR_TOKEN }}
+    - name: Build bundle image for test
+      id: build-bundle
+      run: |
+        make bundle bundle-build BUNDLE_IMG=ghcr.io/${{ github.repository_owner }}/cryostat-operator-bundle:ci-$GITHUB_SHA
+        echo "tag=ci-$GITHUB_SHA" >> $GITHUB_OUTPUT
+    - name: Push bundle image to ghcr.io for test
+      id: push-bundle-to-ghcr
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: cryostat-operator-bundle
+        tags: ${{ steps.build-bundle.outputs.tag }}
+        registry: ghcr.io/${{ github.repository_owner }}
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GHCR_PR_TOKEN }}
+    - name: Set up Kind cluster
+      run: |
+        {
+            printf -- "kind: Cluster\n"
+            printf -- "apiVersion: kind.x-k8s.io/v1alpha4\n"
+            printf -- "nodes:\n"
+            printf -- "- role: control-plane\n"
+            printf -- "  kubeadmConfigPatches:\n"
+            printf -- "  - |\n"
+            printf -- "    kind: InitConfiguration\n"
+            printf -- "    nodeRegistration:\n"
+            printf -- "      kubeletExtraArgs:\n"
+            printf -- "        node-labels: \"ingress-ready=true\"\n"
+        } > kind-config.yaml
+        kind create cluster --config=kind-config.yaml -n ci-${{ github.repository_owner }}
+        # Enabling Ingress
+        kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+        kubectl rollout status -w deployment/ingress-nginx-controller -n ingress-nginx --timeout 5m
+    - name: Install Operator Lifecycle Manager
+      run: curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.24.0/install.sh | bash -s v0.24.0
+    - name: Install Cert Manager
+      run: make cert_manager
+    - uses: docker/login-action@v2
+      with:
+        registry: ${{ env.GHCR_SERVER }}
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GHCR_PR_TOKEN }}
+    - name: Set up scorecard environment
+      run: |
+        KUSTOMIZE=$PWD/bin/kustomize
+        make kustomize
+
+        # Create a test namespace
+        kubectl create namespace $SCORECARD_NAMESPACE
+
+        # Generate rbacs
+        pushd internal/images/custom-scorecard-tests/rbac/ && $KUSTOMIZE edit set namespace $SCORECARD_NAMESPACE
+        popd && $KUSTOMIZE build internal/images/custom-scorecard-tests/rbac/ | kubectl apply -f -
+
+        # Define credentials to pull from ghcr.io
+        kubectl create -n $SCORECARD_NAMESPACE secret docker-registry ghcr-key --docker-server="$GHCR_SERVER" \
+          --docker-username="$GHCR_USERNAME" --docker-password="$GHCR_PASSWORD"
+        kubectl patch sa $SCORECARD_SA_NAME -n $SCORECARD_NAMESPACE -p '{"imagePullSecrets": [{"name": "ghcr-key"}]}'
+
+        # Deploy the operator
+        operator-sdk run bundle -n $SCORECARD_NAMESPACE \
+          --timeout 20m --pull-secret-name ghcr-key --service-account $SCORECARD_SA_NAME ${{ steps.push-bundle-to-ghcr.outputs.registry-path }}
+    - name: Run scorecard tests
+      run: |
+        operator-sdk scorecard -n $SCORECARD_NAMESPACE -s $SCORECARD_SA_NAME -w 20m --pod-security=restricted ./bundle
+    - name: Clean up Kind cluster 
+      run: kind delete cluster -n ci-${{ github.repository_owner }}
+  build-operator:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build operator image
+      run: SKIP_TESTS=true make oci-build
     - name: Tag image
       id: tag-image
       run: |
@@ -48,11 +160,10 @@ jobs:
           podman tag \
           ${{ env.CI_OPERATOR_IMG }}:$IMG_TAG \
           ${{ env.CI_OPERATOR_IMG }}:latest
-          echo "::set-output name=tags::$IMG_TAG latest"
+          echo "tags=$IMG_TAG latest" >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=tags::$IMG_TAG"
-        fi
-      if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
+          echo "tags=$IMG_TAG" >> $GITHUB_OUTPUT
+        fi    
     - name: Push to quay.io
       id: push-to-quay
       uses: redhat-actions/push-to-registry@v2
@@ -62,7 +173,69 @@ jobs:
         registry: quay.io/cryostat
         username: cryostat+bot
         password: ${{ secrets.REGISTRY_PASSWORD }}
-      if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
     - name: Print image URL
       run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
-      if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
+  build-bundle:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build bundle image
+      run: make bundle-build
+    - name: Tag image
+      id: tag-image
+      run: |
+        IMG_TAG="$(make --eval='print-img-ver: ; @echo $(IMAGE_VERSION)' print-img-ver)"
+        if [ "$GITHUB_REF" == "refs/heads/main" ]; then
+          podman tag \
+          ${{ env.CI_BUNDLE_IMG }}:$IMG_TAG \
+          ${{ env.CI_BUNDLE_IMG }}:latest
+          echo "tags=$IMG_TAG latest" >> $GITHUB_OUTPUT
+        else
+          echo "tags=$IMG_TAG" >> $GITHUB_OUTPUT
+        fi
+    - name: Push to quay.io
+      id: push-to-quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: cryostat-operator-bundle
+        tags: ${{ steps.tag-image.outputs.tags }}
+        registry: quay.io/cryostat
+        username: cryostat+bot
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+    - name: Print image URL
+      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+  build-scorecard:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && github.repository_owner == 'cryostatio' }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get scorecard image tag
+      id: get-image-tag
+      run: |
+        SCORECARD_TAG=$(yq '[.stages[0].tests[].image | capture("cryostat-operator-scorecard:(?P<tag>[\w.\-_]+)$")][0].tag' bundle/tests/scorecard/config.yaml)
+        echo "tag=$SCORECARD_TAG" >> $GITHUB_OUTPUT
+    - name: Check if scorecard image tag already exists
+      id: check-tag-exists
+      run: |
+        EXIST=false
+        if [ -n $(podman search --list-tags ${CI_SCORECARD_IMG} --format json | jq --arg TAG ${{ steps.get-image-tag.outputs.tag }} '.[0].Tags[] | select( . == $TAG)') ]; then
+          EXIST=true
+        fi
+        echo "exist=$EXIST" >> $GITHUB_OUTPUT
+    - name: Build scorecard image
+      run: make scorecard-build CUSTOM_SCORECARD_IMG=${CI_SCORECARD_IMG}:${{ steps.get-image-tag.outputs.tag }}
+      if: ${{ steps.check-tag-exists.outputs.exist == 'false' }}
+    - name: Push to quay.io
+      id: push-to-quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: cryostat-operator-scorecard
+        tags: ${{ steps.get-image-tag.outputs.tag }}
+        registry: quay.io/cryostat
+        username: cryostat+bot
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+      if: ${{ steps.check-tag-exists.outputs.exist == 'false' }}
+    - name: Print image URL
+      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+      if: ${{ steps.check-tag-exists.outputs.exist == 'false' }}

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ cache/
 
 # OPM tmp directory
 bundle_tmp*/
+
+# operator-sdk tmp bundles
+bundle-*/

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,3 +9,10 @@ pull_request_rules:
           - cryostat-v2.3
         assignees:
           - "{{ author }}"
+  - name: auto label PRs from reviewers
+    conditions:
+      - author=@reviewers
+    actions:
+      label:
+        add:
+          - safe-to-test

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ function cleanup { \
 	set +e; \
 	operator-sdk cleanup -n $(SCORECARD_NAMESPACE) $(OPERATOR_NAME); \
 	$(KUSTOMIZE) build internal/images/custom-scorecard-tests/rbac/ | $(CLUSTER_CLIENT) delete --ignore-not-found=$(ignore-not-found) -f -; \
+	$(CLUSTER_CLIENT) delete --ignore-not-found=$(ignore-not-found) -n $(SCORECARD_NAMESPACE) secret registry-key; \
 	$(CLUSTER_CLIENT) delete --ignore-not-found=$(ignore-not-found) namespace $(SCORECARD_NAMESPACE); \
 	)\
 }

--- a/Makefile
+++ b/Makefile
@@ -148,14 +148,13 @@ $(CLUSTER_CLIENT) create namespace $(SCORECARD_NAMESPACE)
 cd internal/images/custom-scorecard-tests/rbac/ && $(KUSTOMIZE) edit set namespace $(SCORECARD_NAMESPACE)
 $(KUSTOMIZE) build internal/images/custom-scorecard-tests/rbac/ | $(CLUSTER_CLIENT) apply -f -
 
-if [[ -n $(SCORECARD_REGISTRY_SERVER) && -n $(SCORECARD_REGISTRY_USERNAME) && -n $(SCORECARD_REGISTRY_PASSWORD) ]]; then \
+if [[ -n "$(SCORECARD_REGISTRY_SERVER)" && -n "$(SCORECARD_REGISTRY_USERNAME)" && -n "$(SCORECARD_REGISTRY_PASSWORD)" ]]; then \
 	$(CLUSTER_CLIENT) create -n $(SCORECARD_NAMESPACE) secret docker-registry registry-key --docker-server="$(SCORECARD_REGISTRY_SERVER)" \
 		--docker-username="$(SCORECARD_REGISTRY_USERNAME)" --docker-password="$(SCORECARD_REGISTRY_PASSWORD)"; \
 	$(CLUSTER_CLIENT) patch sa cryostat-scorecard -n $(SCORECARD_NAMESPACE) -p '{"imagePullSecrets": [{"name": "registry-key"}]}'; \
-	operator-sdk run bundle -n $(SCORECARD_NAMESPACE) --timeout 20m $(BUNDLE_IMG) --pull-secret-name registry-key --service-account cryostat-scorecard; \
-else \
-	operator-sdk run bundle -n $(SCORECARD_NAMESPACE) --timeout 20m $(BUNDLE_IMG);\
+	$(eval SCORECARD_ARGS=--pull-secret-name registry-key --service-account cryostat-scorecard) \
 fi
+operator-sdk run bundle -n $(SCORECARD_NAMESPACE) --timeout 20m $(BUNDLE_IMG) $(SCORECARD_ARGS)
 endef
 
 define scorecard-cleanup

--- a/Makefile
+++ b/Makefile
@@ -150,11 +150,11 @@ define scorecard-setup
 $(CLUSTER_CLIENT) create namespace $(SCORECARD_NAMESPACE)
 cd internal/images/custom-scorecard-tests/rbac/ && $(KUSTOMIZE) edit set namespace $(SCORECARD_NAMESPACE)
 $(KUSTOMIZE) build internal/images/custom-scorecard-tests/rbac/ | $(CLUSTER_CLIENT) apply -f -
-ifneq ($(SCORECARD_ARGS),)
-@$(CLUSTER_CLIENT) create -n $(SCORECARD_NAMESPACE) secret docker-registry registry-key --docker-server="$(SCORECARD_REGISTRY_SERVER)" \
-	--docker-username="$(SCORECARD_REGISTRY_USERNAME)" --docker-password="$(SCORECARD_REGISTRY_PASSWORD)"; \
-$(CLUSTER_CLIENT) patch sa cryostat-scorecard -n $(SCORECARD_NAMESPACE) -p '{"imagePullSecrets": [{"name": "registry-key"}]}'
-endif
+@if [ -n "$(SCORECARD_ARGS)" ]; then \
+	$(CLUSTER_CLIENT) create -n $(SCORECARD_NAMESPACE) secret docker-registry registry-key --docker-server="$(SCORECARD_REGISTRY_SERVER)" \
+		--docker-username="$(SCORECARD_REGISTRY_USERNAME)" --docker-password="$(SCORECARD_REGISTRY_PASSWORD)"; \
+	$(CLUSTER_CLIENT) patch sa cryostat-scorecard -n $(SCORECARD_NAMESPACE) -p '{"imagePullSecrets": [{"name": "registry-key"}]}'; \
+fi
 operator-sdk run bundle -n $(SCORECARD_NAMESPACE) --timeout 20m $(BUNDLE_IMG) $(SCORECARD_ARGS)
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ cd internal/images/custom-scorecard-tests/rbac/ && $(KUSTOMIZE) edit set namespa
 $(KUSTOMIZE) build internal/images/custom-scorecard-tests/rbac/ | $(CLUSTER_CLIENT) apply -f -
 
 if [[ -n "$(SCORECARD_REGISTRY_SERVER)" && -n "$(SCORECARD_REGISTRY_USERNAME)" && -n "$(SCORECARD_REGISTRY_PASSWORD)" ]]; then \
-	$(CLUSTER_CLIENT) create -n $(SCORECARD_NAMESPACE) secret docker-registry registry-key --docker-server="$(SCORECARD_REGISTRY_SERVER)" \
+	@$(CLUSTER_CLIENT) create -n $(SCORECARD_NAMESPACE) secret docker-registry registry-key --docker-server="$(SCORECARD_REGISTRY_SERVER)" \
 		--docker-username="$(SCORECARD_REGISTRY_USERNAME)" --docker-password="$(SCORECARD_REGISTRY_PASSWORD)"; \
 	$(CLUSTER_CLIENT) patch sa cryostat-scorecard -n $(SCORECARD_NAMESPACE) -p '{"imagePullSecrets": [{"name": "registry-key"}]}'; \
 	$(eval SCORECARD_ARGS=--pull-secret-name registry-key --service-account cryostat-scorecard) \

--- a/Makefile
+++ b/Makefile
@@ -150,11 +150,11 @@ define scorecard-setup
 $(CLUSTER_CLIENT) create namespace $(SCORECARD_NAMESPACE)
 cd internal/images/custom-scorecard-tests/rbac/ && $(KUSTOMIZE) edit set namespace $(SCORECARD_NAMESPACE)
 $(KUSTOMIZE) build internal/images/custom-scorecard-tests/rbac/ | $(CLUSTER_CLIENT) apply -f -
-if [ -n "$(SCORECARD_ARGS)" ]; then \
-	@$(CLUSTER_CLIENT) create -n $(SCORECARD_NAMESPACE) secret docker-registry registry-key --docker-server="$(SCORECARD_REGISTRY_SERVER)" \
-		--docker-username="$(SCORECARD_REGISTRY_USERNAME)" --docker-password="$(SCORECARD_REGISTRY_PASSWORD)"; \
-	$(CLUSTER_CLIENT) patch sa cryostat-scorecard -n $(SCORECARD_NAMESPACE) -p '{"imagePullSecrets": [{"name": "registry-key"}]}'; \
-fi
+ifneq ($(SCORECARD_ARGS),)
+@$(CLUSTER_CLIENT) create -n $(SCORECARD_NAMESPACE) secret docker-registry registry-key --docker-server="$(SCORECARD_REGISTRY_SERVER)" \
+	--docker-username="$(SCORECARD_REGISTRY_USERNAME)" --docker-password="$(SCORECARD_REGISTRY_PASSWORD)"; \
+$(CLUSTER_CLIENT) patch sa cryostat-scorecard -n $(SCORECARD_NAMESPACE) -p '{"imagePullSecrets": [{"name": "registry-key"}]}'
+endif
 operator-sdk run bundle -n $(SCORECARD_NAMESPACE) --timeout 20m $(BUNDLE_IMG) $(SCORECARD_ARGS)
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ IMAGE_TAG_BASE ?= $(IMAGE_NAMESPACE)/$(OPERATOR_NAME)
 # Default bundle image tag
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:$(BUNDLE_VERSION)
 BUNDLE_IMGS ?= $(BUNDLE_IMG)
-BUNDLE_SOURCE ?= $(BUNDLE_IMG)
 
 # Default catalog image tag
 CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:$(BUNDLE_VERSION) 
@@ -134,7 +133,7 @@ ifneq ($(SKIP_TESTS), true)
 	$(call scorecard-setup)
 	$(call scorecard-cleanup); \
 	trap cleanup EXIT; \
-	operator-sdk scorecard -n $(SCORECARD_NAMESPACE) -s cryostat-scorecard -w 20m $(BUNDLE_SOURCE) --pod-security=restricted
+	operator-sdk scorecard -n $(SCORECARD_NAMESPACE) -s cryostat-scorecard -w 20m $(BUNDLE_IMG) --pod-security=restricted
 endif
 
 .PHONY: clean-scorecard
@@ -154,7 +153,7 @@ if [[ -n "$(SCORECARD_REGISTRY_SERVER)" && -n "$(SCORECARD_REGISTRY_USERNAME)" &
 	$(CLUSTER_CLIENT) patch sa cryostat-scorecard -n $(SCORECARD_NAMESPACE) -p '{"imagePullSecrets": [{"name": "registry-key"}]}'; \
 	$(eval SCORECARD_ARGS=--pull-secret-name registry-key --service-account cryostat-scorecard) \
 fi
-operator-sdk run bundle -n $(SCORECARD_NAMESPACE) --timeout 20m $(BUNDLE_IMG) $(SCORECARD_ARGS)
+operator-sdk run bundle -n $(SCORECARD_NAMESPACE) --timeout 20m $(BUNDLE_IMG)
 endef
 
 define scorecard-cleanup


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #227, #493 
Depends on #589

## Description of the change:

- Add CI to push bundle and scorecard image (if not exists) to quay.io.
- Add CI to run envtest and scorecard.

## Motivation for the change:

See #227, #493

## How to manually test:

See CI job status:
- https://github.com/tthvo/cryostat-operator/actions/runs/5042553727/jobs/9043312859
- https://github.com/tthvo/cryostat-operator/actions/runs/5042639850/jobs/9043480603?pr=4

Push jobs on `main` push is failing on my repo since it does not have access to `cryostat/cryostat` but build steps seems to work fine.

## Others

We also need to remove checks for `build Expected — Waiting for status to be reported ` as CI job name is changed.