### PR TITLE
chore(version): bump version to 3.0.0-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OS = $(shell go env GOOS)
 ARCH = $(shell go env GOARCH)
 
 # Current Operator version
-export OPERATOR_VERSION ?= 2.5.0-dev
+export OPERATOR_VERSION ?= 3.0.0-dev
 IMAGE_VERSION ?= $(OPERATOR_VERSION)
 BUNDLE_VERSION ?= $(IMAGE_VERSION)
 DEFAULT_NAMESPACE ?= quay.io/cryostat
@@ -92,7 +92,7 @@ ENVTEST_K8S_VERSION ?= 1.26
 # See: https://github.com/operator-framework/operator-sdk/pull/4762
 #
 # Suffix is the timestamp of the image build, compute with: date -u '+%Y%m%d%H%M%S'
-CUSTOM_SCORECARD_VERSION ?= 2.5.0-$(shell date -u '+%Y%m%d%H%M%S')
+CUSTOM_SCORECARD_VERSION ?= 3.0.0-$(shell date -u '+%Y%m%d%H%M%S')
 export CUSTOM_SCORECARD_IMG ?= $(IMAGE_TAG_BASE)-scorecard:$(CUSTOM_SCORECARD_VERSION)
 
 DEPLOY_NAMESPACE ?= cryostat-operator-system

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -52,8 +52,8 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
-    containerImage: quay.io/cryostat/cryostat-operator:2.5.0-dev
-    createdAt: "2024-03-27T17:35:46Z"
+    containerImage: quay.io/cryostat/cryostat-operator:3.0.0-dev
+    createdAt: "2024-03-27T18:00:37Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {
@@ -77,7 +77,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
-  name: cryostat-operator.v2.5.0-dev
+  name: cryostat-operator.v3.0.0-dev
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1106,7 +1106,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/cryostat/cryostat-operator:2.5.0-dev
+                image: quay.io/cryostat/cryostat-operator:3.0.0-dev
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -1234,7 +1234,7 @@ spec:
     name: grafana
   - image: quay.io/cryostat/cryostat-reports:latest
     name: reports
-  version: 2.5.0-dev
+  version: 3.0.0-dev
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -70,7 +70,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - operator-install
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240327173340
+    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240327175250
     labels:
       suite: cryostat
       test: operator-install
@@ -80,7 +80,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-cr
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240327173340
+    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240327175250
     labels:
       suite: cryostat
       test: cryostat-cr
@@ -90,7 +90,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-recording
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240327173340
+    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240327175250
     labels:
       suite: cryostat
       test: cryostat-recording
@@ -100,7 +100,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-config-change
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240327173340
+    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240327175250
     labels:
       suite: cryostat
       test: cryostat-config-change
@@ -110,7 +110,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-report
-    image: quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240327173340
+    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240327175250
     labels:
       suite: cryostat
       test: cryostat-report

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/cryostat/cryostat-operator
-  newTag: 2.5.0-dev
+  newTag: 3.0.0-dev

--- a/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
-    containerImage: quay.io/cryostat/cryostat-operator:2.5.0-dev
+    containerImage: quay.io/cryostat/cryostat-operator:3.0.0-dev
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {

--- a/config/scorecard/patches/custom.config.yaml
+++ b/config/scorecard/patches/custom.config.yaml
@@ -8,7 +8,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - operator-install
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240327173340"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240327175250"
     labels:
       suite: cryostat
       test: operator-install
@@ -18,7 +18,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-cr
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240327173340"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240327175250"
     labels:
       suite: cryostat
       test: cryostat-cr
@@ -28,7 +28,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-recording
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240327173340"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240327175250"
     labels:
       suite: cryostat
       test: cryostat-recording
@@ -38,7 +38,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-config-change
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240327173340"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240327175250"
     labels:
       suite: cryostat
       test: cryostat-config-change
@@ -48,7 +48,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-report
-    image: "quay.io/cryostat/cryostat-operator-scorecard:2.5.0-20240327173340"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240327175250"
     labels:
       suite: cryostat
       test: cryostat-report

--- a/internal/controllers/const_generated.go
+++ b/internal/controllers/const_generated.go
@@ -5,7 +5,7 @@ package controllers
 const AppName = "Cryostat"
 
 // Version of the Cryostat Operator
-const OperatorVersion = "2.5.0-dev"
+const OperatorVersion = "3.0.0-dev"
 
 // Default image tag for the core application image
 const DefaultCoreImageTag = "quay.io/cryostat/cryostat:latest"

--- a/internal/controllers/cryostat_controller.go
+++ b/internal/controllers/cryostat_controller.go
@@ -26,6 +26,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+// Generates constants from environment variables at build time
+//go:generate go run ../tools/const_generator.go
+
 // Verify that *CryostatReconciler implements CommonReconciler.
 var _ CommonReconciler = (*CryostatReconciler)(nil)
 

--- a/internal/controllers/insights/test/resources.go
+++ b/internal/controllers/insights/test/resources.go
@@ -31,7 +31,7 @@ type InsightsTestResources struct {
 	Resources *corev1.ResourceRequirements
 }
 
-const expectedOperatorVersion = "2.5.0-dev"
+const expectedOperatorVersion = "3.0.0-dev"
 
 func (r *InsightsTestResources) NewGlobalPullSecret() *corev1.Secret {
 	config := `{"auths":{"example.com":{"auth":"hello"},"cloud.openshift.com":{"auth":"world"}}}`

--- a/internal/tools/const_generator.go
+++ b/internal/tools/const_generator.go
@@ -29,9 +29,9 @@ const datasourceImageEnv = "DATASOURCE_IMG"
 const grafanaImageEnv = "GRAFANA_IMG"
 const reportsImageEnv = "REPORTS_IMG"
 
-// This program generates a imagetag_generated.go file containing image tag
-// constants for each container image deployed by the operator. These constants
-// are populated using environment variables.
+// This program generates a const_generated.go file containing image tag
+// constants for each container image deployed by the operator, along with
+// other constants. These constants are populated using environment variables.
 func main() {
 	// Fill in image tags struct from the environment variables
 	consts := struct {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #761 

## Description of the change:
Bumps the operator and scorecard image versions to 3.0.0-dev. Also restores the Go Generate comment, which was accidentally removed along with the ClusterCryostat controller.

## Motivation for the change:
Doesn't conflict with CI builds from the main branch.
