### PR TITLE
feat(scorecard): allow running scorecard test locally

### DIFF
--- a/internal/images/custom-scorecard-tests/main.go
+++ b/internal/images/custom-scorecard-tests/main.go
@@ -51,8 +51,15 @@ func main() {
 		log.Fatal("SCORECARD_NAMESPACE environment variable not set")
 	}
 
-	// Read the pod's untar'd bundle from a well-known path.
-	bundle, err := apimanifests.GetBundleFromDir(podBundleRoot)
+	// Get the path to the bundle from BUNDLE_DIR environment variable
+	// If empty, assume running within a pod and use a well-known path to the pod's untar'd bundle
+	bundleDir := os.Getenv("BUNDLE_DIR")
+	if len(bundleDir) == 0 {
+		bundleDir = podBundleRoot
+	}
+
+	// Read the bundle from the specified path
+	bundle, err := apimanifests.GetBundleFromDir(bundleDir)
 	if err != nil {
 		log.Fatalf("failed to read bundle manifest: %s", err.Error())
 	}

--- a/internal/test/scorecard/clients.go
+++ b/internal/test/scorecard/clients.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -51,7 +52,7 @@ func (c *CryostatClientset) OperatorCRDs() *OperatorCRDClient {
 // NewClientset creates a CryostatClientset
 func NewClientset() (*CryostatClientset, error) {
 	// Get in-cluster REST config from pod
-	config, err := rest.InClusterConfig()
+	config, err := config.GetConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -583,7 +584,7 @@ func NewHttpRequest(ctx context.Context, method string, url string, body *string
 	}
 
 	// Authentication for OpenShift SSO
-	config, err := rest.InClusterConfig()
+	config, err := config.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get in-cluster configurations: %s", err.Error())
 	}


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #775 

## Description of the change:

Modify scorecard to allow running scorecard test locally.
- Update to use `config.GetConfig` to also pick local kube configurations (e.g. ` $HOME/.kube/config`)
- Allow overwriting bundle path with `BUNDLE_DIR`.

**Note:** This requires the cluster to be reachable from the host (e.g. local OpenShift with `crc`). Setup with `kind` and `podman` is not supported as host is not interfaced with the cluster network (but `kind` and `docker` should work).

## Motivation for the change:

This makes it easier to run scorecard without having to rebuild the scorecard and bundle images.

## How to manually test:

Assuming local host is properly configured to communicate with a k8s cluster. See https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client/config#GetConfig

If using `crc`:

```bash
crc start
oc login -u kubeadmin
```

Run the scorecard locally:

```bash
export SCORECARD_NAMESPACE=cryostat-operator-scorecard
export BUNDLE_DIR=./bundle
kubectl create ns $SCORECARD_NAMESPACE
kubectl config set-context --current --namespace $SCORECARD_NAMESPACE
make deploy_bundle
go run internal/images/custom-scorecard-tests/main.go cryostat-recording
```

Note: Replace `cryostat-recording` with any support test names (e.g. `operator-install`,`cryostat-cr,cryostat-multi-namespace`)
