### PR TITLE
test(scorecard): fix broken scorecard tests for 3.0

### DIFF
--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -53,7 +53,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:3.0.0-dev
-    createdAt: "2024-05-10T19:40:13Z"
+    createdAt: "2024-05-11T06:47:54Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -70,7 +70,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - operator-install
-    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240416210645
+    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726
     labels:
       suite: cryostat
       test: operator-install
@@ -80,7 +80,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-cr
-    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240416210645
+    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726
     labels:
       suite: cryostat
       test: cryostat-cr
@@ -90,7 +90,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-multi-namespace
-    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240416210645
+    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726
     labels:
       suite: cryostat
       test: cryostat-multi-namespace
@@ -100,7 +100,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-recording
-    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240416210645
+    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726
     labels:
       suite: cryostat
       test: cryostat-recording
@@ -110,7 +110,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-config-change
-    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240416210645
+    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726
     labels:
       suite: cryostat
       test: cryostat-config-change
@@ -120,7 +120,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-report
-    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240416210645
+    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726
     labels:
       suite: cryostat
       test: cryostat-report

--- a/config/scorecard/patches/custom.config.yaml
+++ b/config/scorecard/patches/custom.config.yaml
@@ -8,7 +8,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - operator-install
-    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240510194331"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726"
     labels:
       suite: cryostat
       test: operator-install
@@ -18,7 +18,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-cr
-    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240510194331"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726"
     labels:
       suite: cryostat
       test: cryostat-cr
@@ -28,7 +28,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-multi-namespace
-    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240510194331"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726"
     labels:
       suite: cryostat
       test: cryostat-multi-namespace
@@ -38,7 +38,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-recording
-    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240510194331"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726"
     labels:
       suite: cryostat
       test: cryostat-recording
@@ -48,7 +48,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-config-change
-    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240510194331"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726"
     labels:
       suite: cryostat
       test: cryostat-config-change
@@ -58,7 +58,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-report
-    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240510194331"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726"
     labels:
       suite: cryostat
       test: cryostat-report

