### PR TITLE
fix(CI): add permission to publish comment when ci fails

### DIFF
--- a/.github/workflows/test-ci-command.yml
+++ b/.github/workflows/test-ci-command.yml
@@ -119,6 +119,8 @@ jobs:
     if: (always() && contains(needs.*.result, 'failure'))
     runs-on: ubuntu-latest
     needs: [run-test-jobs]
+    permissions:
+      pull-requests: write
     steps:
     - name: Leave Actions Run Comment
       uses: actions/github-script@v6


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to #744 

Add `pull-requests: write` so when a test fails, a comment can be made on the PR.