### PR TITLE
feat(tls): enable TLS on authproxies

### DIFF
--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -53,7 +53,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:3.0.0-dev
-    createdAt: "2024-05-08T15:33:40Z"
+    createdAt: "2024-05-08T18:54:35Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {

--- a/internal/controllers/certmanager.go
+++ b/internal/controllers/certmanager.go
@@ -93,14 +93,6 @@ func (r *Reconciler) setupTLS(ctx context.Context, cr *model.CryostatInstance) (
 		KeystorePassSecret: cryostatCert.Spec.Keystores.PKCS12.PasswordSecretRef.Name,
 	}
 	certificates := []*certv1.Certificate{caCert, cryostatCert, reportsCert}
-	// Create a certificate for Grafana signed by the Cryostat CA
-	grafanaCert := resources.NewGrafanaCert(cr)
-	err = r.createOrUpdateCertificate(ctx, grafanaCert, cr.Object)
-	if err != nil {
-		return nil, err
-	}
-	certificates = append(certificates, grafanaCert)
-	tlsConfig.GrafanaSecret = grafanaCert.Spec.SecretName
 
 	// Update owner references of TLS secrets created by cert-manager to ensure proper cleanup
 	err = r.setCertSecretOwner(ctx, cr.Object, certificates...)

--- a/internal/controllers/common/resource_definitions/certificates.go
+++ b/internal/controllers/common/resource_definitions/certificates.go
@@ -20,7 +20,6 @@ import (
 	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	certMeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cryostatio/cryostat-operator/internal/controllers/common"
-	"github.com/cryostatio/cryostat-operator/internal/controllers/constants"
 	"github.com/cryostatio/cryostat-operator/internal/controllers/model"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -104,31 +103,6 @@ func NewCryostatCert(cr *model.CryostatInstance, keystoreSecretName string) *cer
 			Usages: append(certv1.DefaultKeyUsages(),
 				certv1.UsageServerAuth,
 				certv1.UsageClientAuth,
-			),
-		},
-	}
-}
-
-func NewGrafanaCert(cr *model.CryostatInstance) *certv1.Certificate {
-	return &certv1.Certificate{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Name + "-grafana",
-			Namespace: cr.InstallNamespace,
-		},
-		Spec: certv1.CertificateSpec{
-			CommonName: fmt.Sprintf("%s-grafana.%s.svc", cr.Name, cr.InstallNamespace),
-			DNSNames: []string{
-				cr.Name + "-grafana",
-				fmt.Sprintf("%s-grafana.%s.svc", cr.Name, cr.InstallNamespace),
-				fmt.Sprintf("%s-grafana.%s.svc.cluster.local", cr.Name, cr.InstallNamespace),
-				constants.HealthCheckHostname,
-			},
-			SecretName: cr.Name + "-grafana-tls",
-			IssuerRef: certMeta.ObjectReference{
-				Name: cr.Name + "-ca",
-			},
-			Usages: append(certv1.DefaultKeyUsages(),
-				certv1.UsageServerAuth,
 			),
 		},
 	}

--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -421,16 +421,6 @@ func NewPodForCR(cr *model.CryostatInstance, specs *ServiceSpecs, imageTags *Ima
 		}
 	}
 
-	// Use HostAlias for loopback address to allow health checks to
-	// work over HTTPS with hostname added as a SubjectAltName
-	hostAliases := []corev1.HostAlias{
-		{
-			IP: constants.LoopbackAddress,
-			Hostnames: []string{
-				constants.HealthCheckHostname,
-			},
-		},
-	}
 	var nodeSelector map[string]string
 	var affinity *corev1.Affinity
 	var tolerations []corev1.Toleration
