### PR TITLE
test(scorecard): add container logs to scorecard results

### DIFF
--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -54,7 +54,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:2.5.0-dev
-    createdAt: "2024-03-13T15:52:10Z"
+    createdAt: "2024-03-18T06:48:08Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -70,7 +70,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - operator-install
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240313145612
+    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240318064753
     labels:
       suite: cryostat
       test: operator-install
@@ -80,7 +80,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-cr
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240313145612
+    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240318064753
     labels:
       suite: cryostat
       test: cryostat-cr
@@ -90,7 +90,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-recording
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240313145612
+    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240318064753
     labels:
       suite: cryostat
       test: cryostat-recording
@@ -100,7 +100,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-config-change
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240313145612
+    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240318064753
     labels:
       suite: cryostat
       test: cryostat-config-change
@@ -110,7 +110,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-report
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240313145612
+    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240318064753
     labels:
       suite: cryostat
       test: cryostat-report

--- a/config/scorecard/patches/custom.config.yaml
+++ b/config/scorecard/patches/custom.config.yaml
@@ -8,7 +8,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - operator-install
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240313155212"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240318064753"
     labels:
       suite: cryostat
       test: operator-install
@@ -18,7 +18,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-cr
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240313155212"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240318064753"
     labels:
       suite: cryostat
       test: cryostat-cr
@@ -28,7 +28,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-recording
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240313155212"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240318064753"
     labels:
       suite: cryostat
       test: cryostat-recording
@@ -38,7 +38,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-config-change
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240313155212"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240318064753"
     labels:
       suite: cryostat
       test: cryostat-config-change
@@ -48,7 +48,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-report
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240313155212"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240318064753"
     labels:
       suite: cryostat
       test: cryostat-report

--- a/internal/images/custom-scorecard-tests/rbac/scorecard_role.yaml
+++ b/internal/images/custom-scorecard-tests/rbac/scorecard_role.yaml
@@ -102,6 +102,13 @@ rules:
   - statefulsets
   verbs:
   - get
+# Permissions to retrieve container logs
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/internal/test/scorecard/logger.go
+++ b/internal/test/scorecard/logger.go
@@ -1,0 +1,135 @@
+// Copyright The Cryostat Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scorecard
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	operatorv1beta1 "github.com/cryostatio/cryostat-operator/api/v1beta1"
+	scapiv1alpha3 "github.com/operator-framework/api/pkg/apis/scorecard/v1alpha3"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type ContainerLog struct {
+	Container string
+	Log       string
+}
+
+func LogCryostatContainer(clientset *kubernetes.Clientset, cr *operatorv1beta1.Cryostat, ch chan *ContainerLog) {
+	containerLog := &ContainerLog{
+		Container: "cryostat",
+	}
+	buf := &strings.Builder{}
+	podName, err := getCryostatPodNameForCR(clientset, cr)
+	if err != nil {
+		buf.WriteString(fmt.Sprintf("failed to get pod name: %s", err.Error()))
+	} else {
+		err := LogContainer(clientset, cr.Namespace, podName, cr.Name, buf)
+		if err != nil {
+			buf.WriteString(err.Error())
+		}
+	}
+
+	containerLog.Log = buf.String()
+	ch <- containerLog
+}
+
+func LogGrafanaContainer(clientset *kubernetes.Clientset, cr *operatorv1beta1.Cryostat, ch chan *ContainerLog) {
+	containerLog := &ContainerLog{
+		Container: "grafana",
+	}
+	buf := &strings.Builder{}
+	podName, err := getCryostatPodNameForCR(clientset, cr)
+	if err != nil {
+		buf.WriteString(fmt.Sprintf("failed to get pod name: %s", err.Error()))
+	} else {
+		err := LogContainer(clientset, cr.Namespace, podName, cr.Name+"-grafana", buf)
+		if err != nil {
+			buf.WriteString(err.Error())
+		}
+	}
+
+	containerLog.Log = buf.String()
+	ch <- containerLog
+}
+
+func LogDatasourceContainer(clientset *kubernetes.Clientset, cr *operatorv1beta1.Cryostat, ch chan *ContainerLog) {
+	containerLog := &ContainerLog{
+		Container: "jfr-datasource",
+	}
+	buf := &strings.Builder{}
+	podName, err := getCryostatPodNameForCR(clientset, cr)
+	if err != nil {
+		buf.WriteString(fmt.Sprintf("failed to get pod name: %s", err.Error()))
+	} else {
+		err := LogContainer(clientset, cr.Namespace, podName, cr.Name+"-jfr-datasource", buf)
+		if err != nil {
+			buf.WriteString(err.Error())
+		}
+	}
+
+	containerLog.Log = buf.String()
+	ch <- containerLog
+}
+
+func LogContainer(clientset *kubernetes.Clientset, namespace, podName, containerName string, dest io.Writer) error {
+	ctx, cancel := context.WithTimeout(context.TODO(), testTimeout)
+	defer cancel()
+
+	logOptions := &v1.PodLogOptions{
+		Follow:    true,
+		Container: containerName,
+	}
+	stream, err := clientset.CoreV1().Pods(namespace).GetLogs(podName, logOptions).Stream(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get logs for container %s in pod %s: %s", containerName, podName, err.Error())
+	}
+	defer stream.Close()
+
+	_, err = io.Copy(dest, stream)
+	if err != nil {
+		return fmt.Errorf("failed to store logs for container %s in pod %s: %s", containerName, podName, err.Error())
+	}
+	return nil
+}
+
+func CollectLogs(ch chan *ContainerLog) []*ContainerLog {
+	logs := make([]*ContainerLog, 0)
+	for i := 0; i < cap(ch); i++ {
+		logs = append(logs, <-ch)
+	}
+	return logs
+}
+
+func CollectContainersLogsToResult(result *scapiv1alpha3.TestResult, ch chan *ContainerLog) {
+	logs := CollectLogs(ch)
+	for _, log := range logs {
+		if log != nil {
+			result.Log += fmt.Sprintf("%s CONTAINER LOG:\n\n\t%s\n", strings.ToUpper(log.Container), log.Log)
+		}
+	}
+}
+
+func StartLogs(clientset *kubernetes.Clientset, cr *operatorv1beta1.Cryostat) chan *ContainerLog {
+	ch := make(chan *ContainerLog, 3)
+	go LogCryostatContainer(clientset, cr, ch)
+	go LogGrafanaContainer(clientset, cr, ch)
+	go LogDatasourceContainer(clientset, cr, ch)
+	return ch
+}

