### PR TITLE
feat(scorecard): add psa labels for scorecard namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ define scorecard-setup
 @$(CLUSTER_CLIENT) get namespace $(SCORECARD_NAMESPACE) >/dev/null 2>&1 &&\
 	echo "$(SCORECARD_NAMESPACE) namespace already exists, please remove it with \"make clean-scorecard\"" >&2 && exit 1 || true
 $(CLUSTER_CLIENT) create namespace $(SCORECARD_NAMESPACE) && \
-	kubectl label --overwrite namespace $(SCORECARD_NAMESPACE) pod-security.kubernetes.io/warn=restricted pod-security.kubernetes.io/audit=restricted
+	$(CLUSTER_CLIENT) label --overwrite namespace $(SCORECARD_NAMESPACE) pod-security.kubernetes.io/warn=restricted pod-security.kubernetes.io/audit=restricted
 cd internal/images/custom-scorecard-tests/rbac/ && $(KUSTOMIZE) edit set namespace $(SCORECARD_NAMESPACE)
 $(KUSTOMIZE) build internal/images/custom-scorecard-tests/rbac/ | $(CLUSTER_CLIENT) apply -f -
 @if [ -n "$(SCORECARD_ARGS)" ]; then \


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to https://github.com/cryostatio/cryostat-operator/pull/450

## Description of the change:

Label namespace to `warn` and `audit` violations to restricted standards. This is similar to SCC on  OpenShift 4.11 or 4.12 (if I remember correctly).

Ideally, we would want to set enforcing mode but there is an issue with the bundle pod (ie. `runAsNonRoot` is not `true`) - See below.

## Motivation for the change:

Scorecard pods are run with security contexts conforming to restricted standards.

https://github.com/cryostatio/cryostat-operator/blob/5c3769f5a2823847214528fb655b297d688dac14/Makefile#L141

However, scorecard namespace is not labelled to enforce such restricted policy.