### PR TITLE
feat(status): CR status for database and storage secrets

### DIFF
--- a/api/v1beta1/cryostat_types.go
+++ b/api/v1beta1/cryostat_types.go
@@ -141,8 +141,6 @@ type CryostatStatus struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=status,order=2,xDescriptors={"urn:alm:descriptor:io.kubernetes:Secret"}
 	GrafanaSecret string `json:"grafanaSecret,omitempty"`
-	// Name of the Secret containing the cryostat storage connection key
-	StorageSecret string `json:"storageSecret,omitempty"`
 	// Address of the deployed Cryostat web application.
 	// +operator-sdk:csv:customresourcedefinitions:type=status,order=1,xDescriptors={"urn:alm:descriptor:org.w3:link"}
 	ApplicationURL string `json:"applicationUrl"`
@@ -315,12 +313,12 @@ type ServiceConfigList struct {
 	// Specification for the service responsible for the Cryostat Grafana dashboard.
 	// +optional
 	GrafanaConfig *GrafanaServiceConfig `json:"grafanaConfig,omitempty"`
-	// Specification for the service responsible for the cryostat-reports sidecars.
+	// Specification for the service responsible for the Cryostat reports sidecars.
 	// +optional
 	ReportsConfig *ReportsServiceConfig `json:"reportsConfig,omitempty"`
-	// Specification for the service responsible for the cryostat storage container.
+	// Specification for the service responsible for the Cryostat storage container.
 	// +optional
-	StorageConfig *StorageServiceConfig `json:"storageConfig,omitEmpty"`
+	StorageConfig *StorageServiceConfig `json:"storageConfig,omitempty"`
 }
 
 // NetworkConfiguration provides customization for how to expose a Cryostat

--- a/api/v1beta2/cryostat_types.go
+++ b/api/v1beta2/cryostat_types.go
@@ -159,6 +159,14 @@ type CryostatStatus struct {
 	// Address of the deployed Cryostat web application.
 	// +operator-sdk:csv:customresourcedefinitions:type=status,order=1,xDescriptors={"urn:alm:descriptor:org.w3:link"}
 	ApplicationURL string `json:"applicationUrl"`
+	// Name of the Secret containing the Cryostat storage connection key.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=status,order=2,xDescriptors={"urn:alm:descriptor:io.kubernetes:Secret"}
+	StorageSecret string `json:"storageSecret,omitempty"`
+	// Name of the Secret containing the Cryostat database connection and encryption keys.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=status,order=2,xDescriptors={"urn:alm:descriptor:io.kubernetes:Secret"}
+	DatabaseSecret string `json:"databaseSecret,omitempty"`
 }
 
 // CryostatConditionType refers to a Condition type that may be used in status.conditions
