### PR TITLE
feat(ocp): add optional flag to force platform as openshift

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -14,3 +14,12 @@ images:
 - name: controller
   newName: quay.io/cryostat/cryostat-operator
   newTag: 3.0.0-dev
+
+# patchesJson6902:
+# - path: patches/force_openshift_patch.yaml
+#   target:
+#     group: apps
+#     kind: Deployment
+#     name: controller-manager
+#     namespace: system
+#     version: v1

--- a/config/manager/patches/force_openshift_patch.yaml
+++ b/config/manager/patches/force_openshift_patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --force-openshift


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes #805 

## Description of the change:

Provided an optional flag to overwrite platform discovery to set openshift to `true`. 

With these changes, I try to utilize kustomize. I can try automatically add the patch the deployment like below but it looks not so nice:

```make
cd config/manager && $(KUSTOMIZE) edit add patch \
--path patches/force_openshift_patch.yaml \
--group apps \
--version v1 \
--kind Deployment \
--name controller-manager \
--namespace system
```

But things can be much easier with `yq`. What do you think? 

## Motivation for the change:

See #805 

## How to manually test:

- Uncomment the patch in `manager.yaml`
- `make oci-build bundle bundle-build`
- Push the controller and bundle images.
- Launch a local `kind` cluster and logs the controller pod. It should show the following message regardless.
  ```
  2024-05-03T18:34:47Z	INFO	setup	detected OpenShift environment
  ```
