### PR TITLE
chore(api): remove minimal option from CR spec

### DIFF
--- a/api/v1beta1/cryostat_conversion.go
+++ b/api/v1beta1/cryostat_conversion.go
@@ -42,7 +42,6 @@ func (src *Cryostat) ConvertTo(dstRaw conversion.Hub) error {
 }
 
 func convertSpecTo(src *CryostatSpec, dst *operatorv1beta2.CryostatSpec) {
-	dst.Minimal = src.Minimal
 	dst.EnableCertManager = src.EnableCertManager
 	dst.TrustedCertSecrets = convertCertSecretsTo(src.TrustedCertSecrets)
 	dst.EventTemplates = convertEventTemplatesTo(src.EventTemplates)
@@ -326,7 +325,6 @@ func (dst *Cryostat) ConvertFrom(srcRaw conversion.Hub) error {
 }
 
 func convertSpecFrom(src *operatorv1beta2.CryostatSpec, dst *CryostatSpec) {
-	dst.Minimal = src.Minimal
 	dst.EnableCertManager = src.EnableCertManager
 	dst.TrustedCertSecrets = convertCertSecretsFrom(src.TrustedCertSecrets)
 	dst.EventTemplates = convertEventTemplatesFrom(src.EventTemplates)

--- a/api/v1beta1/cryostat_conversion_test.go
+++ b/api/v1beta1/cryostat_conversion_test.go
@@ -81,7 +81,10 @@ func tableEntriesTo() []TableEntry {
 		Entry("WS connections", (*test.TestResources).NewCryostatWithWsConnectionsSpecV1Beta1,
 			(*test.TestResources).NewCryostat),
 		Entry("command config", (*test.TestResources).NewCryostatWithCommandConfigV1Beta1,
-			(*test.TestResources).NewCryostatWithIngress))
+			(*test.TestResources).NewCryostatWithIngress),
+		Entry("minimal mode", (*test.TestResources).NewCryostatWithMinimalModeV1Beta1,
+			(*test.TestResources).NewCryostat),
+	)
 }
 
 func tableEntriesFrom() []TableEntry {

--- a/api/v1beta2/cryostat_types.go
+++ b/api/v1beta2/cryostat_types.go
@@ -31,9 +31,6 @@ type CryostatSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=2
 	TargetNamespaces []string `json:"targetNamespaces,omitempty"`
-	// Deploy a pared-down Cryostat instance with no Grafana Dashboard or JFR Data Source.
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=4,displayName="Minimal Deployment",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
-	Minimal bool `json:"minimal"`
 	// List of TLS certificates to trust when connecting to targets.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Trusted TLS Certificates"

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -36,7 +36,6 @@ metadata:
           "spec": {
             "enableCertManager": true,
             "eventTemplates": [],
-            "minimal": false,
             "reportOptions": {
               "replicas": 0
             },
@@ -54,7 +53,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:2.5.0-dev
-    createdAt: "2024-03-15T21:38:16Z"
+    createdAt: "2024-03-18T06:34:51Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {
@@ -65,7 +64,6 @@ metadata:
         },
         "spec": {
           "enableCertManager": true,
-          "minimal": false,
           "reportOptions": {
             "replicas": 0
           }
@@ -525,12 +523,6 @@ spec:
           components. Requires cert-manager to be installed.
         displayName: Enable cert-manager Integration
         path: enableCertManager
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Deploy a pared-down Cryostat instance with no Grafana Dashboard
-          or JFR Data Source.
-        displayName: Minimal Deployment
-        path: minimal
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Override default authorization properties for Cryostat on OpenShift.

--- a/bundle/manifests/operator.cryostat.io_cryostats.yaml
+++ b/bundle/manifests/operator.cryostat.io_cryostats.yaml
@@ -4844,10 +4844,6 @@ spec:
                       credentials database.
                     type: string
                 type: object
-              minimal:
-                description: Deploy a pared-down Cryostat instance with no Grafana
-                  Dashboard or JFR Data Source.
-                type: boolean
               networkOptions:
                 description: Options to control how the operator exposes the application
                   outside of the cluster, such as using an Ingress or Route.
@@ -9056,8 +9052,6 @@ spec:
                   - secretName
                   type: object
                 type: array
-            required:
-            - minimal
             type: object
           status:
             description: CryostatStatus defines the observed state of Cryostat.

--- a/config/crd/bases/operator.cryostat.io_cryostats.yaml
+++ b/config/crd/bases/operator.cryostat.io_cryostats.yaml
@@ -4834,10 +4834,6 @@ spec:
                       credentials database.
                     type: string
                 type: object
-              minimal:
-                description: Deploy a pared-down Cryostat instance with no Grafana
-                  Dashboard or JFR Data Source.
-                type: boolean
               networkOptions:
                 description: Options to control how the operator exposes the application
                   outside of the cluster, such as using an Ingress or Route.
@@ -9046,8 +9042,6 @@ spec:
                   - secretName
                   type: object
                 type: array
-            required:
-            - minimal
             type: object
           status:
             description: CryostatStatus defines the observed state of Cryostat.

--- a/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
@@ -15,7 +15,6 @@ metadata:
         },
         "spec": {
           "enableCertManager": true,
-          "minimal": false,
           "reportOptions": {
             "replicas": 0
           }
@@ -75,12 +74,6 @@ spec:
           components. Requires cert-manager to be installed.
         displayName: Enable cert-manager Integration
         path: enableCertManager
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Deploy a pared-down Cryostat instance with no Grafana Dashboard
-          or JFR Data Source.
-        displayName: Minimal Deployment
-        path: minimal
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Override default authorization properties for Cryostat on OpenShift.

--- a/config/samples/operator_v1beta2_cryostat.yaml
+++ b/config/samples/operator_v1beta2_cryostat.yaml
@@ -3,7 +3,6 @@ kind: Cryostat
 metadata:
   name: cryostat-sample
 spec:
-  minimal: false
   enableCertManager: true
   trustedCertSecrets: []
   eventTemplates: []

--- a/docs/config.md
+++ b/docs/config.md
@@ -20,17 +20,6 @@ When installed in a multi-namespace manner, all users with access to a Cryostat 
 
 For now, all authorization checks are done against the namespace where Cryostat is installed. For a user to use Cryostat with workloads in a target namespace, that user must have the necessary Kubernetes permissions in the namespace where Cryostat is installed.
 
-### Minimal Deployment
-The `spec.minimal` property determines what is deployed alongside Cryostat. This value is set to `false` by default, which tells the operator to deploy Cryostat, with a [customized Grafana](https://github.com/cryostatio/cryostat-grafana-dashboard) and a [Grafana Data Source for JFR files](https://github.com/cryostatio/jfr-datasource) as 3 containers within a Pod. When `minimal` is set to `true`, the Deployment consists of only the Cryostat container.
-```yaml
-apiVersion: operator.cryostat.io/v1beta1
-kind: Cryostat
-metadata:
-  name: cryostat-sample
-spec:
-  minimal: true
-```
-
 ### Disabling cert-manager Integration
 By default, the operator expects [cert-manager](https://cert-manager.io/) to be available in the cluster. The operator uses cert-manager to generate a self-signed CA to allow traffic between Cryostat components within the cluster to use HTTPS. If cert-manager is not available in the cluster, this integration can be disabled with the `spec.enableCertManager` property.
 ```yaml

--- a/internal/controllers/ingresses.go
+++ b/internal/controllers/ingresses.go
@@ -61,10 +61,9 @@ func (r *Reconciler) reconcileGrafanaIngress(ctx context.Context, cr *model.Cryo
 		},
 	}
 
-	if cr.Spec.Minimal || cr.Spec.NetworkOptions == nil || cr.Spec.NetworkOptions.GrafanaConfig == nil ||
+	if cr.Spec.NetworkOptions == nil || cr.Spec.NetworkOptions.GrafanaConfig == nil ||
 		cr.Spec.NetworkOptions.GrafanaConfig.IngressSpec == nil {
-		// User has either chosen a minimal deployment or not requested
-		// an Ingress, delete if it exists
+		// User has not requested an Ingress, delete if it exists
 		return r.deleteIngress(ctx, ingress)
 	}
 	grafanaConfig := configureGrafanaIngress(cr)

--- a/internal/controllers/reconciler.go
+++ b/internal/controllers/reconciler.go
@@ -176,8 +176,6 @@ func (r *Reconciler) reconcileCryostat(ctx context.Context, cr *model.CryostatIn
 		}
 	}
 
-	reqLogger.Info("Spec", "Minimal", cr.Spec.Minimal)
-
 	// Create lock config map or fail if owned by another CR
 	err := r.reconcileLockConfigMap(ctx, cr)
 	if err != nil {

--- a/internal/controllers/routes.go
+++ b/internal/controllers/routes.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cryostatio/cryostat-operator/internal/controllers/model"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -61,10 +60,7 @@ func (r *Reconciler) reconcileGrafanaRoute(ctx context.Context, svc *corev1.Serv
 			Namespace: cr.InstallNamespace,
 		},
 	}
-	if cr.Spec.Minimal {
-		// Delete route if it exists
-		return r.deleteRoute(ctx, route)
-	}
+
 	grafanaConfig := configureGrafanaRoute(cr)
 	url, err := r.reconcileRoute(ctx, route, svc, cr, tls, grafanaConfig)
 	if err != nil {
@@ -143,16 +139,6 @@ func getProtocol(route *routev1.Route) string {
 		return "http"
 	}
 	return "https"
-}
-
-func (r *Reconciler) deleteRoute(ctx context.Context, route *routev1.Route) error {
-	err := r.Client.Delete(ctx, route)
-	if err != nil && !errors.IsNotFound(err) {
-		r.Log.Error(err, "Could not delete route", "name", route.Name, "namespace", route.Namespace)
-		return err
-	}
-	r.Log.Info("Route deleted", "name", route.Name, "namespace", route.Namespace)
-	return nil
 }
 
 func getHTTPPort(svc *corev1.Service) (*corev1.ServicePort, error) {

--- a/internal/controllers/secrets.go
+++ b/internal/controllers/secrets.go
@@ -43,34 +43,24 @@ func (r *Reconciler) reconcileGrafanaSecret(ctx context.Context, cr *model.Cryos
 		},
 	}
 
-	var secretName string
-	if cr.Spec.Minimal {
-		err := r.deleteSecret(ctx, secret)
-		if err != nil {
-			return err
+	err := r.createOrUpdateSecret(ctx, secret, cr.Object, func() error {
+		if secret.StringData == nil {
+			secret.StringData = map[string]string{}
 		}
-		secretName = ""
-	} else {
-		err := r.createOrUpdateSecret(ctx, secret, cr.Object, func() error {
-			if secret.StringData == nil {
-				secret.StringData = map[string]string{}
-			}
-			secret.StringData["GF_SECURITY_ADMIN_USER"] = "admin"
+		secret.StringData["GF_SECURITY_ADMIN_USER"] = "admin"
 
-			// Password is generated, so don't regenerate it when updating
-			if secret.CreationTimestamp.IsZero() {
-				secret.StringData["GF_SECURITY_ADMIN_PASSWORD"] = r.GenPasswd(20)
-			}
-			return nil
-		})
-		if err != nil {
-			return err
+		// Password is generated, so don't regenerate it when updating
+		if secret.CreationTimestamp.IsZero() {
+			secret.StringData["GF_SECURITY_ADMIN_PASSWORD"] = r.GenPasswd(20)
 		}
-		secretName = secret.Name
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	// Set the Grafana secret in the CR status
-	cr.Status.GrafanaSecret = secretName
+	cr.Status.GrafanaSecret = secret.Name
 	return r.Client.Status().Update(ctx, cr.Object)
 }
 

--- a/internal/test/conversion.go
+++ b/internal/test/conversion.go
@@ -43,9 +43,20 @@ func (r *TestResources) newCryostatSpecV1Beta1() operatorv1beta1.CryostatSpec {
 		}
 	}
 	return operatorv1beta1.CryostatSpec{
-		Minimal:           r.Minimal,
 		EnableCertManager: &certManager,
 		ReportOptions:     reportOptions,
+	}
+}
+
+func (r *TestResources) NewCryostatWithMinimalModeV1Beta1() *operatorv1beta1.Cryostat {
+	spec := r.newCryostatSpecV1Beta1()
+	spec.Minimal = true
+	return &operatorv1beta1.Cryostat{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      r.Name,
+			Namespace: r.Namespace,
+		},
+		Spec: spec,
 	}
 }
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #728 

## Description of the change:

- Removed minimal mode support in v1beta2 API.
  - I left the network resources (i.e. ingress, route) for grafana intact utill #727 that deploy cryostat3 behind proxy.

## Motivation for the change:

See #728 

## How to manually test:

Set up and rebuild images:

```bash
export IMAGE_NAMESPACE=quay.io/<namespace>
export IMAGE_VERSION=3.0.0-remove-minimal
make oci-build bundle bundle-build
podman push quay.io/<namespace>/cryostat-operator:$IMAGE_VERSION
podman push quay.io/<namespace>/cryostat-operator-bundle:$IMAGE_VERSION
make deploy_bundle
```

**With OpenShift:**

```bash
yq .spec.minimal=true config/samples/operator_v1beta1_cryostat.yaml | oc apply -f -
```

**With k8s (and Nginx Ingress Controller):**

Create a CR with the following specs in this [https://gist.github.com/tthvo/4be15d6ad0b52c5e1d6ee6f053f12371](https://gist.github.com/tthvo/4be15d6ad0b52c5e1d6ee6f053f12371).

```bash
kubectl apply -f <path-to-cr.yaml>
```

Watch the beta1 CR converted to beta2 without minimal mode and the k8s resources are created correctly as in non-minimal mode.