### PR TITLE
feat(ci): update github actions to node 16

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -26,7 +26,7 @@ jobs:
   build-operator:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install podman v4
       run: |
         echo "deb $OPENSUSE_UNOFFICIAL_LIBCONTAINERS_SOURCE_URL/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list
@@ -63,7 +63,7 @@ jobs:
   build-bundle:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build bundle image
       run: IMAGE_NAMESPACE=${{ env.CI_REGISTRY }} make bundle-build
     - name: Tag image
@@ -93,7 +93,7 @@ jobs:
   build-scorecard:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Get scorecard image tag
       id: get-image-tag
       run: |

--- a/.github/workflows/test-ci-command.yml
+++ b/.github/workflows/test-ci-command.yml
@@ -38,7 +38,7 @@ jobs:
       with:
         script: |
             const {owner, repo} = context.issue
-            github.rest.reactions.createForIssueComment({github.reactions.createForIssueComment
+            github.rest.reactions.createForIssueComment({
               owner,
               repo,
               comment_id: context.payload.comment.id,

--- a/.github/workflows/test-ci-command.yml
+++ b/.github/workflows/test-ci-command.yml
@@ -34,11 +34,11 @@ jobs:
         && (!contains(github.event.issue.labels.*.name, 'safe-to-test') || github.event.issue.user.name != github.event.comment.user.name)
       run: exit 1
     - name: React to comment
-      uses: actions/github-script@v4
+      uses: actions/github-script@v6
       with:
         script: |
             const {owner, repo} = context.issue
-            github.reactions.createForIssueComment({
+            github.rest.reactions.createForIssueComment({github.reactions.createForIssueComment
               owner,
               repo,
               comment_id: context.payload.comment.id,
@@ -55,11 +55,11 @@ jobs:
       PR_num: ${{ fromJSON(steps.comment-branch.outputs.result).num }}
       PR_repo: ${{ fromJSON(steps.comment-branch.outputs.result).repo }}
     steps:
-    - uses: actions/github-script@v4
+    - uses: actions/github-script@v6
       id: comment-branch
       with:
         script: |
-          const result = await github.pulls.get ({
+          const result = await github.rest.pulls.get ({
             owner: context.repo.owner,
             repo: context.repo.repo,
             pull_number: context.issue.number

--- a/.github/workflows/test-ci-command.yml
+++ b/.github/workflows/test-ci-command.yml
@@ -34,7 +34,7 @@ jobs:
         && (!contains(github.event.issue.labels.*.name, 'safe-to-test') || github.event.issue.user.name != github.event.comment.user.name)
       run: exit 1
     - name: React to comment
-      uses: actions/github-script@v4
+      uses: actions/github-script@v6
       with:
         script: |
             const {owner, repo} = context.issue
@@ -55,7 +55,7 @@ jobs:
       PR_num: ${{ fromJSON(steps.comment-branch.outputs.result).num }}
       PR_repo: ${{ fromJSON(steps.comment-branch.outputs.result).repo }}
     steps:
-    - uses: actions/github-script@v4
+    - uses: actions/github-script@v6
       id: comment-branch
       with:
         script: |

--- a/.github/workflows/test-ci-command.yml
+++ b/.github/workflows/test-ci-command.yml
@@ -34,7 +34,7 @@ jobs:
         && (!contains(github.event.issue.labels.*.name, 'safe-to-test') || github.event.issue.user.name != github.event.comment.user.name)
       run: exit 1
     - name: React to comment
-      uses: actions/github-script@v6
+      uses: actions/github-script@v4
       with:
         script: |
             const {owner, repo} = context.issue
@@ -55,7 +55,7 @@ jobs:
       PR_num: ${{ fromJSON(steps.comment-branch.outputs.result).num }}
       PR_repo: ${{ fromJSON(steps.comment-branch.outputs.result).repo }}
     steps:
-    - uses: actions/github-script@v6
+    - uses: actions/github-script@v4
       id: comment-branch
       with:
         script: |

--- a/.github/workflows/test-ci-reusable.yml
+++ b/.github/workflows/test-ci-reusable.yml
@@ -35,14 +35,14 @@ jobs:
   controller-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v4
       with:
         go-version: '1.20.*'
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           ~/go/pkg/mod
@@ -56,7 +56,7 @@ jobs:
   scorecard-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}

--- a/.github/workflows/test-ci-reusable.yml
+++ b/.github/workflows/test-ci-reusable.yml
@@ -42,7 +42,7 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version: '1.20.*'
-    - uses: actions/cache@v4
+    - uses: actions/cache@v3
       with:
         path: |
           ~/go/pkg/mod


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #638 

## Description of the change:
This change updates GitHub actions node version from 12 that is deprecated to v16

## Motivation for the change:
Running workflows produces warning of the deprecated node 12 version

## How to manually test:
1. *Insert steps here...*
2. *...*
