### PR TITLE
fix(build-ci): fix scorecard image tag returned as null

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Get scorecard image tag
       id: get-image-tag
       run: |
-        SCORECARD_TAG=$(yq '[.stages[0].tests[].image | capture("cryostat-operator-scorecard:(?P<tag>[\w.\-_]+)$")][0].tag' bundle/tests/scorecard/config.yaml)
+        SCORECARD_TAG=$(yq '[.stages[1].tests[].image | capture("cryostat-operator-scorecard:(?P<tag>[\w.\-_]+)$")][0].tag' bundle/tests/scorecard/config.yaml)
         echo "tag=$SCORECARD_TAG" >> $GITHUB_OUTPUT
     - name: Check if scorecard image tag already exists
       id: check-tag-exists


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to #698 

## Description of the change:

Updated CI to get scorecard tag from the 2nd test stage (custom scorecard) added in #698.

## Motivation for the change:

The scorecard image is being built with tag `null` on upstream main.

CI: https://github.com/cryostatio/cryostat-operator/actions/runs/8161839436/job/22311468196

Quay: https://quay.io/repository/cryostat/cryostat-operator-scorecard?tab=tags
