### PR TITLE
chore(makefile): option to generate bundles with quickstart on ocp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ IMAGE_TAG_BASE ?= $(IMAGE_NAMESPACE)/$(OPERATOR_NAME)
 # Default bundle image tag
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:$(BUNDLE_VERSION)
 BUNDLE_IMGS ?= $(BUNDLE_IMG)
+BUNDLE_MODE ?= k8s
 
 # Default catalog image tag
 CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:$(BUNDLE_VERSION)
@@ -275,6 +276,9 @@ catalog-build: opm ## Build a catalog image.
 bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(OPERATOR_IMG)
+ifeq ($(BUNDLE_MODE), ocp)
+	cd config/manifests && $(KUSTOMIZE) edit add base ../openshift
+endif
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	$(OPERATOR_SDK) bundle validate ./bundle
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to #668 

## Description of the change:

Added an option (Makefile) to generate the bundle with OpenShift manifests. Default to Kubernetes.

## Motivation for the change:

Avoid the need to manually edit the kustomize file when building bundles for OCP. I used this to check out the #668  so I thought it would be nice to have it here. 

## How to manually test:

```bash
BUNDLE_MODE=ocp make bundle
```