--- a/internal/test/scorecard/common_utils.go
+++ b/internal/test/scorecard/common_utils.go
@@ -56,7 +56,7 @@ type TestResources struct {
 }
 
 func (r *TestResources) waitForDeploymentAvailability(ctx context.Context, name string, namespace string) error {
-	err := wait.PollImmediateUntilWithContext(ctx, time.Second, func(ctx context.Context) (done bool, err error) {
+	err := wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (done bool, err error) {
 		deploy, err := r.Client.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			if kerrors.IsNotFound(err) {
@@ -344,7 +344,7 @@ func (r *TestResources) createAndWaitTillCryostatAvailable(cr *operatorv1beta2.C
 		return nil, err
 	}
 
-	err = wait.PollImmediateUntilWithContext(ctx, time.Second, func(ctx context.Context) (done bool, err error) {
+	err = wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (done bool, err error) {
 		cr, err = r.Client.OperatorCRDs().Cryostats(cr.Namespace).Get(ctx, cr.Name)
 		if err != nil {
 			return false, fmt.Errorf("failed to get Cryostat CR: %s", err.Error())
@@ -421,7 +421,7 @@ func (r *TestResources) sendHealthRequest(base *url.URL, healthCheck func(resp *
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
-	err := wait.PollImmediateUntilWithContext(ctx, time.Second, func(ctx context.Context) (done bool, err error) {
+	err := wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (done bool, err error) {
 		url := base.JoinPath("/health")
 		req, err := NewHttpRequest(ctx, http.MethodGet, url.String(), nil, make(http.Header))
 		if err != nil {
@@ -483,7 +483,7 @@ func (r *TestResources) updateAndWaitTillCryostatAvailable(cr *operatorv1beta2.C
 	// Poll the deployment until it becomes available or we timeout
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
-	err = wait.PollImmediateUntilWithContext(ctx, time.Second, func(ctx context.Context) (done bool, err error) {
+	err = wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (done bool, err error) {
 		deploy, err := r.Client.AppsV1().Deployments(cr.Namespace).Get(ctx, cr.Name, metav1.GetOptions{})
 		if err != nil {
 			if kerrors.IsNotFound(err) {

--- a/internal/test/scorecard/openshift.go
+++ b/internal/test/scorecard/openshift.go
@@ -175,7 +175,7 @@ func (r *TestResources) installOpenShiftCertManager() error {
 	// Check CSV status until we know cert-manager installed successfully
 	ctx, cancel := context.WithTimeout(ctx, testTimeout)
 	defer cancel()
-	return wait.PollImmediateUntilWithContext(ctx, time.Second, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
 		err := olmClient.Get().Resource("subscriptions").Namespace(sub.Namespace).Name(sub.Name).Do(ctx).Into(sub)
 		if err != nil {
 			return false, fmt.Errorf("failed to get Subscription: %s", err.Error())

--- a/internal/test/scorecard/tests.go
+++ b/internal/test/scorecard/tests.go
@@ -185,7 +185,6 @@ func CryostatRecordingTest(bundle *apimanifests.Bundle, namespace string, openSh
 		return r.fail(fmt.Sprintf("failed to create a target: %s", err.Error()))
 	}
 	r.Log += fmt.Sprintf("created a custom target: %+v\n", target)
-	connectUrl := target.ConnectUrl
 
 	jmxSecretName := CryostatRecordingTestName + "-jmx-auth"
 	secret, err := r.Client.CoreV1().Secrets(namespace).Get(context.Background(), jmxSecretName, metav1.GetOptions{})
@@ -217,48 +216,48 @@ func CryostatRecordingTest(bundle *apimanifests.Bundle, namespace string, openSh
 		MaxSize:       0,
 		MaxAge:        0,
 	}
-	rec, err := apiClient.Recordings().Create(context.Background(), connectUrl, options)
+	rec, err := apiClient.Recordings().Create(context.Background(), target, options)
 	if err != nil {
 		return r.fail(fmt.Sprintf("failed to create a recording: %s", err.Error()))
 	}
 	r.Log += fmt.Sprintf("created a recording: %+v\n", rec)
 
 	// View the current recording list after creating one
-	recs, err := apiClient.Recordings().List(context.Background(), connectUrl)
+	recs, err := apiClient.Recordings().List(context.Background(), target)
 	if err != nil {
 		return r.fail(fmt.Sprintf("failed to list recordings: %s", err.Error()))
 	}
 	r.Log += fmt.Sprintf("current list of recordings: %+v\n", recs)
 
-	// Allow the recording to run for 10s
+	// Allow the recording to run for 30s
 	time.Sleep(30 * time.Second)
 
 	// Archive the recording
-	archiveName, err := apiClient.Recordings().Archive(context.Background(), connectUrl, rec.Name)
+	archiveName, err := apiClient.Recordings().Archive(context.Background(), target, rec.Id)
 	if err != nil {
 		return r.fail(fmt.Sprintf("failed to archive the recording: %s", err.Error()))
 	}
 	r.Log += fmt.Sprintf("archived the recording %s at: %s\n", rec.Name, archiveName)
 
-	archives, err := apiClient.Recordings().ListArchives(context.Background(), connectUrl)
+	archives, err := apiClient.Recordings().ListArchives(context.Background(), target)
 	if err != nil {
 		return r.fail(fmt.Sprintf("failed to list archives: %s", err.Error()))
 	}
 	r.Log += fmt.Sprintf("current list of archives: %+v\n", archives)
 
-	report, err := apiClient.Recordings().GenerateReport(context.Background(), connectUrl, rec)
+	report, err := apiClient.Recordings().GenerateReport(context.Background(), target, rec)
 	if err != nil {
 		return r.fail(fmt.Sprintf("failed to generate report for the recording: %s", err.Error()))
 	}
 	r.Log += fmt.Sprintf("generated report for the recording %s: %+v\n", rec.Name, report)
 
 	// Stop the recording
-	err = apiClient.Recordings().Stop(context.Background(), connectUrl, rec.Name)
+	err = apiClient.Recordings().Stop(context.Background(), target, rec.Id)
 	if err != nil {
 		return r.fail(fmt.Sprintf("failed to stop the recording %s: %s", rec.Name, err.Error()))
 	}
 	// Get the recording to verify its state
-	rec, err = apiClient.Recordings().Get(context.Background(), connectUrl, rec.Name)
+	rec, err = apiClient.Recordings().Get(context.Background(), target, rec.Name)
 	if err != nil {
 		return r.fail(fmt.Sprintf("failed to get the recordings: %s", err.Error()))
 	}
@@ -268,14 +267,14 @@ func CryostatRecordingTest(bundle *apimanifests.Bundle, namespace string, openSh
 	r.Log += fmt.Sprintf("stopped the recording: %s\n", rec.Name)
 
 	// Delete the recording
-	err = apiClient.Recordings().Delete(context.Background(), connectUrl, rec.Name)
+	err = apiClient.Recordings().Delete(context.Background(), target, rec.Id)
 	if err != nil {
 		return r.fail(fmt.Sprintf("failed to delete the recording %s: %s", rec.Name, err.Error()))
 	}
 	r.Log += fmt.Sprintf("deleted the recording: %s\n", rec.Name)
 
 	// View the current recording list after deleting one
-	recs, err = apiClient.Recordings().List(context.Background(), connectUrl)
+	recs, err = apiClient.Recordings().List(context.Background(), target)
 	if err != nil {
 		return r.fail(fmt.Sprintf("failed to list recordings: %s", err.Error()))
 	}

--- a/internal/test/scorecard/types.go
+++ b/internal/test/scorecard/types.go
@@ -99,13 +99,16 @@ type Recording struct {
 }
 
 type Archive struct {
-	Name        string
-	DownloadUrl string
-	ReportUrl   string
+	Name        string `json:"name"`
+	DownloadUrl string `json:"downloadUrl"`
+	ReportUrl   string `json:"reportUrl"`
 	Metadata    struct {
-		Labels map[string]interface{}
-	}
-	Size int32
+		Labels []struct {
+			Key   string `json:"key"`
+			Value string `json:"value"`
+		}
+	} `json:"metadata"`
+	Size uint32 `json:"size"`
 }
 
 type CustomTargetResponse struct {
@@ -115,6 +118,7 @@ type CustomTargetResponse struct {
 }
 
 type Target struct {
+	Id         uint32 `json:"id,omitempty"`
 	ConnectUrl string `json:"connectUrl"`
 	Alias      string `json:"alias,omitempty"`
 }
@@ -129,8 +133,8 @@ func (target *Target) ToFormData() string {
 }
 
 type GraphQLQuery struct {
-	Query     string            `json:"query"`
-	Variables map[string]string `json:"variables,omitempty"`
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables,omitempty"`
 }
 
 func (query *GraphQLQuery) ToJSON() ([]byte, error) {
@@ -139,8 +143,12 @@ func (query *GraphQLQuery) ToJSON() ([]byte, error) {
 
 type ArchiveGraphQLResponse struct {
 	Data struct {
-		ArchivedRecordings struct {
-			Data []Archive `json:"data"`
-		} `json:"archivedRecordings"`
+		TargetNodes []struct {
+			Target struct {
+				ArchivedRecordings struct {
+					Data []Archive `json:"data"`
+				} `json:"archivedRecordings"`
+			} `json:"target"`
+		} `json:"targetNodes"`
 	} `json:"data"`
 }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #816 

## Description of the change:

- Updated `RecordingClient` to use `v3` APIs. `v1` API calls are failing, likely due to https://github.com/openshift/oauth-proxy/issues/272 as `connectUrl` segment is invalid when passed to upstream cryostat.
- Updated GraphQL for fetching Archives.
- Updated utility to not base64 encode the Bearer token (encoding was necessary for built-in OpenShift auth-manager in v2).
- Replaced deprecated [`PollImmediateUntilWithContext`](https://pkg.go.dev/k8s.io/apimachinery@v0.28.9/pkg/util/wait#PollImmediateUntilWithContext) with `PollUntilContextCancel`.

## Motivation for the change:

See #816 

## How to manually test:


```bash
export PLATFORMS=linux/amd64
export IMAGE_NAMESPACE=quay.io/<namespace>
make scorecard-build bundle bundle-build && podman push quay.io/<namespace>/cryostat-operator-bundle:2.5.0-dev && make test-scorecard
```
