### PR TITLE
feat(ci): clean up test images after closing PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ on:
       - synchronize
       - labeled
       - unlabeled
+      - closed
     branches:
       - main
       - v[0-9]+
@@ -268,3 +269,22 @@ jobs:
     - name: Print image URL
       run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
       if: ${{ steps.check-tag-exists.outputs.exist == 'false' }}
+  delete-images:
+      name: Delete Docker images
+      runs-on: ubuntu-latest
+      steps:
+        - name: Check out code
+          uses: actions/checkout@v2
+
+        - name: Delete Docker images
+          uses: r26d/ghcr-delete-image-action@v1.2.2
+          with:
+            owner: ${{ github.repository_owner }}
+            name: cryostat-operator
+            token: ${{ secrets.GHCR_PR_TOKEN }}
+            ignore-missing-package: true
+            tag-regex: pr-${{ github.event.number }}-.*
+            tagged-keep-latest: 0
+
+        if: github.repository_owner == 'cryostatio'
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,6 @@ on:
       - synchronize
       - labeled
       - unlabeled
-      - closed
     branches:
       - main
       - v[0-9]+
@@ -269,22 +268,3 @@ jobs:
     - name: Print image URL
       run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
       if: ${{ steps.check-tag-exists.outputs.exist == 'false' }}
-  delete-images:
-      name: Delete Docker images
-      runs-on: ubuntu-latest
-      steps:
-        - name: Check out code
-          uses: actions/checkout@v2
-
-        - name: Delete Docker images
-          uses: r26d/ghcr-delete-image-action@v1.2.2
-          with:
-            owner: ${{ github.repository_owner }}
-            name: cryostat-operator
-            token: ${{ secrets.GHCR_PR_TOKEN }}
-            ignore-missing-package: true
-            tag-regex: pr-${{ github.event.number }}-.*
-            tagged-keep-latest: 0
-
-        if: github.repository_owner == 'cryostatio'
-

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,7 +85,7 @@ jobs:
     - name: Build scorecard image for test
       id: build-scorecard
       run: |
-        CUSTOM_SCORECARD_IMG=ghcr.io/${{ github.repository_owner }}/cryostat-operator-scorecard:ci-$GITHUB_SHA \
+        CUSTOM_SCORECARD_IMG=ghcr.io/${{ github.repository_owner }}/cryostat-operator-scorecard:pr-${{ github.event.number }}-$GITHUB_SHA \
         PLATFORMS=linux/amd64 \
         MANIFEST_PUSH=false \
         make scorecard-build
@@ -102,10 +102,10 @@ jobs:
     - name: Build operator image for test
       id: build-operator
       run: |
-        OPERATOR_IMG=ghcr.io/${{ github.repository_owner }}/cryostat-operator:ci-$GITHUB_SHA \
+        OPERATOR_IMG=ghcr.io/${{ github.repository_owner }}/cryostat-operator:pr-${{ github.event.number }}-$GITHUB_SHA \
         SKIP_TESTS=true \
         make oci-build
-        echo "tag=ci-$GITHUB_SHA" >> $GITHUB_OUTPUT
+        echo "tag=pr-${{ github.event.number }}-$GITHUB_SHA" >> $GITHUB_OUTPUT
     - name: Push operator image to ghcr.io for test
       id: push-operator-to-ghcr
       uses: redhat-actions/push-to-registry@v2
@@ -120,9 +120,9 @@ jobs:
       run: |
         yq -i '.spec.template.spec.imagePullSecrets = [{"name": "registry-key"}]' config/manager/manager.yaml
         OPERATOR_IMG=${{ steps.push-operator-to-ghcr.outputs.registry-path }} \
-        BUNDLE_IMG=ghcr.io/${{ github.repository_owner }}/cryostat-operator-bundle:ci-$GITHUB_SHA \
-        make bundle bundle-build 
-        echo "tag=ci-$GITHUB_SHA" >> $GITHUB_OUTPUT
+        BUNDLE_IMG=ghcr.io/${{ github.repository_owner }}/cryostat-operator-bundle:pr-${{ github.event.number }}-$GITHUB_SHA \
+        make bundle bundle-build
+        echo "tag=pr-${{ github.event.number }}-$GITHUB_SHA" >> $GITHUB_OUTPUT
     - name: Push bundle image to ghcr.io for test
       id: push-bundle-to-ghcr
       uses: redhat-actions/push-to-registry@v2
@@ -182,7 +182,7 @@ jobs:
           echo "tags=$IMG_TAG latest" >> $GITHUB_OUTPUT
         else
           echo "tags=$IMG_TAG" >> $GITHUB_OUTPUT
