### PR TITLE
chore(oauth): remove modifications to OpenShift api-server

### DIFF
--- a/internal/controllers/openshift.go
+++ b/internal/controllers/openshift.go
@@ -56,11 +56,7 @@ func (r *Reconciler) reconcileOpenShift(ctx context.Context, cr *model.CryostatI
 	if !r.IsOpenShift {
 		return nil
 	}
-	err := r.reconcileConsoleLink(ctx, cr)
-	if err != nil {
-		return err
-	}
-	return r.addCorsAllowedOriginIfNotPresent(ctx, cr)
+	return r.reconcileConsoleLink(ctx, cr)
 }
 
 func (r *Reconciler) finalizeOpenShift(ctx context.Context, cr *model.CryostatInstance) error {
@@ -127,44 +123,6 @@ func (r *Reconciler) deleteConsoleLink(ctx context.Context, link *consolev1.Cons
 		return err
 	}
 	logger.Info("deleted ConsoleLink", "name", link.Name)
-	return nil
-}
-
-func (r *Reconciler) addCorsAllowedOriginIfNotPresent(ctx context.Context, cr *model.CryostatInstance) error {
-	reqLogger := r.Log.WithValues("Request.Namespace", cr.InstallNamespace, "Request.Name", cr.Name)
-
-	allowedOrigin := cr.Status.ApplicationURL
-	if len(allowedOrigin) == 0 {
-		return nil
-	}
-
-	apiServer := &configv1.APIServer{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: apiServerName}, apiServer)
-	if err != nil {
-		reqLogger.Error(err, "Failed to get APIServer config")
-		return err
-	}
-
-	allowedOriginAsRegex := regexp.QuoteMeta(allowedOrigin)
-
-	for _, origin := range apiServer.Spec.AdditionalCORSAllowedOrigins {
-		if origin == allowedOriginAsRegex {
-			return nil
-		}
-	}
-
-	apiServer.Spec.AdditionalCORSAllowedOrigins = append(
-		apiServer.Spec.AdditionalCORSAllowedOrigins,
-		allowedOriginAsRegex,
-	)
-
-	err = r.Client.Update(ctx, apiServer)
-	if err != nil {
-		reqLogger.Error(err, "Failed to update APIServer CORS allowed origins")
-		return err
-	}
-
-	reqLogger.Info("Added to APIServer CORS allowed origins")
 	return nil
 }
 

--- a/internal/controllers/openshift.go
+++ b/internal/controllers/openshift.go
@@ -56,7 +56,12 @@ func (r *Reconciler) reconcileOpenShift(ctx context.Context, cr *model.CryostatI
 	if !r.IsOpenShift {
 		return nil
 	}
-	return r.reconcileConsoleLink(ctx, cr)
+	err := r.reconcileConsoleLink(ctx, cr)
+	if err != nil {
+		return err
+	}
+	// Remove CORS modifications from previous operator versions
+	return r.deleteCorsAllowedOrigins(ctx, cr)
 }
 
 func (r *Reconciler) finalizeOpenShift(ctx context.Context, cr *model.CryostatInstance) error {

--- a/internal/controllers/openshift.go
+++ b/internal/controllers/openshift.go
@@ -154,16 +154,15 @@ func (r *Reconciler) deleteCorsAllowedOrigins(ctx context.Context, cr *model.Cry
 			apiServer.Spec.AdditionalCORSAllowedOrigins = append(
 				apiServer.Spec.AdditionalCORSAllowedOrigins[:i],
 				apiServer.Spec.AdditionalCORSAllowedOrigins[i+1:]...)
-			break
+			err = r.Client.Update(ctx, apiServer)
+			if err != nil {
+				reqLogger.Error(err, "Failed to remove Cryostat origin from APIServer CORS allowed origins")
+				return err
+			}
+
+			reqLogger.Info("Removed from APIServer CORS allowed origins")
+			return nil
 		}
 	}
-
-	err = r.Client.Update(ctx, apiServer)
-	if err != nil {
-		reqLogger.Error(err, "Failed to remove Cryostat origin from APIServer CORS allowed origins")
-		return err
-	}
-
-	reqLogger.Info("Removed from APIServer CORS allowed origins")
 	return nil
 }

--- a/internal/controllers/reconciler_test.go
+++ b/internal/controllers/reconciler_test.go
@@ -1282,9 +1282,6 @@ func (c *controllerTest) commonTests() {
 					Expect(link.Spec.NamespaceDashboard).To(Equal(expectedLink.Spec.NamespaceDashboard))
 				})
 			})
-			It("should add application url to APIServer AdditionalCORSAllowedOrigins", func() {
-				t.expectAPIServer()
-			})
 			It("should add the finalizer", func() {
 				t.expectCryostatFinalizerPresent()
 			})