@@ -414,6 +422,9 @@ type TargetConnectionCacheOptions struct {
 // to deploy the Cryostat application.
 // +operator-sdk:csv:customresourcedefinitions:resources={{Deployment,v1},{Ingress,v1},{PersistentVolumeClaim,v1},{Secret,v1},{Service,v1},{Route,v1},{ConsoleLink,v1}}
 // +kubebuilder:printcolumn:name="Application URL",type=string,JSONPath=`.status.applicationUrl`
+// +kubebuilder:printcolumn:name="Target Namespaces",type=string,JSONPath=`.status.targetNamespaces`
+// +kubebuilder:printcolumn:name="Storage Secret",type=string,JSONPath=`.status.storageSecret`
+// +kubebuilder:printcolumn:name="Database Secret",type=string,JSONPath=`.status.databaseSecret`
 type Cryostat struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -53,7 +53,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:3.0.0-dev
-    createdAt: "2024-05-11T06:47:54Z"
+    createdAt: "2024-05-20T05:12:58Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {
@@ -889,6 +889,18 @@ spec:
         path: applicationUrl
         x-descriptors:
         - urn:alm:descriptor:org.w3:link
+      - description: Name of the Secret containing the Cryostat database connection
+          and encryption keys.
+        displayName: Database Secret
+        path: databaseSecret
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
+      - description: Name of the Secret containing the Cryostat storage connection
+          key.
+        displayName: Storage Secret
+        path: storageSecret
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
       - description: List of namespaces that Cryostat has been configured and authorized
           to access and profile.
         displayName: Target Namespaces

--- a/bundle/manifests/operator.cryostat.io_cryostats.yaml
+++ b/bundle/manifests/operator.cryostat.io_cryostats.yaml
@@ -4646,7 +4646,7 @@ spec:
                     type: object
                   reportsConfig:
                     description: Specification for the service responsible for the
-                      cryostat-reports sidecars.
+                      Cryostat reports sidecars.
                     properties:
                       annotations:
                         additionalProperties:
@@ -4672,7 +4672,7 @@ spec:
                     type: object
                   storageConfig:
                     description: Specification for the service responsible for the
-                      cryostat storage container.
+                      Cryostat storage container.
                     properties:
                       annotations:
                         additionalProperties:
@@ -5085,10 +5085,6 @@ spec:
               grafanaSecret:
                 description: Name of the Secret containing the generated Grafana credentials.
                 type: string
-              storageSecret:
-                description: Name of the Secret containing the cryostat storage connection
-                  key
-                type: string
             required:
             - applicationUrl
             type: object
@@ -5100,6 +5096,15 @@ spec:
   - additionalPrinterColumns:
     - jsonPath: .status.applicationUrl
       name: Application URL
+      type: string
+    - jsonPath: .status.targetNamespaces
+      name: Target Namespaces
+      type: string
+    - jsonPath: .status.storageSecret
+      name: Storage Secret
+      type: string
+    - jsonPath: .status.databaseSecret
+      name: Database Secret
       type: string
     name: v1beta2
     schema:
@@ -9832,6 +9837,14 @@ spec:
                   - type
                   type: object
                 type: array
+              databaseSecret:
+                description: Name of the Secret containing the Cryostat database connection
+                  and encryption keys.
+                type: string
+              storageSecret:
+                description: Name of the Secret containing the Cryostat storage connection
+                  key.
+                type: string
               targetNamespaces:
                 description: List of namespaces that Cryostat has been configured
                   and authorized to access and profile.

--- a/config/crd/bases/operator.cryostat.io_cryostats.yaml
+++ b/config/crd/bases/operator.cryostat.io_cryostats.yaml
@@ -4636,7 +4636,7 @@ spec:
                     type: object
                   reportsConfig:
                     description: Specification for the service responsible for the
-                      cryostat-reports sidecars.
+                      Cryostat reports sidecars.
                     properties:
                       annotations:
                         additionalProperties:
@@ -4662,7 +4662,7 @@ spec:
                     type: object
                   storageConfig:
                     description: Specification for the service responsible for the
-                      cryostat storage container.
+                      Cryostat storage container.
                     properties:
                       annotations:
                         additionalProperties:
@@ -5075,10 +5075,6 @@ spec:
               grafanaSecret:
                 description: Name of the Secret containing the generated Grafana credentials.
                 type: string
-              storageSecret:
-                description: Name of the Secret containing the cryostat storage connection
-                  key
-                type: string
             required:
             - applicationUrl
             type: object
@@ -5090,6 +5086,15 @@ spec:
   - additionalPrinterColumns:
     - jsonPath: .status.applicationUrl
       name: Application URL
+      type: string
+    - jsonPath: .status.targetNamespaces
+      name: Target Namespaces
+      type: string
+    - jsonPath: .status.storageSecret
+      name: Storage Secret
+      type: string
+    - jsonPath: .status.databaseSecret
+      name: Database Secret
       type: string
     name: v1beta2
     schema:
@@ -9822,6 +9827,14 @@ spec:
                   - type
                   type: object
                 type: array
+              databaseSecret:
+                description: Name of the Secret containing the Cryostat database connection
+                  and encryption keys.
+                type: string
+              storageSecret:
+                description: Name of the Secret containing the Cryostat storage connection
+                  key.
+                type: string
               targetNamespaces:
                 description: List of namespaces that Cryostat has been configured
                   and authorized to access and profile.

--- a/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
@@ -428,6 +428,18 @@ spec:
         path: applicationUrl
         x-descriptors:
         - urn:alm:descriptor:org.w3:link
+      - description: Name of the Secret containing the Cryostat database connection
+          and encryption keys.
+        displayName: Database Secret
+        path: databaseSecret
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
+      - description: Name of the Secret containing the Cryostat storage connection
+          key.
+        displayName: Storage Secret
+        path: storageSecret
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
       - description: List of namespaces that Cryostat has been configured and authorized
           to access and profile.
         displayName: Target Namespaces

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -855,8 +855,21 @@ func (r *TestResources) NewDatabaseSecret() *corev1.Secret {
 			Namespace: r.Namespace,
 		},
 		StringData: map[string]string{
-			"CONNECTION_KEY": "credentials_database",
+			"CONNECTION_KEY": "connection_key",
 			"ENCRYPTION_KEY": "encryption_key",
+		},
+	}
+}
+
+func (r *TestResources) NewCustomDatabaseSecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      providedDatabaseSecretName,
+			Namespace: r.Namespace,
+		},
+		StringData: map[string]string{
+			"CONNECTION_KEY": "custom-connection_database",
+			"ENCRYPTION_KEY": "custom-encryption_key",
 		},
 	}
 }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to #710 

## Description of the change:

- Moved/Added new status fields for secrets to `v1beta2` since they are only applicable in Cryostat `3.0`.
- Updated the controller to set missing status fields for database and storage secrets.
- Added kubebuilder/operator-sdk markers for status fields such that:
  - Database and Storage secrets' names are also showed when `kubectl get cryostat` (default output).
    ```bash
    NAME              APPLICATION URL                                 TARGET NAMESPACES   STORAGE SECRET                       DATABASE SECRET
    cryostat-sample   https://cryostat-sample-myns.apps-crc.testing   ["myns"]            cryostat-sample-storage-secret-key   cryostat-sample-db
    ```
  - [`xDescriptors={"urn:alm:descriptor:io.kubernetes:Secret"}`](https://github.com/openshift/console/blob/master/frontend/packages/operator-lifecycle-manager/src/components/descriptors/reference/reference.md#3-k8sresourceprefix) for Secrets. On OpenShift, this should render the status fields as clickable links to view the corresponding secrets.
- Added more tests to validate status fields.

## Motivation for the change:

Status fields for database and storage secrets are missing in the Cryostat CR. These fields would also be useful for tackling #475.

## How to manually test:

```bash
export IMAGE_NAMESPACE=quay.io/some-user
export IMAGE_VERSION=test-version
make oci-build bundle bundle-build
podman push $IMAGE_NAMESPACE/cryostat-operator:$IMAGE_VERSION
podman push $IMAGE_NAMESPACE/cryostat-operator-bundle:$IMAGE_VERSION
make deploy_bundle
make create_cryostat_cr
```
