### PR TITLE
fix(makefile): fix ignore-not-found is not defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ run: manifests generate fmt vet
 	go run ./internal/main.go
 
 ifndef ignore-not-found
-	ignore-not-found = false
+ignore-not-found = false
 endif
 
 # Install CRDs into a cluster


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to #629 

## Description of the change:

Remove leading space when using conditional directives.

## Motivation for the change:

 Looks like leading tab is causing the variable to be undefined. And `kubectl delete` is complaining.