### PR TITLE
feat(deployment): core resource requests split with sidecar

### DIFF
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -536,7 +536,16 @@ func NewCoreContainerResource(cr *model.CryostatInstance) *corev1.ResourceRequir
 	if cr.Spec.Resources != nil {
 		resources = cr.Spec.Resources.CoreResources.DeepCopy()
 	}
-	populateResourceRequest(resources, defaultCoreCpuRequest, defaultCoreMemoryRequest)
+	hasReportSidecar := cr.Spec.ReportOptions.Replicas > 0
+	cpuRequest := defaultCoreCpuRequest
+	if !hasReportSidecar {
+		cpuRequest = defaultReportCpuRequest
+	}
+	memoryRequest := defaultCoreMemoryRequest
+	if !hasReportSidecar {
+		memoryRequest = defaultReportMemoryRequest
+	}
+	populateResourceRequest(resources, cpuRequest, memoryRequest)
 	return resources
 }
 

--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -60,14 +60,14 @@ type TLSConfig struct {
 }
 
 const (
-	defaultCoreCpuRequest             string = "100m"
-	defaultCoreMemoryRequest          string = "384Mi"
-	defaultJfrDatasourceCpuRequest    string = "100m"
-	defaultJfrDatasourceMemoryRequest string = "512Mi"
+	defaultCoreCpuRequest             string = "500m"
+	defaultCoreMemoryRequest          string = "256Mi"
+	defaultJfrDatasourceCpuRequest    string = "200m"
+	defaultJfrDatasourceMemoryRequest string = "384Mi"
 	defaultGrafanaCpuRequest          string = "100m"
-	defaultGrafanaMemoryRequest       string = "256Mi"
-	defaultReportCpuRequest           string = "128m"
-	defaultReportMemoryRequest        string = "256Mi"
+	defaultGrafanaMemoryRequest       string = "120Mi"
+	defaultReportCpuRequest           string = "200m"
+	defaultReportMemoryRequest        string = "384Mi"
 )
 
 func NewDeploymentForCR(cr *model.CryostatInstance, specs *ServiceSpecs, imageTags *ImageTags,

--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -539,14 +539,23 @@ func NewCoreContainerResource(cr *model.CryostatInstance) *corev1.ResourceRequir
 	hasReportSidecar := cr.Spec.ReportOptions.Replicas > 0
 	cpuRequest := defaultCoreCpuRequest
 	if !hasReportSidecar {
-		cpuRequest = defaultReportCpuRequest
+		cpuRequest = max(defaultReportCpuRequest, defaultCoreCpuRequest)
 	}
 	memoryRequest := defaultCoreMemoryRequest
 	if !hasReportSidecar {
-		memoryRequest = defaultReportMemoryRequest
+		memoryRequest = max(defaultReportMemoryRequest, defaultCoreMemoryRequest)
 	}
 	populateResourceRequest(resources, cpuRequest, memoryRequest)
 	return resources
+}
+
+func max(x string, y string) string {
+	xr := resource.MustParse(x)
+	yr := resource.MustParse(y)
+	if xr.Cmp(yr) == 1 {
+		return x
+	}
+	return y
 }
 
 func NewCoreContainer(cr *model.CryostatInstance, specs *ServiceSpecs, imageTag string,

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -2631,8 +2631,8 @@ func (r *TestResources) NewApiServerWithApplicationURL() *configv1.APIServer {
 func newCoreContainerDefaultResource() *corev1.ResourceRequirements {
 	return &corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("100m"),
-			corev1.ResourceMemory: resource.MustParse("384Mi"),
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
 		},
 	}
 }
@@ -2659,8 +2659,8 @@ func (r *TestResources) NewCoreContainerResource(cr *model.CryostatInstance) *co
 func newDatasourceContainerDefaultResource() *corev1.ResourceRequirements {
 	return &corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("100m"),
-			corev1.ResourceMemory: resource.MustParse("512Mi"),
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("384Mi"),
 		},
 	}
 }
@@ -2688,7 +2688,7 @@ func newGrafanaContainerDefaultResource() *corev1.ResourceRequirements {
 	return &corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("100m"),
-			corev1.ResourceMemory: resource.MustParse("256Mi"),
+			corev1.ResourceMemory: resource.MustParse("120Mi"),
 		},
 	}
 }
@@ -2715,8 +2715,8 @@ func (r *TestResources) NewGrafanaContainerResource(cr *model.CryostatInstance) 
 func newReportContainerDefaultResource() *corev1.ResourceRequirements {
 	return &corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("128m"),
-			corev1.ResourceMemory: resource.MustParse("256Mi"),
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("384Mi"),
 		},
 	}
 }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Based on #617

## Description of the change:
If there is no configuration for `-reports` sidecar(s), increase the resources requested for the main `cryostat` container instead.

## Motivation for the change:
If the CR does not have any report generation configuration then the Cryostat server will fall back to generating reports itself by forking a subprocess within its container. This at least needs some memory allocation of its own and preferably some CPU time as well to complete its work in a reasonable time. So, in deployments like this, assign the maximum of the CPU and Memory requests that would go to either the core container or the reports container(s) to the core container so that the additional headroom may be used for subprocess report generation.
