### PR TITLE
fix(cleanup): allow deletion to proceed without config map

### DIFF
--- a/internal/controllers/clustercryostat_controller_test.go
+++ b/internal/controllers/clustercryostat_controller_test.go
@@ -73,6 +73,7 @@ var _ = Describe("ClusterCryostatController", func() {
 
 		JustBeforeEach(func() {
 			c.commonJustBeforeEach(t)
+			t.reconcileCryostatFully()
 		})
 
 		JustAfterEach(func() {
@@ -80,7 +81,7 @@ var _ = Describe("ClusterCryostatController", func() {
 		})
 
 		It("should create the expected main deployment", func() {
-			t.expectDeployment()
+			t.expectMainDeployment()
 		})
 
 		It("should create RBAC in each namespace", func() {
@@ -103,24 +104,18 @@ var _ = Describe("ClusterCryostatController", func() {
 					t.NewRoleBinding(targetNamespaces[0]),
 					t.NewRoleBinding(targetNamespaces[1]))
 			})
-
 			It("should create the expected main deployment", func() {
-				t.expectDeployment()
+				t.expectMainDeployment()
 			})
-
 			It("leave RBAC for the first namespace", func() {
 				t.expectRBAC()
 			})
-
 			It("should remove RBAC from the second namespace", func() {
-				t.reconcileCryostatFully()
-
 				binding := t.NewRoleBinding(targetNamespaces[1])
 				err := t.Client.Get(context.Background(), types.NamespacedName{Name: binding.Name, Namespace: binding.Namespace}, binding)
 				Expect(err).ToNot(BeNil())
 				Expect(errors.IsNotFound(err)).To(BeTrue())
 			})
-
 			It("should update the target namespaces in Status", func() {
 				t.expectTargetNamespaces()
 			})
@@ -132,11 +127,6 @@ var _ = Describe("ClusterCryostatController", func() {
 				t.TargetNamespaces = nil
 				t.objs = append(t.objs, t.NewCryostat().Object)
 			})
-
-			It("should reconcile successfully", func() {
-				t.reconcileCryostatFully()
-			})
-
 			It("should update the target namespaces in Status", func() {
 				t.expectTargetNamespaces()
 			})
@@ -145,7 +135,6 @@ var _ = Describe("ClusterCryostatController", func() {
 })
 
 func (t *cryostatTestInput) expectTargetNamespaces() {
-	t.reconcileCryostatFully()
 	cr := t.getCryostatInstance()
 	Expect(*cr.TargetNamespaceStatus).To(ConsistOf(t.TargetNamespaces))
 }

--- a/internal/controllers/openshift.go
+++ b/internal/controllers/openshift.go
@@ -173,6 +173,7 @@ func (r *Reconciler) deleteCorsAllowedOrigins(ctx context.Context, cr *model.Cry
 
 	allowedOrigin := cr.Status.ApplicationURL
 	if len(allowedOrigin) == 0 {
+		reqLogger.Info("No Route to remove from APIServer config")
 		return nil
 	}
 

--- a/internal/controllers/reconciler.go
+++ b/internal/controllers/reconciler.go
@@ -145,12 +145,6 @@ func (r *Reconciler) reconcileCryostat(ctx context.Context, cr *model.CryostatIn
 func (r *Reconciler) reconcile(ctx context.Context, cr *model.CryostatInstance) (ctrl.Result, error) {
 	reqLogger := r.Log.WithValues("Request.Namespace", cr.InstallNamespace, "Request.Name", cr.Name)
 
-	// Create lock config map or fail if owned by another CR
-	err := r.reconcileLockConfigMap(ctx, cr)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
 	// Check if this Cryostat is being deleted
 	if cr.Object.GetDeletionTimestamp() != nil {
 		if controllerutil.ContainsFinalizer(cr.Object, cryostatFinalizer) {
@@ -184,6 +178,12 @@ func (r *Reconciler) reconcile(ctx context.Context, cr *model.CryostatInstance) 
 	}
 
 	reqLogger.Info("Spec", "Minimal", cr.Spec.Minimal)
+
+	// Create lock config map or fail if owned by another CR
+	err := r.reconcileLockConfigMap(ctx, cr)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
 
 	err = r.reconcilePVC(ctx, cr)
 	if err != nil {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #584 

## Description of the change:
The main change is to move the lock config map creation after handling the finalizer logic. The rest of the patch is additional test assurances that this doesn't break the name conflict handling introduced in #545.

## Motivation for the change:
This fixes the namespace deletion bug that's present in 2.3.0.

## How to manually test:
Ensure that deleting a conflicting CR doesn't delete/modify the original Cryostat installation:

1. Deploy operator into cryostat-operator-system
```
$ make deploy OPERATOR_IMG=quay.io/ebaron/cryostat-operator:namespace-del-fix-01
```
2. Create namespace c
```
$ kubectl create namespace c
```
3. Create Cryostat
```yaml
apiVersion: operator.cryostat.io/v1beta1
kind: Cryostat
metadata:
  name: cryostat-sample
  namespace: c
spec:
  minimal: false
  enableCertManager: true
  reportOptions:
    replicas: 0
```
4. Create ClusterCryostat
```yaml
apiVersion: operator.cryostat.io/v1beta1
kind: ClusterCryostat
metadata:
  name: cryostat-sample
spec:
  minimal: false
  enableCertManager: true
  installNamespace: c
  targetNamespaces:
  - c
  reportOptions:
    replicas: 0
```
5. Observe finalizer on ClusterCryostat
```
$ kubectl get clustercryostat cryostat-sample -o jsonpath='{.metadata.finalizers}'
["operator.cryostat.io/cryostat.finalizer"]
```
6. Delete ClusterCryostat
```
$ kubectl delete clustercryostat cryostat-sample
```
7. Check that ClusterRoleBinding and ConsoleLink were not deleted
```
$ kubectl get clusterrolebinding cryostat-22ca2798ad950a2953c096d484826501ddbae477d771250523c5523d9bd5a842
NAME                                                                        ROLE                                     AGE
cryostat-22ca2798ad950a2953c096d484826501ddbae477d771250523c5523d9bd5a842   ClusterRole/cryostat-operator-cryostat   46s
$ kubectl get consolelink cryostat-22ca2798ad950a2953c096d484826501ddbae477d771250523c5523d9bd5a842
NAME                                                                        TEXT       URL                                                                 MENU   AGE
cryostat-22ca2798ad950a2953c096d484826501ddbae477d771250523c5523d9bd5a842   Cryostat   https://cryostat-sample-cryostat-operator-system.apps.example.com          80s
```
8. Check that additionalCORSAllowedOrigins entry is still present in APIServer config:
```
$ kubectl get apiserver cluster -o jsonpath='{.spec.additionalCORSAllowedOrigins}'
["https://cryostat-sample-cryostat-operator-system\\.apps\\.example\\.com"]
```

Check that the namespace deletion bug is fixed:

1. Scale down the operator deployment
```
$ kubectl scale --replicas=0 deploy cryostat-operator-controller-manager
deployment.apps/cryostat-operator-controller-manager scaled
```
2. In another terminal, delete the namespace
```
$ kubectl delete namespace c
namespace "c" deleted
# hangs...
```
3. Scale the operator deployment back up
```
$ kubectl scale --replicas=1 deploy cryostat-operator-controller-manager
deployment.apps/cryostat-operator-controller-manager scaled
```
4. After some time, the namespace deletion proceeds