-        fi    
+        fi
     - name: Push to quay.io
       id: push-to-quay
       uses: redhat-actions/push-to-registry@v2

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -1,0 +1,28 @@
+name: Clean up PR-scoped test images
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+jobs:
+  delete-images:
+    name: Delete PR-scoped test images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Delete Docker images
+        uses: r26d/ghcr-delete-image-action@v1.2.2
+        with:
+          owner: ${{ github.repository_owner }}
+          name: cryostat-operator
+          token: ${{ secrets.GHCR_PR_TOKEN }}
+          ignore-missing-package: true
+          tag-regex: pr-${{ github.event.number }}-.*
+          tagged-keep-latest: 0
+
+        if: github.repository_owner == 'cryostatio'
+
+

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         image: [cryostat-operator, cryostat-operator-bundle, cryostat-operator-scorecard]
     steps:
-    - uses: r26d/ghcr-delete-image-action@v1.2.2
+    - uses: r26d/ghcr-delete-image-action@v1.3.0
       with:
         owner: ${{ github.repository_owner }}
         name: ${{ matrix.image }}

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -12,16 +12,13 @@ jobs:
 
     strategy:
       matrix:
-       image-names:
-        - cryostat-operator
-        - cryostat-operator-bundle
-        - cryostat-operator-scorecard
+        image: [cryostat-operator, cryostat-operator-bundle, cryostat-operator-scorecard]
     steps:
       - name: Delete Docker images
        uses: r26d/ghcr-delete-image-action@v1.2.2
        with:
           owner: ${{ github.repository_owner }}
-          name: ${{ matrix.image-names }}
+          name: ${{ matrix.image }}
           token: ${{ secrets.GHCR_PR_TOKEN }}
           ignore-missing-package: true
           tag-regex: pr-${{ github.event.number }}-.*

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -9,20 +9,24 @@ jobs:
   delete-images:
     name: Delete PR-scoped test images
     runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
 
+    strategy:
+      matrix:
+       image-names:
+        - cryostat-operator
+        - cryostat-operator-bundle
+        - cryostat-operator-scorecard
+    steps:
       - name: Delete Docker images
-        uses: r26d/ghcr-delete-image-action@v1.2.2
-        with:
+       uses: r26d/ghcr-delete-image-action@v1.2.2
+       with:
           owner: ${{ github.repository_owner }}
-          name: cryostat-operator
+          name: ${{ matrix.image-names }}
           token: ${{ secrets.GHCR_PR_TOKEN }}
           ignore-missing-package: true
           tag-regex: pr-${{ github.event.number }}-.*
           tagged-keep-latest: 0
 
-        if: github.repository_owner == 'cryostatio'
+       if: github.repository_owner == 'cryostatio'
 
 

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -7,15 +7,13 @@ on:
 
 jobs:
   delete-images:
-    name: Delete PR-scoped test images
     runs-on: ubuntu-latest
     if: github.repository_owner == 'cryostatio'
     strategy:
       matrix:
         image: [cryostat-operator, cryostat-operator-bundle, cryostat-operator-scorecard]
     steps:
-    - name: Delete Docker images
-      uses: r26d/ghcr-delete-image-action@v1.2.2
+    - uses: r26d/ghcr-delete-image-action@v1.2.2
       with:
         owner: ${{ github.repository_owner }}
         name: ${{ matrix.image }}

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -9,21 +9,17 @@ jobs:
   delete-images:
     name: Delete PR-scoped test images
     runs-on: ubuntu-latest
-
+    if: github.repository_owner == 'cryostatio'
     strategy:
       matrix:
         image: [cryostat-operator, cryostat-operator-bundle, cryostat-operator-scorecard]
     steps:
-      - name: Delete Docker images
-       uses: r26d/ghcr-delete-image-action@v1.2.2
-       with:
-          owner: ${{ github.repository_owner }}
-          name: ${{ matrix.image }}
-          token: ${{ secrets.GHCR_PR_TOKEN }}
-          ignore-missing-package: true
-          tag-regex: pr-${{ github.event.number }}-.*
-          tagged-keep-latest: 0
-
-       if: github.repository_owner == 'cryostatio'
-
-
+    - name: Delete Docker images
+      uses: r26d/ghcr-delete-image-action@v1.2.2
+      with:
+        owner: ${{ github.repository_owner }}
+        name: ${{ matrix.image }}
+        token: ${{ secrets.GHCR_PR_TOKEN }}
+        ignore-missing-package: true
+        tag-regex: pr-${{ github.event.number }}-.*
+        tagged-keep-latest: 0


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #603 

## Description of the change:
This change allows the removal of test images after the PR is closed

## Motivation for the change:
This change is helpful because it helps get rid of polluted dangling images

## How to manually test:
1. *Insert steps here...*
2. *...*
