### PR TITLE
chore(scorecard): bump Scorecard tag to trigger arm64 build

### DIFF
--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -54,7 +54,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:2.4.0-dev
-    createdAt: "2023-08-16T13:02:09Z"
+    createdAt: "2023-08-16T19:16:28Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -69,7 +69,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - operator-install
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230525203053
+    image: quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230816190348
     labels:
       suite: cryostat
       test: operator-install
@@ -79,7 +79,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-cr
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230525203053
+    image: quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230816190348
     labels:
       suite: cryostat
       test: cryostat-cr

--- a/config/scorecard/patches/custom.config.yaml
+++ b/config/scorecard/patches/custom.config.yaml
@@ -8,7 +8,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - operator-install
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230525203053"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230816190348"
     labels:
       suite: cryostat
       test: operator-install
@@ -18,7 +18,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-cr
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230525203053"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:2.4.0-20230816190348"
     labels:
       suite: cryostat
       test: cryostat-cr


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to: https://github.com/cryostatio/cryostat/issues/1329

## Description of the change:
Bumps custom Scorecard image tag.

## Motivation for the change:
To trigger CI to build and push multi-arch (amd64, arm64) images.
