### PR TITLE
docs(readme): build-ci and test-ci-push badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cryostat-operator
 
-[![CI build](https://github.com/cryostatio/cryostat-operator/actions/workflows/build-ci.yaml/badge.svg)](https://github.com/cryostatio/cryostat-operator/actions/workflows/build-ci.yaml)
+[![CI build](https://github.com/cryostatio/cryostat-operator/actions/workflows/build-ci.yml/badge.svg)](https://github.com/cryostatio/cryostat-operator/actions/workflows/build-ci.yml)
 [![Test CI push](https://github.com/cryostatio/cryostat-operator/actions/workflows/test-ci-push.yaml/badge.svg)](https://github.com/cryostatio/cryostat-operator/actions/workflows/test-ci-push.yaml)
 [![Google Group : Cryostat Development](https://img.shields.io/badge/Google%20Group-Cryostat%20Development-blue.svg)](https://groups.google.com/g/cryostat-development)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # cryostat-operator
 
-[![CI build](https://github.com/cryostatio/cryostat-operator/actions/workflows/ci.yaml/badge.svg)](https://github.com/cryostatio/cryostat-operator/actions/workflows/ci.yaml)
+[![CI build](https://github.com/cryostatio/cryostat-operator/actions/workflows/build-ci.yaml/badge.svg)](https://github.com/cryostatio/cryostat-operator/actions/workflows/build-ci.yaml)
+[![Test CI push](https://github.com/cryostatio/cryostat-operator/actions/workflows/test-ci-push.yaml/badge.svg)](https://github.com/cryostatio/cryostat-operator/actions/workflows/test-ci-push.yaml)
 [![Google Group : Cryostat Development](https://img.shields.io/badge/Google%20Group-Cryostat%20Development-blue.svg)](https://groups.google.com/g/cryostat-development)
 
 A Kubernetes Operator to automate deployment of

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cryostat-operator
 
 [![CI build](https://github.com/cryostatio/cryostat-operator/actions/workflows/build-ci.yml/badge.svg)](https://github.com/cryostatio/cryostat-operator/actions/workflows/build-ci.yml)
-[![Test CI push](https://github.com/cryostatio/cryostat-operator/actions/workflows/test-ci-push.yaml/badge.svg)](https://github.com/cryostatio/cryostat-operator/actions/workflows/test-ci-push.yaml)
+[![Test CI push](https://github.com/cryostatio/cryostat-operator/actions/workflows/test-ci-push.yml/badge.svg)](https://github.com/cryostatio/cryostat-operator/actions/workflows/test-ci-push.yml)
 [![Google Group : Cryostat Development](https://img.shields.io/badge/Google%20Group-Cryostat%20Development-blue.svg)](https://groups.google.com/g/cryostat-development)
 
 A Kubernetes Operator to automate deployment of


### PR DESCRIPTION
Fixes: #631 

## Description of the change:
* Edited existing badge from `ci.yml` to `build-ci.yml`
* Added another badge to `test-ci-push.yml`

## Motivation for the change:
* There was no `ci.yml` anymore.

## How to manually test:
* Open `README.md` and click on the badges.
