### PR TITLE
test(scorecard): add container logs for report sidecard test

### DIFF
--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -54,7 +54,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:2.5.0-dev
-    createdAt: "2024-04-04T17:17:25Z"
+    createdAt: "2024-04-05T22:43:31Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -70,7 +70,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - operator-install
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240404171629
+    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240405224154
     labels:
       suite: cryostat
       test: operator-install
@@ -80,7 +80,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-cr
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240404171629
+    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240405224154
     labels:
       suite: cryostat
       test: cryostat-cr
@@ -90,7 +90,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-multi-namespace
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240404171629
+    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240405224154
     labels:
       suite: cryostat
       test: cryostat-multi-namespace
@@ -100,7 +100,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-recording
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240404171629
+    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240405224154
     labels:
       suite: cryostat
       test: cryostat-recording
@@ -110,7 +110,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-config-change
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240404171629
+    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240405224154
     labels:
       suite: cryostat
       test: cryostat-config-change
@@ -120,7 +120,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-report
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240404171629
+    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240405224154
     labels:
       suite: cryostat
       test: cryostat-report

--- a/config/scorecard/patches/custom.config.yaml
+++ b/config/scorecard/patches/custom.config.yaml
@@ -8,7 +8,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - operator-install
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240404171725"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240405224154"
     labels:
       suite: cryostat
       test: operator-install
@@ -18,7 +18,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-cr
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240404171725"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240405224154"
     labels:
       suite: cryostat
       test: cryostat-cr
@@ -28,7 +28,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-multi-namespace
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240404171725"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240405224154"
     labels:
       suite: cryostat
       test: cryostat-multi-namespace
@@ -38,7 +38,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-recording
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240404171725"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240405224154"
     labels:
       suite: cryostat
       test: cryostat-recording
@@ -48,7 +48,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-config-change
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240404171725"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240405224154"
     labels:
       suite: cryostat
       test: cryostat-config-change
@@ -58,7 +58,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-report
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240404171725"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240405224154"
     labels:
       suite: cryostat
       test: cryostat-report

--- a/internal/test/scorecard/common_utils.go
+++ b/internal/test/scorecard/common_utils.go
@@ -600,26 +600,52 @@ func (r *TestResources) getCryostatPodNameForCR(cr *operatorv1beta1.Cryostat) (s
 	selector := metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"app":       cr.Name,
+			"kind":      "cryostat",
 			"component": "cryostat",
 		},
 	}
-	opts := metav1.ListOptions{
-		LabelSelector: labels.Set(selector.MatchLabels).String(),
-	}
 
-	ctx, cancel := context.WithTimeout(context.TODO(), testTimeout)
-	defer cancel()
-
-	pods, err := r.Client.CoreV1().Pods(cr.Namespace).List(ctx, opts)
+	names, err := r.getPodnamesForSelector(cr.Namespace, selector)
 	if err != nil {
 		return "", err
 	}
 
-	if len(pods.Items) == 0 {
+	if len(names) == 0 {
 		return "", fmt.Errorf("no matching cryostat pods for cr: %s", cr.Name)
 	}
+	return names[0].ObjectMeta.Name, nil
+}
 
-	return pods.Items[0].ObjectMeta.Name, nil
+func (r *TestResources) getReportPodNameForCR(cr *operatorv1beta1.Cryostat) (string, error) {
+	selector := metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"app":       cr.Name,
+			"kind":      "cryostat",
+			"component": "reports",
+		},
+	}
+
+	names, err := r.getPodnamesForSelector(cr.Namespace, selector)
+	if err != nil {
+		return "", err
+	}
+
+	if len(names) == 0 {
+		return "", fmt.Errorf("no matching report sidecar pods for cr: %s", cr.Name)
+	}
+	return names[0].ObjectMeta.Name, nil
+}
+
+func (r *TestResources) getPodnamesForSelector(namespace string, selector metav1.LabelSelector) ([]corev1.Pod, error) {
+	labelSelector := labels.Set(selector.MatchLabels).String()
+
+	ctx, cancel := context.WithTimeout(context.TODO(), testTimeout)
+	defer cancel()
+
+	pods, err := r.Client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	return pods.Items, err
 }
 
 func (r *TestResources) cleanupClusterCryostat(name string, namespace string, targetNamespaces []string) {

--- a/internal/test/scorecard/logger.go
+++ b/internal/test/scorecard/logger.go
@@ -97,11 +97,12 @@ func (r *TestResources) StartLogs(cr *operatorv1beta1.Cryostat) error {
 		return fmt.Errorf("failed to get pod name for CR: %s", err.Error())
 	}
 
-	logSelections := make(map[string][]string)
-	logSelections[cryostatPodName] = []string{
-		cr.Name,
-		cr.Name + "-grafana",
-		cr.Name + "-jfr-datasource",
+	logSelections := map[string][]string{
+		cryostatPodName: {
+			cr.Name,
+			cr.Name + "-grafana",
+			cr.Name + "-jfr-datasource",
+		},
 	}
 	bufferSize := 3
 
@@ -116,9 +117,9 @@ func (r *TestResources) StartLogs(cr *operatorv1beta1.Cryostat) error {
 
 	r.LogChannel = make(chan *ContainerLog, bufferSize)
 
-	for podName, containers := range logSelections {
+	for pod, containers := range logSelections {
 		for _, container := range containers {
-			go r.logContainer(cr.Namespace, podName, container)
+			go r.logContainer(cr.Namespace, pod, container)
 		}
 	}
 

--- a/internal/test/scorecard/tests.go
+++ b/internal/test/scorecard/tests.go
@@ -342,5 +342,10 @@ func CryostatReportTest(bundle *apimanifests.Bundle, namespace string, openShift
 		return r.fail(fmt.Sprintf("failed to reach the application: %s", err.Error()))
 	}
 
+	err = r.StartLogs(cr)
+	if err != nil {
+		r.Log += fmt.Sprintf("failed to retrieve logs for the application: %s", err.Error())
+	}
+
 	return r.TestResult
 }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to #758 

## Description of the change:

- Extended container logging goroutine to support report sidecar.
  - I was not sure if you meant to request it to be added in other tests too so I added only to report test now. Please let me know if you need it in others too :D 
- Formatted log output with some headers that include namespace, pod name, and container name.

## Motivation for the change:

> It would be cool in a follow up PR if we could get this working for other tests too. Like for the reports test, it would good to see the logs from the reports container too.

_Originally posted by @ebaron in https://github.com/cryostatio/cryostat-operator/pull/758#pullrequestreview-1947366013_

## Sample

https://gist.github.com/tthvo/3ec9f94f55aa1a376f4d2bc18069d5d7