### PR TITLE
fix(insights): set User-Agent header for UHC Auth Proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OS = $(shell go env GOOS)
 ARCH = $(shell go env GOARCH)
 
 # Current Operator version
-IMAGE_VERSION ?= 2.5.0-dev
+export IMAGE_VERSION ?= 2.5.0-dev
 BUNDLE_VERSION ?= $(IMAGE_VERSION)
 DEFAULT_NAMESPACE ?= quay.io/cryostat
 IMAGE_NAMESPACE ?= $(DEFAULT_NAMESPACE)
@@ -128,7 +128,7 @@ INSIGHTS_PROXY_NAMESPACE ?= quay.io/3scale
 INSIGHTS_PROXY_NAME ?= apicast
 INSIGHTS_PROXY_VERSION ?= insights-01
 export INSIGHTS_PROXY_IMG ?= $(INSIGHTS_PROXY_NAMESPACE)/$(INSIGHTS_PROXY_NAME):$(INSIGHTS_PROXY_VERSION)
-export INSIGHTS_BACKEND ?= cert.console.redhat.com
+export INSIGHTS_BACKEND ?= console.redhat.com
 else
 KUSTOMIZE_DIR ?= config/default
 endif

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ OS = $(shell go env GOOS)
 ARCH = $(shell go env GOARCH)
 
 # Current Operator version
-export IMAGE_VERSION ?= 2.5.0-dev
+export OPERATOR_VERSION ?= 2.5.0-dev
+IMAGE_VERSION ?= $(OPERATOR_VERSION)
 BUNDLE_VERSION ?= $(IMAGE_VERSION)
 DEFAULT_NAMESPACE ?= quay.io/cryostat
 IMAGE_NAMESPACE ?= $(DEFAULT_NAMESPACE)

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -54,7 +54,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:2.5.0-dev
-    createdAt: "2023-11-07T20:18:21Z"
+    createdAt: "2023-11-13T21:47:45Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {
@@ -970,6 +970,14 @@ spec:
           - get
           - list
           - update
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusterversions
+          verbs:
+          - get
+          - list
           - watch
         - apiGroups:
           - console.openshift.io

--- a/config/insights/insights_patch.yaml
+++ b/config/insights/insights_patch.yaml
@@ -14,4 +14,4 @@ spec:
         - name: INSIGHTS_ENABLED
           value: "true"
         - name: INSIGHTS_BACKEND_DOMAIN
-          value: "cert.console.redhat.com"
+          value: "console.redhat.com"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -98,6 +98,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - console.openshift.io
   resources:
   - consolelinks

--- a/internal/controllers/const_generated.go
+++ b/internal/controllers/const_generated.go
@@ -4,6 +4,9 @@ package controllers
 // User facing name of the operand application
 const AppName = "Cryostat"
 
+// Version of the Cryostat Operator
+const OperatorVersion = "2.5.0-dev"
+
 // Default image tag for the core application image
 const DefaultCoreImageTag = "quay.io/cryostat/cryostat:latest"
 

--- a/internal/controllers/insights/apicast.go
+++ b/internal/controllers/insights/apicast.go
@@ -23,6 +23,7 @@ type apiCastConfigParams struct {
 	FrontendDomains       string
 	BackendInsightsDomain string
 	HeaderValue           string
+	UserAgent             string
 	ProxyDomain           string
 }
 
