### PR TITLE
chore(discovery): ensure consistent names for discovery options in CRD

### DIFF
--- a/api/v1beta1/cryostat_conversion.go
+++ b/api/v1beta1/cryostat_conversion.go
@@ -245,7 +245,7 @@ func convertTargetDiscoveryTo(srcOpts *TargetDiscoveryOptions) *operatorv1beta2.
 	var dstOpts *operatorv1beta2.TargetDiscoveryOptions
 	if srcOpts != nil {
 		dstOpts = &operatorv1beta2.TargetDiscoveryOptions{
-			BuiltInDiscoveryDisabled:  srcOpts.BuiltInDiscoveryDisabled,
+			DisableBuiltInDiscovery:   srcOpts.BuiltInDiscoveryDisabled,
 			DisableBuiltInPortNames:   srcOpts.DisableBuiltInPortNames,
 			DiscoveryPortNames:        srcOpts.DiscoveryPortNames,
 			DisableBuiltInPortNumbers: srcOpts.DisableBuiltInPortNumbers,
@@ -507,7 +507,7 @@ func convertTargetDiscoveryFrom(srcOpts *operatorv1beta2.TargetDiscoveryOptions)
 	var dstOpts *TargetDiscoveryOptions
 	if srcOpts != nil {
 		dstOpts = &TargetDiscoveryOptions{
-			BuiltInDiscoveryDisabled:  srcOpts.BuiltInDiscoveryDisabled,
+			BuiltInDiscoveryDisabled:  srcOpts.DisableBuiltInDiscovery,
 			DisableBuiltInPortNames:   srcOpts.DisableBuiltInPortNames,
 			DiscoveryPortNames:        srcOpts.DiscoveryPortNames,
 			DisableBuiltInPortNumbers: srcOpts.DisableBuiltInPortNumbers,

--- a/api/v1beta2/cryostat_types.go
+++ b/api/v1beta2/cryostat_types.go
@@ -584,8 +584,8 @@ type TargetDiscoveryOptions struct {
 	// When true, the Cryostat application will disable the built-in discovery mechanisms. Defaults to false
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Disable Built-in Discovery",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
-	BuiltInDiscoveryDisabled bool `json:"builtInDiscoveryDisabled,omitempty"`
-	// When true, the Cryostat application will use the default port name jfr-jmx to look for JMX connectable targets.
+	DisableBuiltInDiscovery bool `json:"disableBuiltInDiscovery,omitempty"`
+	// When false and discoveryPortNames is empty, the Cryostat application will use the default port name jfr-jmx to look for JMX connectable targets. Defaults to false.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Disable Built-in Port Names",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	DisableBuiltInPortNames bool `json:"disableBuiltInPortNames,omitempty"`
@@ -593,7 +593,7 @@ type TargetDiscoveryOptions struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldDependency:targetDiscoveryOptions.disableBuiltInPortNames:true"}
 	DiscoveryPortNames []string `json:"discoveryPortNames,omitempty"`
-	// When true, the Cryostat application will use the default port number 9091 to look for JMX connectable targets.
+	// When false and discoveryPortNumbers is empty, the Cryostat application will use the default port number 9091 to look for JMX connectable targets. Defaults to false.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Disable Built-in Port Numbers",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	DisableBuiltInPortNumbers bool `json:"disableBuiltInPortNumbers,omitempty"`

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -53,7 +53,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:3.0.0-dev
-    createdAt: "2024-05-27T20:00:30Z"
+    createdAt: "2024-05-28T20:14:14Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {
@@ -842,17 +842,19 @@ spec:
       - description: When true, the Cryostat application will disable the built-in
           discovery mechanisms. Defaults to false
         displayName: Disable Built-in Discovery
-        path: targetDiscoveryOptions.builtInDiscoveryDisabled
+        path: targetDiscoveryOptions.disableBuiltInDiscovery
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: When true, the Cryostat application will use the default port
-          name jfr-jmx to look for JMX connectable targets.
+      - description: When false and discoveryPortNames is empty, the Cryostat application
+          will use the default port name jfr-jmx to look for JMX connectable targets.
+          Defaults to false.
         displayName: Disable Built-in Port Names
         path: targetDiscoveryOptions.disableBuiltInPortNames
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: When true, the Cryostat application will use the default port
-          number 9091 to look for JMX connectable targets.
+      - description: When false and discoveryPortNumbers is empty, the Cryostat application
+          will use the default port number 9091 to look for JMX connectable targets.
+          Defaults to false.
         displayName: Disable Built-in Port Numbers
         path: targetDiscoveryOptions.disableBuiltInPortNumbers
         x-descriptors:

--- a/bundle/manifests/operator.cryostat.io_cryostats.yaml
+++ b/bundle/manifests/operator.cryostat.io_cryostats.yaml
@@ -9711,17 +9711,19 @@ spec:
                 description: Options to configure the Cryostat application's target
                   discovery mechanisms.
                 properties:
-                  builtInDiscoveryDisabled:
+                  disableBuiltInDiscovery:
                     description: When true, the Cryostat application will disable
                       the built-in discovery mechanisms. Defaults to false
                     type: boolean
                   disableBuiltInPortNames:
-                    description: When true, the Cryostat application will use the
-                      default port name jfr-jmx to look for JMX connectable targets.
+                    description: When false and discoveryPortNames is empty, the Cryostat
+                      application will use the default port name jfr-jmx to look for
+                      JMX connectable targets. Defaults to false.
                     type: boolean
                   disableBuiltInPortNumbers:
-                    description: When true, the Cryostat application will use the
-                      default port number 9091 to look for JMX connectable targets.
+                    description: When false and discoveryPortNumbers is empty, the
+                      Cryostat application will use the default port number 9091 to
+                      look for JMX connectable targets. Defaults to false.
                     type: boolean
                   discoveryPortNames:
                     description: List of port names that the Cryostat application

--- a/config/crd/bases/operator.cryostat.io_cryostats.yaml
+++ b/config/crd/bases/operator.cryostat.io_cryostats.yaml
@@ -9701,17 +9701,19 @@ spec:
                 description: Options to configure the Cryostat application's target
                   discovery mechanisms.
                 properties:
-                  builtInDiscoveryDisabled:
+                  disableBuiltInDiscovery:
                     description: When true, the Cryostat application will disable
                       the built-in discovery mechanisms. Defaults to false
                     type: boolean
                   disableBuiltInPortNames:
-                    description: When true, the Cryostat application will use the
-                      default port name jfr-jmx to look for JMX connectable targets.
+                    description: When false and discoveryPortNames is empty, the Cryostat
+                      application will use the default port name jfr-jmx to look for
+                      JMX connectable targets. Defaults to false.
                     type: boolean
                   disableBuiltInPortNumbers:
-                    description: When true, the Cryostat application will use the
-                      default port number 9091 to look for JMX connectable targets.
+                    description: When false and discoveryPortNumbers is empty, the
+                      Cryostat application will use the default port number 9091 to
+                      look for JMX connectable targets. Defaults to false.
                     type: boolean
                   discoveryPortNames:
                     description: List of port names that the Cryostat application

--- a/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
@@ -387,17 +387,19 @@ spec:
       - description: When true, the Cryostat application will disable the built-in
           discovery mechanisms. Defaults to false
         displayName: Disable Built-in Discovery
-        path: targetDiscoveryOptions.builtInDiscoveryDisabled
+        path: targetDiscoveryOptions.disableBuiltInDiscovery
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: When true, the Cryostat application will use the default port
-          name jfr-jmx to look for JMX connectable targets.
+      - description: When false and discoveryPortNames is empty, the Cryostat application
+          will use the default port name jfr-jmx to look for JMX connectable targets.
+          Defaults to false.
         displayName: Disable Built-in Port Names
         path: targetDiscoveryOptions.disableBuiltInPortNames
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: When true, the Cryostat application will use the default port
-          number 9091 to look for JMX connectable targets.
+      - description: When false and discoveryPortNumbers is empty, the Cryostat application
+          will use the default port number 9091 to look for JMX connectable targets.
+          Defaults to false.
         displayName: Disable Built-in Port Numbers
         path: targetDiscoveryOptions.disableBuiltInPortNumbers
         x-descriptors:

--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -1095,7 +1095,7 @@ func NewCoreContainer(cr *model.CryostatInstance, specs *ServiceSpecs, imageTag 
 	k8sDiscoveryPortNames := "jfr-jmx"
 	k8sDiscoveryPortNumbers := "9091"
 	if cr.Spec.TargetDiscoveryOptions != nil {
-		k8sDiscoveryEnabled = !cr.Spec.TargetDiscoveryOptions.BuiltInDiscoveryDisabled
+		k8sDiscoveryEnabled = !cr.Spec.TargetDiscoveryOptions.DisableBuiltInDiscovery
 
 		if len(cr.Spec.TargetDiscoveryOptions.DiscoveryPortNames) > 0 {
 			k8sDiscoveryPortNames = strings.Join(cr.Spec.TargetDiscoveryOptions.DiscoveryPortNames[:], ",")

--- a/internal/controllers/reconciler_test.go
+++ b/internal/controllers/reconciler_test.go
@@ -2616,7 +2616,7 @@ func (t *cryostatTestInput) checkMainPodTemplate(deployment *appsv1.Deployment, 
 	hasPortConfig := cr.Spec.TargetDiscoveryOptions != nil &&
 		len(cr.Spec.TargetDiscoveryOptions.DiscoveryPortNames) > 0 &&
 		len(cr.Spec.TargetDiscoveryOptions.DiscoveryPortNumbers) > 0
-	builtInDiscoveryDisabled := cr.Spec.TargetDiscoveryOptions != nil && cr.Spec.TargetDiscoveryOptions.BuiltInDiscoveryDisabled
+	builtInDiscoveryDisabled := cr.Spec.TargetDiscoveryOptions != nil && cr.Spec.TargetDiscoveryOptions.DisableBuiltInDiscovery
 	builtInPortConfigDisabled := cr.Spec.TargetDiscoveryOptions != nil &&
 		cr.Spec.TargetDiscoveryOptions.DisableBuiltInPortNames &&
 		cr.Spec.TargetDiscoveryOptions.DisableBuiltInPortNumbers

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -466,7 +466,7 @@ func (r *TestResources) NewCryostatWithLowResourceLimit() *model.CryostatInstanc
 func (r *TestResources) NewCryostatWithBuiltInDiscoveryDisabled() *model.CryostatInstance {
 	cr := r.NewCryostat()
 	cr.Spec.TargetDiscoveryOptions = &operatorv1beta2.TargetDiscoveryOptions{
-		BuiltInDiscoveryDisabled: true,
+		DisableBuiltInDiscovery: true,
 	}
 	return cr
 }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to #715 

## Description of the change:

- Correct documentations for discovery fields. The field doc said the below previously though it should be the opposite.
  > // When true, the Cryostat application will use the default port name jfr-jmx to look for JMX connectable targets.
  > DisableBuiltInPortNames bool `json:"disableBuiltInPortNames,omitempty"`
- Updated field names to be consistent. @ebaron Is it OK to update `v1beta2`  as such? Otherwise, I can just update the docs only.


## Motivation for the change:

Documentation might be confusing as they state the opposite of what the fields should do.