### PR TITLE
test(scorecard): enable scorecard on k8s

### DIFF
--- a/internal/test/scorecard/tests.go
+++ b/internal/test/scorecard/tests.go
@@ -309,7 +309,7 @@ func newCryostatCR(namespace string, withIngress bool) *operatorv1beta1.Cryostat
 					"nginx.ingress.kubernetes.io/backend-protocol": "HTTPS",
 				},
 				IngressSpec: &netv1.IngressSpec{
-					TLS: []netv1.IngressTLS{},
+					TLS: []netv1.IngressTLS{{}},
 					Rules: []netv1.IngressRule{
 						{
 							Host: "testing.cryostat",
@@ -340,7 +340,7 @@ func newCryostatCR(namespace string, withIngress bool) *operatorv1beta1.Cryostat
 					"nginx.ingress.kubernetes.io/backend-protocol": "HTTPS",
 				},
 				IngressSpec: &netv1.IngressSpec{
-					TLS: []netv1.IngressTLS{},
+					TLS: []netv1.IngressTLS{{}},
 					Rules: []netv1.IngressRule{
 						{
 							Host: "testing.cryostat-grafana",

--- a/internal/test/scorecard/tests.go
+++ b/internal/test/scorecard/tests.go
@@ -48,7 +48,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/networking/v1"
+	netv1 "k8s.io/api/networking/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -302,27 +302,27 @@ func newCryostatCR(namespace string, withIngress bool) *operatorv1beta1.Cryostat
 	}
 
 	if withIngress {
-		pathType := v1.PathTypePrefix
+		pathType := netv1.PathTypePrefix
 		cr.Spec.NetworkOptions = &operatorv1beta1.NetworkConfigurationList{
 			CoreConfig: &operatorv1beta1.NetworkConfiguration{
 				Annotations: map[string]string{
 					"nginx.ingress.kubernetes.io/backend-protocol": "HTTPS",
 				},
-				IngressSpec: &v1.IngressSpec{
-					TLS: []v1.IngressTLS{},
-					Rules: []v1.IngressRule{
+				IngressSpec: &netv1.IngressSpec{
+					TLS: []netv1.IngressTLS{},
+					Rules: []netv1.IngressRule{
 						{
 							Host: "testing.cryostat",
-							IngressRuleValue: v1.IngressRuleValue{
-								HTTP: &v1.HTTPIngressRuleValue{
-									Paths: []v1.HTTPIngressPath{
+							IngressRuleValue: netv1.IngressRuleValue{
+								HTTP: &netv1.HTTPIngressRuleValue{
+									Paths: []netv1.HTTPIngressPath{
 										{
 											Path:     "/",
 											PathType: &pathType,
-											Backend: v1.IngressBackend{
-												Service: &v1.IngressServiceBackend{
+											Backend: netv1.IngressBackend{
+												Service: &netv1.IngressServiceBackend{
 													Name: "cryostat-cr-test",
-													Port: v1.ServiceBackendPort{
+													Port: netv1.ServiceBackendPort{
 														Number: 8181,
 													},
 												},
@@ -339,21 +339,21 @@ func newCryostatCR(namespace string, withIngress bool) *operatorv1beta1.Cryostat
 				Annotations: map[string]string{
 					"nginx.ingress.kubernetes.io/backend-protocol": "HTTPS",
 				},
-				IngressSpec: &v1.IngressSpec{
-					TLS: []v1.IngressTLS{},
-					Rules: []v1.IngressRule{
+				IngressSpec: &netv1.IngressSpec{
+					TLS: []netv1.IngressTLS{},
+					Rules: []netv1.IngressRule{
 						{
 							Host: "testing.cryostat-grafana",
-							IngressRuleValue: v1.IngressRuleValue{
-								HTTP: &v1.HTTPIngressRuleValue{
-									Paths: []v1.HTTPIngressPath{
+							IngressRuleValue: netv1.IngressRuleValue{
+								HTTP: &netv1.HTTPIngressRuleValue{
+									Paths: []netv1.HTTPIngressPath{
 										{
 											Path:     "/",
 											PathType: &pathType,
-											Backend: v1.IngressBackend{
-												Service: &v1.IngressServiceBackend{
+											Backend: netv1.IngressBackend{
+												Service: &netv1.IngressServiceBackend{
 													Name: "cryostat-cr-test-grafana",
-													Port: v1.ServiceBackendPort{
+													Port: netv1.ServiceBackendPort{
 														Number: 3000,
 													},
 												},


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to #444 

## Description of the change:

Update tests to support running on k8s clusters. This is added with the assumption that the k8s cluster has Ingress enabled.

## Motivation for the change:

This allows testing other than OCP clusters (i.e. CI with kind).

## How to manually test:
1. Launch `kind` with Ingress enabled and OLM installed.
2. Install Cert Manager
3. Deploy operator bundle
4. Run scorecard
