### PR TITLE
fix(secret): database should use user-defined secret if specified

### DIFF
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -1000,10 +1000,7 @@ func NewCoreContainer(cr *model.CryostatInstance, specs *ServiceSpecs, imageTag 
 	}
 
 	optional := false
-	secretName := cr.Name + "-db"
-	if cr.Spec.DatabaseOptions != nil && cr.Spec.DatabaseOptions.SecretName != nil {
-		secretName = *cr.Spec.DatabaseOptions.SecretName
-	}
+	secretName := getDatabaseSecret(cr)
 	envs = append(envs, corev1.EnvVar{
 		Name: "QUARKUS_DATASOURCE_PASSWORD",
 		ValueFrom: &corev1.EnvVarSource{
@@ -1415,7 +1412,7 @@ func newDatabaseContainer(cr *model.CryostatInstance, imageTag string, tls *TLSC
 	}
 
 	optional := false
-	secretName := cr.Name + "-db"
+	secretName := getDatabaseSecret(cr)
 	envs = append(envs, corev1.EnvVar{
 		Name: "POSTGRESQL_PASSWORD",
 		ValueFrom: &corev1.EnvVarSource{
@@ -1623,4 +1620,12 @@ func populateResourceRequest(resources *corev1.ResourceRequirements, defaultCpu,
 		requests[corev1.ResourceMemory] = resource.MustParse(defaultMemory)
 	}
 	checkResourceRequestWithLimit(requests, resources.Limits)
+}
+
+func getDatabaseSecret(cr *model.CryostatInstance) string {
+	secretName := cr.Name + "-db"
+	if cr.Spec.DatabaseOptions != nil && cr.Spec.DatabaseOptions.SecretName != nil {
+		secretName = *cr.Spec.DatabaseOptions.SecretName
+	}
+	return secretName
 }

--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -1623,9 +1623,8 @@ func populateResourceRequest(resources *corev1.ResourceRequirements, defaultCpu,
 }
 
 func getDatabaseSecret(cr *model.CryostatInstance) string {
-	secretName := cr.Name + "-db"
 	if cr.Spec.DatabaseOptions != nil && cr.Spec.DatabaseOptions.SecretName != nil {
-		secretName = *cr.Spec.DatabaseOptions.SecretName
+		return *cr.Spec.DatabaseOptions.SecretName
 	}
-	return secretName
+	return cr.Name + "-db"
 }

--- a/internal/controllers/reconciler_test.go
+++ b/internal/controllers/reconciler_test.go
@@ -2896,7 +2896,7 @@ func (t *cryostatTestInput) checkAuthProxyContainer(container *corev1.Container,
 	Expect(container.Env).To(ConsistOf(t.NewAuthProxyEnvironmentVariables(basicAuthConfigured, basicAuthFilename)))
 	Expect(container.EnvFrom).To(ConsistOf(t.NewAuthProxyEnvFromSource()))
 	Expect(container.VolumeMounts).To(ConsistOf(t.NewAuthProxyVolumeMounts(basicAuthConfigured)))
-	Expect(container.LivenessProbe).To(Equal(t.NewAuthProxyLivnessProbe()))
+	Expect(container.LivenessProbe).To(Equal(t.NewAuthProxyLivenessProbe()))
 	Expect(container.SecurityContext).To(Equal(securityContext))
 
 	test.ExpectResourceRequirements(&container.Resources, resources)

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -1863,7 +1863,7 @@ func (r *TestResources) NewDatabaseReadinessProbe() *corev1.Probe {
 	}
 }
 
-func (r *TestResources) NewAuthProxyLivnessProbe() *corev1.Probe {
+func (r *TestResources) NewAuthProxyLivenessProbe() *corev1.Probe {
 	protocol := corev1.URISchemeHTTP
 	if r.TLS {
 		protocol = corev1.URISchemeHTTPS


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #826 

## Description of the change:

- Updated the controller to consider custom secret for the database container if specified.
- Tests: Added checks to validate storage, database and auth-proxy container specs. These are previously missing.
  - The AuthProxy container should have some checks for the container's arguments. For OpenShift Auth Proxy, most configs are specified using flags. Maybe, its better to split that into a separate follow-up PR. 

## Motivation for the change:

See #826. Tests are not yet validating the storage, database and auth-proxy containers.

## How to manually test:

Create a database secret:

```bash
cat <<EOF | oc apply -f -
apiVersion: v1
stringData:
  CONNECTION_KEY: connection_key
  ENCRYPTION_KEY: encryption_key
kind: Secret
metadata:
  name: db-secret
type: Opaque
EOF
```

Deploy the operator and create a cryostat CR with database secret specified:

```bash
export IMAGE_NAMESPACE=quay.io/some-user
export IMAGE_VERSION=test-version
make oci-build bundle bundle-build
podman push $IMAGE_NAMESPACE/cryostat-operator:$IMAGE_VERSION
podman push $IMAGE_NAMESPACE/cryostat-operator-bundle:$IMAGE_VERSION
make deploy_bundle

cat <<EOF | oc apply -f -
apiVersion: operator.cryostat.io/v1beta2
kind: Cryostat
metadata:
  name: cryostat-sample
spec:
  enableCertManager: true
  trustedCertSecrets: []
  eventTemplates: []
  storageOptions:
    pvc:
      labels: {}
      annotations: {}
      spec: {}
  reportOptions:
    replicas: 0
  databaseOptions:
    secretName: db-secret
EOF
```

The deployment should progress and all containers should be up and running.
