### PR TITLE
fix(ci): new scorecard tag should trigger CI builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -209,7 +209,7 @@ jobs:
       id: check-tag-exists
       run: |
         EXIST=false
-        if [ -n $(podman search --list-tags ${CI_SCORECARD_IMG} --format json | jq --arg TAG ${{ steps.get-image-tag.outputs.tag }} '.[0].Tags[] | select( . == $TAG)') ]; then
+        if [ -n "$(podman search --list-tags ${CI_SCORECARD_IMG} --format json | jq --arg TAG ${{ steps.get-image-tag.outputs.tag }} '.[0].Tags[] | select( . == $TAG)')" ]; then
           EXIST=true
         fi
         echo "exist=$EXIST" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to: #588 

## Description of the change:

Fix scorecard check command so that new tag can trigger rebuilds.

## Motivation for the change:

New scorecard tag should trigger CI builds but its failing because check command is misbehaving.
