### PR TITLE
ci(dependabot): configure dependabot updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+go.mod @cryostatio/maintainers 
+go.sum @cryostatio/maintainers 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+    reviewers:
+      - "cryostatio/reviewers"
+    labels:
+      - "dependencies"
+      - "chore"
+      - "safe-to-test"
+    open-pull-requests-limit: 20
+    ignore:
+      - dependency-name: k8s.io/*
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: sigs.k8s.io/*
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: github.com/openshift/api
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: github.com/onsi/*
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,5 @@ updates:
       - dependency-name: sigs.k8s.io/*
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: github.com/openshift/api
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: github.com/onsi/*
         update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #537 

## Description of the change:

Configure dependabot updates to ignore k8s related deps. These deps will be upgrade with operator-sdk upgrades.

## Motivation for the change:

See #537 