@@ -1810,9 +1807,6 @@ func (c *controllerTest) commonTests() {
 					Context("on OpenShift", func() {
 						It("should not delete exisiting ConsoleLink", func() {
 							otherInput.expectConsoleLink()
-						})
-						It("should not remove CORS entry from APIServer", func() {
-							otherInput.expectAPIServer()
 						})
 					})
 				})

--- a/internal/controllers/reconciler_test.go
+++ b/internal/controllers/reconciler_test.go
@@ -1293,7 +1293,7 @@ func (c *controllerTest) commonTests() {
 					apiServer := &configv1.APIServer{}
 					err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cluster"}, apiServer)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(apiServer.Spec.AdditionalCORSAllowedOrigins).ToNot(ContainElement("https://cryostat\\.example\\.com"))
+					Expect(apiServer.Spec.AdditionalCORSAllowedOrigins).ToNot(ContainElement(fmt.Sprintf("https://%s\\.example\\.com", t.Name)))
 					Expect(apiServer.Spec.AdditionalCORSAllowedOrigins).To(ContainElement("https://an-existing-user-specified\\.allowed\\.origin\\.com"))
 				})
 			})
@@ -1331,7 +1331,7 @@ func (c *controllerTest) commonTests() {
 						apiServer := &configv1.APIServer{}
 						err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cluster"}, apiServer)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(apiServer.Spec.AdditionalCORSAllowedOrigins).ToNot(ContainElement("https://cryostat\\.example\\.com"))
+						Expect(apiServer.Spec.AdditionalCORSAllowedOrigins).ToNot(ContainElement(fmt.Sprintf("https://%s\\.example\\.com", t.Name)))
 						Expect(apiServer.Spec.AdditionalCORSAllowedOrigins).To(ContainElement("https://an-existing-user-specified\\.allowed\\.origin\\.com"))
 					})
 					It("should delete Cryostat", func() {

--- a/internal/controllers/reconciler_test.go
+++ b/internal/controllers/reconciler_test.go
@@ -1282,6 +1282,21 @@ func (c *controllerTest) commonTests() {
 					Expect(link.Spec.NamespaceDashboard).To(Equal(expectedLink.Spec.NamespaceDashboard))
 				})
 			})
+			Context("with an existing application url in APIServer AdditionalCORSAllowedOrigins", func() {
+				BeforeEach(func() {
+					t.objs = []ctrlclient.Object{
+						t.NewApiServerWithApplicationURL(),
+						t.NewNamespace(),
+					}
+				})
+				It("should remove the application url", func() {
+					apiServer := &configv1.APIServer{}
+					err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cluster"}, apiServer)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(apiServer.Spec.AdditionalCORSAllowedOrigins).ToNot(ContainElement("https://cryostat\\.example\\.com"))
+					Expect(apiServer.Spec.AdditionalCORSAllowedOrigins).To(ContainElement("https://an-existing-user-specified\\.allowed\\.origin\\.com"))
+				})
+			})
 			It("should add the finalizer", func() {
 				t.expectCryostatFinalizerPresent()
 			})

--- a/internal/controllers/reconciler_test.go
+++ b/internal/controllers/reconciler_test.go
@@ -2960,13 +2960,6 @@ func (t *cryostatTestInput) expectConsoleLink() {
 	Expect(link.Spec).To(Equal(expectedLink.Spec))
 }
 
-func (t *cryostatTestInput) expectAPIServer() {
-	apiServer := &configv1.APIServer{}
-	err := t.Client.Get(context.Background(), types.NamespacedName{Name: "cluster"}, apiServer)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(apiServer.Spec.AdditionalCORSAllowedOrigins).To(ContainElement(fmt.Sprintf("https://%s\\.example\\.com", t.Name)))
-}
-
 func (t *cryostatTestInput) expectResourcesUnaffected() {
 	for _, check := range resourceChecks() {
 		check.expectFunc(t)

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -2636,6 +2636,20 @@ func (r *TestResources) NewApiServer() *configv1.APIServer {
 	}
 }
 
+func (r *TestResources) NewApiServerWithApplicationURL() *configv1.APIServer {
+	return &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: configv1.APIServerSpec{
+			AdditionalCORSAllowedOrigins: []string{
+				"https://an-existing-user-specified\\.allowed\\.origin\\.com",
+				fmt.Sprintf("https://%s.example.com", r.Name),
+			},
+		},
+	}
+}
+
 func newCoreContainerDefaultResource() *corev1.ResourceRequirements {
 	return &corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to https://github.com/cryostatio/cryostat/issues/1489
Depends on https://github.com/cryostatio/cryostat-web/pull/1059

## Description of the change:

Remove the reconciler logics that modify the api-server to add cryostat application URL as allowed CORS origins.

## Motivation for the change:

https://github.com/cryostatio/cryostat-web/pull/1059 will submit form on the web client to clear login session. This removes the requirement for making CORS request.