@@ -63,6 +64,12 @@ var apiCastConfigTemplate = template.Must(template.New("").Parse(`{
                   "header": "Authorization",
                   "value_type": "plain",
                   "value": "Bearer {{ .HeaderValue }}"
+                },
+                {
+                  "op": "set",
+                  "header": "User-Agent",
+                  "value_type": "plain",
+                  "value": "{{ .UserAgent }}"
                 }
               ]
             }

--- a/internal/controllers/insights/insights_controller.go
+++ b/internal/controllers/insights/insights_controller.go
@@ -85,6 +85,7 @@ func NewInsightsReconciler(config *InsightsReconcilerConfig) (*InsightsReconcile
 
 // +kubebuilder:rbac:groups=apps,resources=deployments;deployments/finalizers,verbs=*
 // +kubebuilder:rbac:groups="",resources=services;secrets;configmaps;configmaps/finalizers,verbs=*
+// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
 
 // Reconcile processes the Insights proxy deployment and configures it accordingly
 func (r *InsightsReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {

--- a/internal/controllers/insights/insights_controller_test.go
+++ b/internal/controllers/insights/insights_controller_test.go
@@ -63,6 +63,7 @@ var _ = Describe("InsightsController", func() {
 			t.objs = []ctrlclient.Object{
 				t.NewNamespace(),
 				t.NewGlobalPullSecret(),
+				t.NewClusterVersion(),
 				t.NewOperatorDeployment(),
 				t.NewProxyConfigMap(),
 			}

--- a/internal/controllers/insights/test/resources.go
+++ b/internal/controllers/insights/test/resources.go
@@ -17,7 +17,6 @@ package test
 import (
 	"fmt"
 
-	"github.com/cryostatio/cryostat-operator/internal/controllers"
 	"github.com/cryostatio/cryostat-operator/internal/test"
 	configv1 "github.com/openshift/api/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -31,6 +30,8 @@ type InsightsTestResources struct {
 	*test.TestResources
 	Resources *corev1.ResourceRequirements
 }
+
+const expectedOperatorVersion = "2.5.0-dev"
 
 func (r *InsightsTestResources) NewGlobalPullSecret() *corev1.Secret {
 	config := `{"auths":{"example.com":{"auth":"hello"},"cloud.openshift.com":{"auth":"world"}}}`
@@ -147,7 +148,7 @@ func (r *InsightsTestResources) NewInsightsProxySecret() *corev1.Secret {
 					}
 				  }
 				]
-			  }`, r.Namespace, controllers.OperatorVersion),
+			  }`, r.Namespace, expectedOperatorVersion),
 		},
 	}
 }
@@ -221,7 +222,7 @@ func (r *InsightsTestResources) NewInsightsProxySecretWithProxyDomain() *corev1.
 					}
 				  }
 				]
-			  }`, r.Namespace, controllers.OperatorVersion),
+			  }`, r.Namespace, expectedOperatorVersion),
 		},
 	}
 }

--- a/internal/controllers/insights/test/resources.go
+++ b/internal/controllers/insights/test/resources.go
@@ -17,7 +17,9 @@ package test
 import (
 	"fmt"
 
+	"github.com/cryostatio/cryostat-operator/internal/controllers"
 	"github.com/cryostatio/cryostat-operator/internal/test"
+	configv1 "github.com/openshift/api/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -118,6 +120,12 @@ func (r *InsightsTestResources) NewInsightsProxySecret() *corev1.Secret {
 								"header": "Authorization",
 								"value_type": "plain",
 								"value": "Bearer world"
+							  },
+							  {
+								"op": "set",
+								"header": "User-Agent",
+								"value_type": "plain",
+								"value": "cryostat-operator/%s cluster/abcde"
 							  }
 							]
 						  }
@@ -139,7 +147,7 @@ func (r *InsightsTestResources) NewInsightsProxySecret() *corev1.Secret {
 					}
 				  }
 				]
-			  }`, r.Namespace),
+			  }`, r.Namespace, controllers.OperatorVersion),
 		},
 	}
 }
@@ -186,6 +194,12 @@ func (r *InsightsTestResources) NewInsightsProxySecretWithProxyDomain() *corev1.
 								"header": "Authorization",
 								"value_type": "plain",
 								"value": "Bearer world"
+							  },
+							  {
+								"op": "set",
+								"header": "User-Agent",
+								"value_type": "plain",
+								"value": "cryostat-operator/%s cluster/abcde"
 							  }
 							]
 						  }
@@ -207,7 +221,7 @@ func (r *InsightsTestResources) NewInsightsProxySecretWithProxyDomain() *corev1.
 					}
 				  }
 				]
-			  }`, r.Namespace),
+			  }`, r.Namespace, controllers.OperatorVersion),
 		},
 	}
 }
@@ -362,6 +376,17 @@ func (r *InsightsTestResources) NewInsightsProxyService() *corev1.Service {
 					TargetPort: intstr.FromString("management"),
 				},
 			},
+		},
+	}
+}
+
+func (r *InsightsTestResources) NewClusterVersion() *configv1.ClusterVersion {
+	return &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "version",
+		},
+		Spec: configv1.ClusterVersionSpec{
+			ClusterID: "abcde",
 		},
 	}
 }

--- a/internal/main.go
+++ b/internal/main.go
@@ -147,9 +147,12 @@ func main() {
 	}
 
 	// Optionally enable Insights integration. Will only be enabled if INSIGHTS_ENABLED is true
-	insightsURL, err := insights.NewInsightsIntegration(mgr, &setupLog).Setup()
-	if err != nil {
-		setupLog.Error(err, "failed to set up Insights integration")
+	var insightsURL *url.URL
+	if openShift {
+		insightsURL, err = insights.NewInsightsIntegration(mgr, &setupLog).Setup()
+		if err != nil {
+			setupLog.Error(err, "failed to set up Insights integration")
+		}
 	}
 
 	config := newReconcilerConfig(mgr, "ClusterCryostat", "clustercryostat-controller", openShift,
@@ -185,7 +188,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupLog.Info("starting manager")
+	setupLog.Info("starting manager", "version", controllers.OperatorVersion)
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)

--- a/internal/tools/const_generator.go
+++ b/internal/tools/const_generator.go
@@ -23,6 +23,7 @@ import (
 )
 
 const appNameEnv = "APP_NAME"
+const imageVersionEnv = "IMAGE_VERSION"
 const coreImageEnv = "CORE_IMG"
 const datasourceImageEnv = "DATASOURCE_IMG"
 const grafanaImageEnv = "GRAFANA_IMG"
@@ -35,12 +36,14 @@ func main() {
 	// Fill in image tags struct from the environment variables
 	consts := struct {
 		AppName            string
+		OperatorVersion    string
 		CoreImageTag       string
 		DatasourceImageTag string
 		GrafanaImageTag    string
 		ReportsImageTag    string
 	}{
 		AppName:            getEnvVar(appNameEnv),
+		OperatorVersion:    getEnvVar(imageVersionEnv),
 		CoreImageTag:       getEnvVar(coreImageEnv),
 		DatasourceImageTag: getEnvVar(datasourceImageEnv),
 		GrafanaImageTag:    getEnvVar(grafanaImageEnv),
@@ -73,6 +76,9 @@ package controllers
 
 // User facing name of the operand application
 const AppName = "{{ .AppName }}"
+
+// Version of the Cryostat Operator
+const OperatorVersion = "{{ .OperatorVersion }}"
 
 // Default image tag for the core application image
 const DefaultCoreImageTag = "{{ .CoreImageTag }}"

--- a/internal/tools/const_generator.go
+++ b/internal/tools/const_generator.go
@@ -23,7 +23,7 @@ import (
 )
 
 const appNameEnv = "APP_NAME"
-const imageVersionEnv = "IMAGE_VERSION"
+const operatorVersionEnv = "OPERATOR_VERSION"
 const coreImageEnv = "CORE_IMG"
 const datasourceImageEnv = "DATASOURCE_IMG"
 const grafanaImageEnv = "GRAFANA_IMG"
@@ -43,7 +43,7 @@ func main() {
 		ReportsImageTag    string
 	}{
 		AppName:            getEnvVar(appNameEnv),
-		OperatorVersion:    getEnvVar(imageVersionEnv),
+		OperatorVersion:    getEnvVar(operatorVersionEnv),
 		CoreImageTag:       getEnvVar(coreImageEnv),
 		DatasourceImageTag: getEnvVar(datasourceImageEnv),
 		GrafanaImageTag:    getEnvVar(grafanaImageEnv),


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to: https://github.com/cryostatio/cryostat/issues/1763

## Description of the change:
Add a specific User-Agent header to route traffic through the UHC Auth Proxy: https://github.com/RedHatInsights/uhc-auth-proxy/commit/663067c681e0557cedc4358e62f130ab1dff6085

## Motivation for the change:
Traffic not routed through the UHC Auth Proxy requires a JWT Bearer token, which the cloud.openshift.com token is not.