@@ -454,7 +444,6 @@ func NewPodForCR(cr *model.CryostatInstance, specs *ServiceSpecs, imageTags *Ima
 		Volumes:                      volumes,
 		Containers:                   containers,
 		SecurityContext:              podSc,
-		HostAliases:                  hostAliases,
 		AutomountServiceAccountToken: &automountSAToken,
 		NodeSelector:                 nodeSelector,
 		Affinity:                     affinity,
@@ -1556,7 +1545,7 @@ func getPort(url *url.URL) string {
 }
 
 func getInternalDashboardURL() string {
-	return fmt.Sprintf("http://%s:%d", constants.HealthCheckHostname, constants.GrafanaContainerPort)
+	return fmt.Sprintf("http://localhost:%d", constants.GrafanaContainerPort)
 }
 
 // Matches image tags of the form "major.minor.patch"

--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -710,7 +710,7 @@ func NewOpenShiftAuthProxyContainer(cr *model.CryostatInstance, specs *ServiceSp
 	if tls != nil {
 		args = append(args,
 			fmt.Sprintf("--http-address="),
-			fmt.Sprintf("--https-address=:%d", constants.AuthProxyHttpContainerPort),
+			fmt.Sprintf("--https-address=0.0.0.0:%d", constants.AuthProxyHttpContainerPort),
 			fmt.Sprintf("--tls-cert=/var/run/secrets/operator.cryostat.io/%s/%s", tls.CryostatSecret, corev1.TLSCertKey),
 			fmt.Sprintf("--tls-key=/var/run/secrets/operator.cryostat.io/%s/%s", tls.CryostatSecret, corev1.TLSPrivateKeyKey),
 		)

--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -1575,7 +1575,7 @@ func getPort(url *url.URL) string {
 }
 
 func getInternalDashboardURL() string {
-	return fmt.Sprintf("%s://%s:%d", "http", constants.HealthCheckHostname, constants.GrafanaContainerPort)
+	return fmt.Sprintf("http://%s:%d", constants.HealthCheckHostname, constants.GrafanaContainerPort)
 }
 
 // Matches image tags of the form "major.minor.patch"

--- a/internal/controllers/configmaps.go
+++ b/internal/controllers/configmaps.go
@@ -46,7 +46,7 @@ type oauth2ProxyAlphaConfig struct {
 
 type alphaConfigServer struct {
 	BindAddress       string   `json:"BindAddress,omitempty"`
-	SecureBindAddress *string  `json:"SecureBindAddress,omitempty"`
+	SecureBindAddress string   `json:"SecureBindAddress,omitempty"`
 	TLS               proxyTLS `json:"TLS,omitempty"`
 }
 
@@ -85,7 +85,7 @@ func (r *Reconciler) reconcileOAuth2ProxyConfig(ctx context.Context, cr *model.C
 	bindHost := "0.0.0.0"
 	immutable := true
 	cfg := &oauth2ProxyAlphaConfig{
-		Server: alphaConfigServer{BindAddress: fmt.Sprintf("http://%s:%d", bindHost, constants.AuthProxyHttpContainerPort)},
+		Server: alphaConfigServer{},
 		UpstreamConfig: alphaConfigUpstreamConfig{ProxyRawPath: true, Upstreams: []alphaConfigUpstream{
 			{
 				Id:   "cryostat",
@@ -110,8 +110,7 @@ func (r *Reconciler) reconcileOAuth2ProxyConfig(ctx context.Context, cr *model.C
 	}
 
 	if tls != nil {
-		tlsBindAddress := fmt.Sprintf("https://%s:%d", bindHost, constants.AuthProxyHttpsContainerPort)
-		cfg.Server.SecureBindAddress = &tlsBindAddress
+		cfg.Server.SecureBindAddress = fmt.Sprintf("https://%s:%d", bindHost, constants.AuthProxyHttpContainerPort)
 		cfg.Server.TLS = proxyTLS{
 			Key: tlsSecretSource{
 				FromFile: fmt.Sprintf("/var/run/secrets/operator.cryostat.io/%s/%s", tls.CryostatSecret, corev1.TLSPrivateKeyKey),
@@ -120,6 +119,8 @@ func (r *Reconciler) reconcileOAuth2ProxyConfig(ctx context.Context, cr *model.C
 				FromFile: fmt.Sprintf("/var/run/secrets/operator.cryostat.io/%s/%s", tls.CryostatSecret, corev1.TLSCertKey),
 			},
 		}
+	} else {
+		cfg.Server.BindAddress = fmt.Sprintf("http://%s:%d", bindHost, constants.AuthProxyHttpContainerPort)
 	}
 
 	data := make(map[string]string)

--- a/internal/controllers/const_generated.go
+++ b/internal/controllers/const_generated.go
@@ -11,7 +11,7 @@ const OperatorVersion = "3.0.0-dev"
 const DefaultOAuth2ProxyImageTag = "quay.io/oauth2-proxy/oauth2-proxy:latest"
 
 // Default image tag for the OpenShift OAuth Proxy
-const DefaultOpenShiftOAuthProxyImageTag = "quay.io/openshift/origin-oauth-proxy:latest"
+const DefaultOpenShiftOAuthProxyImageTag = "quay.io/andrewazores/openshift-oauth-proxy:test-14"
 
 // Default image tag for the core application image
 const DefaultCoreImageTag = "quay.io/cryostat/cryostat:3.0.0-snapshot"

--- a/internal/controllers/constants/constants.go
+++ b/internal/controllers/constants/constants.go
@@ -20,19 +20,18 @@ import (
 )
 
 const (
-	AuthProxyHttpContainerPort  int32  = 4180
-	AuthProxyHttpsContainerPort int32  = 4143
-	CryostatHTTPContainerPort   int32  = 8181
-	CryostatJMXContainerPort    int32  = 9091
-	GrafanaContainerPort        int32  = 3000
-	DatasourceContainerPort     int32  = 8989
-	ReportsContainerPort        int32  = 10000
-	StoragePort                 int32  = 8333
-	DatabasePort                int32  = 5432
-	LoopbackAddress             string = "127.0.0.1"
-	OperatorNamePrefix          string = "cryostat-operator-"
-	OperatorDeploymentName      string = "cryostat-operator-controller-manager"
-	HttpPortName                string = "http"
+	AuthProxyHttpContainerPort int32  = 4180
+	CryostatHTTPContainerPort  int32  = 8181
+	CryostatJMXContainerPort   int32  = 9091
+	GrafanaContainerPort       int32  = 3000
+	DatasourceContainerPort    int32  = 8989
+	ReportsContainerPort       int32  = 10000
+	StoragePort                int32  = 8333
+	DatabasePort               int32  = 5432
+	LoopbackAddress            string = "127.0.0.1"
+	OperatorNamePrefix         string = "cryostat-operator-"
+	OperatorDeploymentName     string = "cryostat-operator-controller-manager"
+	HttpPortName               string = "http"
 	// CAKey is the key for a CA certificate within a TLS secret
 	CAKey = certMeta.TLSCAKey
 	// Hostname alias for loopback address, to be used for health checks

--- a/internal/controllers/constants/constants.go
+++ b/internal/controllers/constants/constants.go
@@ -34,8 +34,6 @@ const (
 	HttpPortName               string = "http"
 	// CAKey is the key for a CA certificate within a TLS secret
 	CAKey = certMeta.TLSCAKey
-	// Hostname alias for loopback address, to be used for health checks
-	HealthCheckHostname = "cryostat-health.local"
 	// ALL capability to drop for restricted pod security. See:
 	// https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
 	CapabilityAll corev1.Capability = "ALL"

--- a/internal/controllers/constants/constants.go
+++ b/internal/controllers/constants/constants.go
@@ -20,18 +20,19 @@ import (
 )
 
 const (
-	AuthProxyHttpContainerPort int32  = 4180
-	CryostatHTTPContainerPort  int32  = 8181
-	CryostatJMXContainerPort   int32  = 9091
-	GrafanaContainerPort       int32  = 3000
-	DatasourceContainerPort    int32  = 8989
-	ReportsContainerPort       int32  = 10000
-	StoragePort                int32  = 8333
-	DatabasePort               int32  = 5432
-	LoopbackAddress            string = "127.0.0.1"
-	OperatorNamePrefix         string = "cryostat-operator-"
-	OperatorDeploymentName     string = "cryostat-operator-controller-manager"
-	HttpPortName               string = "http"
+	AuthProxyHttpContainerPort  int32  = 4180
+	AuthProxyHttpsContainerPort int32  = 4143
+	CryostatHTTPContainerPort   int32  = 8181
+	CryostatJMXContainerPort    int32  = 9091
+	GrafanaContainerPort        int32  = 3000
+	DatasourceContainerPort     int32  = 8989
+	ReportsContainerPort        int32  = 10000
+	StoragePort                 int32  = 8333
+	DatabasePort                int32  = 5432
+	LoopbackAddress             string = "127.0.0.1"
+	OperatorNamePrefix          string = "cryostat-operator-"
+	OperatorDeploymentName      string = "cryostat-operator-controller-manager"
+	HttpPortName                string = "http"
 	// CAKey is the key for a CA certificate within a TLS secret
 	CAKey = certMeta.TLSCAKey
 	// Hostname alias for loopback address, to be used for health checks

--- a/internal/controllers/reconciler.go
+++ b/internal/controllers/reconciler.go
@@ -194,11 +194,6 @@ func (r *Reconciler) reconcileCryostat(ctx context.Context, cr *model.CryostatIn
 		return reconcile.Result{}, err
 	}
 
-	err = r.reconcileOAuth2ProxyConfig(ctx, cr)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
 	err = r.reconcilePVC(ctx, cr)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -248,6 +243,11 @@ func (r *Reconciler) reconcileCryostat(ctx context.Context, cr *model.CryostatIn
 		if err != nil {
 			return reconcile.Result{}, err
 		}
+	}
+
+	err = r.reconcileOAuth2ProxyConfig(ctx, cr, tlsConfig)
+	if err != nil {
+		return reconcile.Result{}, err
 	}
 
 	serviceSpecs := &resources.ServiceSpecs{

--- a/internal/controllers/reconciler_test.go
+++ b/internal/controllers/reconciler_test.go
@@ -2198,7 +2198,7 @@ func (t *cryostatTestInput) expectWaitingForCertificate() {
 
 func (t *cryostatTestInput) expectCertificates() {
 	// Check certificates
-	certs := []*certv1.Certificate{t.NewCryostatCert(), t.NewCACert(), t.NewReportsCert(), t.NewGrafanaCert()}
+	certs := []*certv1.Certificate{t.NewCryostatCert(), t.NewCACert(), t.NewReportsCert()}
 	for _, expected := range certs {
 		actual := &certv1.Certificate{}
 		err := t.Client.Get(context.Background(), types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, actual)

--- a/internal/controllers/routes.go
+++ b/internal/controllers/routes.go
@@ -90,8 +90,9 @@ func (r *Reconciler) createOrUpdateRoute(ctx context.Context, route *routev1.Rou
 		}
 	} else {
 		routeTLS = &routev1.TLSConfig{
-			Termination:              routev1.TLSTerminationReencrypt,
-			DestinationCACertificate: string(tlsConfig.CACert),
+			Termination:                   routev1.TLSTerminationReencrypt,
+			DestinationCACertificate:      string(tlsConfig.CACert),
+			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 		}
 	}
 

--- a/internal/controllers/services.go
+++ b/internal/controllers/services.go
@@ -40,7 +40,7 @@ func (r *Reconciler) reconcileCoreService(ctx context.Context, cr *model.Cryosta
 			Namespace: cr.InstallNamespace,
 		},
 	}
-	config := configureCoreService(cr, tls)
+	config := configureCoreService(cr)
 
 	err := r.createOrUpdateService(ctx, svc, cr.Object, &config.ServiceConfig, func() error {
 		svc.Spec.Selector = map[string]string{
@@ -48,7 +48,7 @@ func (r *Reconciler) reconcileCoreService(ctx context.Context, cr *model.Cryosta
 			"component": "cryostat",
 		}
 		svc.Spec.Ports = []corev1.ServicePort{
-			corev1.ServicePort{
+			{
 				Name:       "http",
 				Port:       *config.HTTPPort,
 				TargetPort: intstr.IntOrString{IntVal: constants.AuthProxyHttpContainerPort},
@@ -116,7 +116,7 @@ func (r *Reconciler) reconcileReportsService(ctx context.Context, cr *model.Cryo
 	return nil
 }
 
-func configureCoreService(cr *model.CryostatInstance, tls *resource_definitions.TLSConfig) *operatorv1beta2.CoreServiceConfig {
+func configureCoreService(cr *model.CryostatInstance) *operatorv1beta2.CoreServiceConfig {
 	// Check CR for config
 	var config *operatorv1beta2.CoreServiceConfig
 	if cr.Spec.ServiceOptions == nil || cr.Spec.ServiceOptions.CoreConfig == nil {

--- a/internal/test/clients.go
+++ b/internal/test/clients.go
@@ -70,7 +70,7 @@ func (c *testClient) makeCertificatesReady(ctx context.Context, obj runtime.Obje
 	// If this object is one of the operator-managed certificates, mock the behaviour
 	// of cert-manager processing those certificates
 	cert, ok := obj.(*certv1.Certificate)
-	if ok && c.matchesName(cert, c.NewCryostatCert(), c.NewCACert(), c.NewGrafanaCert(), c.NewReportsCert()) &&
+	if ok && c.matchesName(cert, c.NewCryostatCert(), c.NewCACert(), c.NewReportsCert()) &&
 		len(cert.Status.Conditions) == 0 {
 		// Create certificate secret
 		c.createCertSecret(ctx, cert)

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -1883,6 +1883,14 @@ func (r *TestResources) newVolumes(certProjections []corev1.VolumeProjection) []
 					},
 				},
 			},
+			corev1.Volume{
+				Name: "auth-proxy-tls-secret",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: r.Name + "-tls",
+					},
+				},
+			},
 		)
 	}
 
@@ -2030,8 +2038,9 @@ func (r *TestResources) newRoute(name string, port int) *routev1.Route {
 		}
 	} else {
 		routeTLS = &routev1.TLSConfig{
-			Termination:              routev1.TLSTerminationReencrypt,
-			DestinationCACertificate: r.Name + "-ca-bytes",
+			Termination:                   routev1.TLSTerminationReencrypt,
+			DestinationCACertificate:      r.Name + "-ca-bytes",
+			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 		}
 	}
 	return &routev1.Route{

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -1344,7 +1344,12 @@ func (r *TestResources) NewCoreEnvironmentVariables(reportsUrl string, ingress b
 }
 
 func (r *TestResources) newNetworkEnvironmentVariables() []corev1.EnvVar {
-	envs := []corev1.EnvVar{}
+	envs := []corev1.EnvVar{
+		{
+			Name:  "GRAFANA_DASHBOARD_URL",
+			Value: "http://localhost:3000",
+		},
+	}
 	if r.ExternalTLS {
 		envs = append(envs,
 			corev1.EnvVar{
@@ -1358,11 +1363,6 @@ func (r *TestResources) newNetworkEnvironmentVariables() []corev1.EnvVar {
 				Value: fmt.Sprintf("http://%s.example.com/grafana/", r.Name),
 			})
 	}
-	envs = append(envs,
-		corev1.EnvVar{
-			Name:  "GRAFANA_DASHBOARD_URL",
-			Value: "http://cryostat-health.local:3000",
-		})
 	return envs
 }
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Based on #809
Depends on #809
Related to #710

## Description of the change:
*This change adds allows the users to provide...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. Check out PR, build with `OPENSHIFT_OAUTH_PROXY_IMG=quay.io/andrewazores/openshift-oauth-proxy:test-14`. Deploy, then create a Cryostat CR. **Don't** set `DISABLE_SERVICE_TLS`, and **do** leave `enableCertManager:true`!
2. Verify that one Route is created pointing at port `4180`, which is the authproxy HTTP(S) port. It should redirect HTTP requests to HTTPS, and then it should reencrypt HTTPS traffic from the Router edge to the authproxy service.
3. Open `http://cryostat-cryostat.mycluster.domain` in your browser. Note that the URL protocol is `http`. The Route should immediately redirect you to HTTPS. You should then get to the OpenShift SSO login page. From this point on everything should behave as normal from prior PRs on this branch.
4. Check the auth-proxy container spec or logs and ensure that its `--http-address` is set to a blank value and `--https-address` is set to use port `4180`. If deploying oauth2_proxy, check its ConfigMap for this rather than its args.

To test oauth2_proxy:
1. deploy on non-OpenShift. Or, to force oauth2_proxy while on OpenShift, apply the following patch:
```diff
diff --git a/internal/controllers/common/resource_definitions/resource_definitions.go b/internal/controllers/common/resource_definitions/resource_definitions.go
index 018320e..8f0ffe0 100644
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -352,26 +352,26 @@ func NewPodForCR(cr *model.CryostatInstance, specs *ServiceSpecs, imageTags *Ima
        }
        volumes = append(volumes, certVolume)
 
-       if !openshift {
-               // if not deploying openshift-oauth-proxy then we must be deploying oauth2_proxy instead
-               volumes = append(volumes, corev1.Volume{
-                       Name: cr.Name + "-oauth2-proxy-cfg",
-                       VolumeSource: corev1.VolumeSource{
-                               ConfigMap: &corev1.ConfigMapVolumeSource{
-                                       LocalObjectReference: corev1.LocalObjectReference{
-                                               Name: cr.Name + "-oauth2-proxy-cfg",
-                                       },
-                                       Items: []corev1.KeyToPath{
-                                               {
-                                                       Key:  OAuth2ConfigFileName,
-                                                       Path: OAuth2ConfigFileName,
-                                                       Mode: &readOnlyMode,
-                                               },
+       // if !openshift {
+       // if not deploying openshift-oauth-proxy then we must be deploying oauth2_proxy instead
+       volumes = append(volumes, corev1.Volume{
+               Name: cr.Name + "-oauth2-proxy-cfg",
+               VolumeSource: corev1.VolumeSource{
+                       ConfigMap: &corev1.ConfigMapVolumeSource{
+                               LocalObjectReference: corev1.LocalObjectReference{
+                                       Name: cr.Name + "-oauth2-proxy-cfg",
+                               },
+                               Items: []corev1.KeyToPath{
+                                       {
+                                               Key:  OAuth2ConfigFileName,
+                                               Path: OAuth2ConfigFileName,
+                                               Mode: &readOnlyMode,
                                        },
                                },
                        },
-               })
-       }
+               },
+       })
+       // }
 
        if isBasicAuthEnabled(cr) {
                volumes = append(volumes,
@@ -636,9 +636,9 @@ func NewAuthProxyContainerResource(cr *model.CryostatInstance) *corev1.ResourceR
 
 func NewAuthProxyContainer(cr *model.CryostatInstance, specs *ServiceSpecs, oauth2ProxyImageTag string, openshiftAuthProxyImageTag string,
        tls *TLSConfig, openshift bool) (*corev1.Container, error) {
-       if openshift {
-               return NewOpenShiftAuthProxyContainer(cr, specs, openshiftAuthProxyImageTag, tls)
-       }
+       // if openshift {
+       //      return NewOpenShiftAuthProxyContainer(cr, specs, openshiftAuthProxyImageTag, tls)
+       // }
        return NewOAuth2ProxyContainer(cr, specs, oauth2ProxyImageTag, tls)
 }
 
diff --git a/internal/controllers/configmaps.go b/internal/controllers/configmaps.go
index 660fb38..194debd 100644
--- a/internal/controllers/configmaps.go
+++ b/internal/controllers/configmaps.go
@@ -137,11 +137,11 @@ func (r *Reconciler) reconcileOAuth2ProxyConfig(ctx context.Context, cr *model.C
                Data:      data,
        }
 
-       if r.IsOpenShift {
-               return r.deleteConfigMap(ctx, cm)
-       } else {
-               return r.createOrUpdateConfigMap(ctx, cm, cr.Object)
-       }
+       // if r.IsOpenShift {
+       //      return r.deleteConfigMap(ctx, cm)
+       // } else {
+       return r.createOrUpdateConfigMap(ctx, cm, cr.Object)
+       // }
 }
```
5. rebuild and redeploy, repeat tests above