### PR TITLE
fix(ci): ci should checkout correct ref

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,8 @@ env:
   CI_OPERATOR_IMG: quay.io/cryostat/cryostat-operator
   CI_BUNDLE_IMG: quay.io/cryostat/cryostat-operator-bundle
   CI_SCORECARD_IMG: quay.io/cryostat/cryostat-operator-scorecard
+  REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+  REF: ${{ github.event.pull_request.head.ref }}
 
 jobs:
   controller-test:
@@ -39,6 +41,9 @@ jobs:
       if: ${{ github.event_name == 'pull_request_target' && !contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
       run: exit 1
     - uses: actions/checkout@v2
+      with:
+        repository: ${{ env.REPOSITORY }}
+        ref: ${{ env.REF }}
     - uses: actions/setup-go@v2
       with:
         go-version: '1.20.*'
@@ -60,6 +65,9 @@ jobs:
       if: ${{ github.event_name == 'pull_request_target' && !contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
       run: exit 1
     - uses: actions/checkout@v2
+      with:
+        repository: ${{ env.REPOSITORY }}
+        ref: ${{ env.REF }}
     - uses: jpkrohling/setup-operator-sdk@v1.1.0
       with:
         operator-sdk-version: v1.28.0


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to #588 

## Description of the change:

Update checkout action to point to the correct ref on pull requests. In case of `main` push, the `github.event.pull_request` will be undefined and env vars are unset -> checkout action will use default values to point to upstream main.

## Motivation for the change:

Tests must be run on correct refs.

## Test Runs

PR: https://github.com/tthvo/cryostat-operator/actions/runs/5204207131/jobs/9388118038?pr=5

Main: https://github.com/tthvo/cryostat-operator/actions/runs/5204160566/jobs/9388004556