### PR TITLE
ci(k8s): use minikube to launch k8s instead of kind

### DIFF
--- a/.github/workflows/test-ci-reusable.yml
+++ b/.github/workflows/test-ci-reusable.yml
@@ -117,14 +117,14 @@ jobs:
         registry: ghcr.io/${{ github.repository_owner }}
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Set up Kind cluster
-      run: |
-        kind create cluster --config=".github/kind-config.yaml" -n ci-${{ github.run_id }}
-        # Enabling Ingress
-        kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
-        kubectl rollout status -w deployment/ingress-nginx-controller -n ingress-nginx --timeout 5m
-    - name: Install Operator Lifecycle Manager
-      run: curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.24.0/install.sh | bash -s v0.24.0
+    - name: Set up k8s
+      uses: medyagh/setup-minikube@v0.0.14
+      with:
+        driver: docker
+        container-runtime: cri-o
+        network-plugin: cni
+        cni: calico
+        addons: storage-provisioner,default-storageclass,ingress,olm
     - name: Install Cert Manager
       run: make cert_manager
     - uses: redhat-actions/podman-login@v1

--- a/.github/workflows/test-ci-reusable.yml
+++ b/.github/workflows/test-ci-reusable.yml
@@ -122,8 +122,6 @@ jobs:
       with:
         driver: docker
         container-runtime: cri-o
-        network-plugin: cni
-        cni: calico
         addons: storage-provisioner,default-storageclass,ingress,olm
     - name: Install Cert Manager
       run: make cert_manager

--- a/.github/workflows/test-ci-reusable.yml
+++ b/.github/workflows/test-ci-reusable.yml
@@ -140,8 +140,6 @@ jobs:
         SCORECARD_REGISTRY_PASSWORD="${{ secrets.GITHUB_TOKEN }}" \
         BUNDLE_IMG="${{ steps.push-bundle-to-ghcr.outputs.registry-path }}" \
         make test-scorecard
-    - name: Clean up Kind cluster
-      run: kind delete cluster -n ci-${{ github.run_id }}
     - name: Set latest commit status as ${{ job.status }}
       uses: myrotvorets/set-commit-status-action@master
       if: always()


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #701 

## Description of the change:

Set up minikube cluster for CI instead of kind. ~I also add an additional cni plugin `calico`  to ensure that network policies are enforced.~

**EDITED:** Actually, seems like 2CPUs (i.e. [github action spec](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)) are not enough for running calico. I am hitting `Insufficient CPU` with cryostat pods remaining as `Pending` when running scorecard.
## Motivation for the change:

See #701. Mostly, this allows an easy way to test ingress host in scorecards.