### PR TITLE
fix(insights): add port to INSIGHTS_PROXY

### DIFF
--- a/internal/controllers/insights/insights.go
+++ b/internal/controllers/insights/insights.go
@@ -221,7 +221,7 @@ func (r *InsightsReconciler) createOrUpdateProxyService(ctx context.Context, svc
 		svc.Spec.Ports = []corev1.ServicePort{
 			{
 				Name:       "proxy",
-				Port:       8080,
+				Port:       ProxyServicePort,
 				TargetPort: intstr.FromString("proxy"),
 			},
 			{
@@ -278,7 +278,7 @@ func (r *InsightsReconciler) createOrUpdateProxyPodSpec(deploy *appsv1.Deploymen
 	container.Ports = []corev1.ContainerPort{
 		{
 			Name:          "proxy",
-			ContainerPort: 8080,
+			ContainerPort: ProxyServicePort,
 		},
 		{
 			Name:          "management",

--- a/internal/controllers/insights/insights_controller.go
+++ b/internal/controllers/insights/insights_controller.go
@@ -54,6 +54,7 @@ const (
 	InsightsConfigMapName    = "insights-proxy"
 	ProxyDeploymentName      = InsightsConfigMapName
 	ProxyServiceName         = ProxyDeploymentName
+	ProxyServicePort         = 8080
 	ProxySecretName          = "apicastconf"
 	EnvInsightsBackendDomain = "INSIGHTS_BACKEND_DOMAIN"
 	EnvInsightsProxyDomain   = "INSIGHTS_PROXY_DOMAIN"

--- a/internal/controllers/insights/setup.go
+++ b/internal/controllers/insights/setup.go
@@ -156,6 +156,7 @@ func (i *InsightsIntegration) deleteConfigMap(ctx context.Context, namespace str
 func (i *InsightsIntegration) getProxyURL(namespace string) *url.URL {
 	return &url.URL{
 		Scheme: "http", // TODO add https support (r.IsCertManagerInstalled)
-		Host:   fmt.Sprintf("%s.%s.svc.cluster.local", ProxyServiceName, namespace),
+		Host: fmt.Sprintf("%s.%s.svc.cluster.local:%d", ProxyServiceName, namespace,
+			ProxyServicePort),
 	}
 }

--- a/internal/controllers/insights/setup_test.go
+++ b/internal/controllers/insights/setup_test.go
@@ -82,7 +82,7 @@ var _ = Describe("InsightsIntegration", func() {
 				result, err := integration.Setup()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).ToNot(BeNil())
-				Expect(result.String()).To(Equal("http://insights-proxy.test.svc.cluster.local"))
+				Expect(result.String()).To(Equal("http://insights-proxy.test.svc.cluster.local:8080"))
 			})
 
 			It("should create config map", func() {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to: https://github.com/cryostatio/cryostat/issues/1763

## Description of the change:
Adds the HTTP port to the `INSIGHTS_PROXY` environment variable in the Cryostat deployment.

## Motivation for the change:
Agents attempt to incorrectly connect to the default port of 80.