--- a/internal/test/scorecard/tests.go
+++ b/internal/test/scorecard/tests.go
@@ -143,7 +143,7 @@ func CryostatConfigChangeTest(bundle *apimanifests.Bundle, namespace string, ope
 }
 
 // TODO add a built in discovery test too
-func CryostatRecordingTest(bundle *apimanifests.Bundle, namespace string, openShiftCertManager bool) scapiv1alpha3.TestResult {
+func CryostatRecordingTest(bundle *apimanifests.Bundle, namespace string, openShiftCertManager bool) (result scapiv1alpha3.TestResult) {
 	tr := newTestResources(CryostatRecordingTestName)
 	r := tr.TestResult
 
@@ -157,6 +157,9 @@ func CryostatRecordingTest(bundle *apimanifests.Bundle, namespace string, openSh
 	if err != nil {
 		return fail(*r, fmt.Sprintf("failed to determine application URL: %s", err.Error()))
 	}
+	ch := StartLogs(tr.Client.Clientset, cr)
+	defer CollectContainersLogsToResult(&result, ch)
+
 	defer cleanupCryostat(r, tr.Client, CryostatRecordingTestName, namespace)
 
 	base, err := url.Parse(cr.Status.ApplicationURL)

--- a/internal/test/scorecard/tests.go
+++ b/internal/test/scorecard/tests.go
@@ -157,7 +157,10 @@ func CryostatRecordingTest(bundle *apimanifests.Bundle, namespace string, openSh
 	if err != nil {
 		return fail(*r, fmt.Sprintf("failed to determine application URL: %s", err.Error()))
 	}
-	ch := StartLogs(tr.Client.Clientset, cr)
+	ch, err := StartLogs(tr.Client.Clientset, cr)
+	if err != nil {
+		return fail(*r, fmt.Sprintf("failed to retrieve logs for the application: %s", err.Error()))
+	}
 	defer CollectContainersLogsToResult(&result, ch)
 
 	defer cleanupCryostat(r, tr.Client, CryostatRecordingTestName, namespace)


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #750 

## Description of the change:

Added goroutines to asynchronously fetch container logs and appended them to test results.

The idea works very nicely: https://gist.github.com/tthvo/fc6b06c948e410c3048610498b0ae09c. Maybe additional formatting is needed?

## Motivation for the change:


See #750 

## How to manually test:

```bash
export IMAGE_NAMESPACE=quay.io/thvo
make scorecard-build bundle bundle-build && \
  podman push $IMAGE_NAMESPACE/cryostat-operator-bundle:2.5.0-dev && \
  make test-scorecard 
```