### PR TITLE
fix(crd): restrict database secret name to be immutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ the JFR datasource for Grafana.
 for the Grafana dashboard.
 
 # Using
+
+Minimum Supported Kubernetes Version: `v1.21`.
+
 Once deployed, the `cryostat` instance can be accessed via web browser
 at the URL provided by:
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ for the Grafana dashboard.
 
 # Using
 
-Minimum Supported Kubernetes Version: `v1.21`.
+## Requirements
+
+- `kubernetes` v1.21+ with [`Operator Lifecycle Manager`](https://olm.operatorframework.io/)
+- [`cert-manager`](https://github.com/cert-manager/cert-manager) v1.11.5+ (Recommended)
+
+## Instructions
 
 Once deployed, the `cryostat` instance can be accessed via web browser
 at the URL provided by:
@@ -44,7 +49,6 @@ the need to expose a JMX port over the network.
 ## Requirements
 - `go` v1.21
 - [`operator-sdk`](https://github.com/operator-framework/operator-sdk) v1.31.0
-- [`cert-manager`](https://github.com/cert-manager/cert-manager) v1.11.5+ (Recommended)
 - `podman` or `docker`
 - [`jq`](https://stedolan.github.io/jq/) v1.6+
 - `ginkgo` (Optional)

--- a/api/v1beta2/cryostat_types.go
+++ b/api/v1beta2/cryostat_types.go
@@ -603,7 +603,7 @@ type TargetDiscoveryOptions struct {
 type DatabaseOptions struct {
 	// Name of the secret containing database keys. This secret must contain a CONNECTION_KEY secret which is the
 	// database connection password, and an ENCRYPTION_KEY secret which is the key used to encrypt sensitive data
-	// stored within the database, such as the target credentials keyring.
+	// stored within the database, such as the target credentials keyring. Cannot be updated.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:io.kubernetes:Secret"}
 	SecretName *string `json:"secretName,omitempty"`

--- a/api/v1beta2/cryostat_types.go
+++ b/api/v1beta2/cryostat_types.go
@@ -604,7 +604,7 @@ type DatabaseOptions struct {
 	// Name of the secret containing database keys. This secret must contain a CONNECTION_KEY secret which is the
 	// database connection password, and an ENCRYPTION_KEY secret which is the key used to encrypt sensitive data
 	// stored within the database, such as the target credentials keyring. This field cannot be updated.
-	// It is recommended that the secret should be marked as immutable to avoid accidential mutations.
+	// It is recommended that the secret should be marked as immutable to avoid accidental changes to secret's data.
 	// More details: https://kubernetes.io/docs/concepts/configuration/secret/#secret-immutable
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:io.kubernetes:Secret"}

--- a/api/v1beta2/cryostat_types.go
+++ b/api/v1beta2/cryostat_types.go
@@ -603,7 +603,9 @@ type TargetDiscoveryOptions struct {
 type DatabaseOptions struct {
 	// Name of the secret containing database keys. This secret must contain a CONNECTION_KEY secret which is the
 	// database connection password, and an ENCRYPTION_KEY secret which is the key used to encrypt sensitive data
-	// stored within the database, such as the target credentials keyring. Cannot be updated.
+	// stored within the database, such as the target credentials keyring. This field cannot be updated.
+	// It is recommended that the secret should be marked as immutable to avoid accidential mutations.
+	// More details: https://kubernetes.io/docs/concepts/configuration/secret/#secret-immutable
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:io.kubernetes:Secret"}
 	SecretName *string `json:"secretName,omitempty"`

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -53,7 +53,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:3.0.0-dev
-    createdAt: "2024-05-31T05:26:09Z"
+    createdAt: "2024-05-31T05:27:37Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {
@@ -581,7 +581,8 @@ spec:
           and an ENCRYPTION_KEY secret which is the key used to encrypt sensitive
           data stored within the database, such as the target credentials keyring.
           This field cannot be updated. It is recommended that the secret should be
-          marked as immutable to avoid accidential mutations. More details: https://kubernetes.io/docs/concepts/configuration/secret/#secret-immutable'
+          marked as immutable to avoid accidental changes to secret''s data. More
+          details: https://kubernetes.io/docs/concepts/configuration/secret/#secret-immutable'
         displayName: Secret Name
         path: databaseOptions.secretName
         x-descriptors:

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -53,7 +53,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:3.0.0-dev
-    createdAt: "2024-05-28T20:14:14Z"
+    createdAt: "2024-05-31T05:18:57Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {
@@ -580,6 +580,7 @@ spec:
           contain a CONNECTION_KEY secret which is the database connection password,
           and an ENCRYPTION_KEY secret which is the key used to encrypt sensitive
           data stored within the database, such as the target credentials keyring.
+          Cannot be updated.
         displayName: Secret Name
         path: databaseOptions.secretName
         x-descriptors:

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -53,7 +53,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:3.0.0-dev
-    createdAt: "2024-05-31T05:18:57Z"
+    createdAt: "2024-05-31T05:26:09Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {
@@ -576,11 +576,12 @@ spec:
       - description: Options to configure the Cryostat application's database.
         displayName: Database Options
         path: databaseOptions
-      - description: Name of the secret containing database keys. This secret must
+      - description: 'Name of the secret containing database keys. This secret must
           contain a CONNECTION_KEY secret which is the database connection password,
           and an ENCRYPTION_KEY secret which is the key used to encrypt sensitive
           data stored within the database, such as the target credentials keyring.
-          Cannot be updated.
+          This field cannot be updated. It is recommended that the secret should be
+          marked as immutable to avoid accidential mutations. More details: https://kubernetes.io/docs/concepts/configuration/secret/#secret-immutable'
         displayName: Secret Name
         path: databaseOptions.secretName
         x-descriptors:

--- a/bundle/manifests/operator.cryostat.io_cryostats.yaml
+++ b/bundle/manifests/operator.cryostat.io_cryostats.yaml
@@ -5212,7 +5212,7 @@ spec:
                       secret must contain a CONNECTION_KEY secret which is the database
                       connection password, and an ENCRYPTION_KEY secret which is the
                       key used to encrypt sensitive data stored within the database,
-                      such as the target credentials keyring.
+                      such as the target credentials keyring. Cannot be updated.
                     type: string
                 type: object
               enableCertManager:

--- a/bundle/manifests/operator.cryostat.io_cryostats.yaml
+++ b/bundle/manifests/operator.cryostat.io_cryostats.yaml
@@ -5214,7 +5214,8 @@ spec:
                       key used to encrypt sensitive data stored within the database,
                       such as the target credentials keyring. This field cannot be
                       updated. It is recommended that the secret should be marked
-                      as immutable to avoid accidential mutations. More details: https://kubernetes.io/docs/concepts/configuration/secret/#secret-immutable'
+                      as immutable to avoid accidental changes to secret''s data.
+                      More details: https://kubernetes.io/docs/concepts/configuration/secret/#secret-immutable'
                     type: string
                 type: object
               enableCertManager:

--- a/bundle/manifests/operator.cryostat.io_cryostats.yaml
+++ b/bundle/manifests/operator.cryostat.io_cryostats.yaml
@@ -5208,11 +5208,13 @@ spec:
                 description: Options to configure the Cryostat application's database.
                 properties:
                   secretName:
-                    description: Name of the secret containing database keys. This
+                    description: 'Name of the secret containing database keys. This
                       secret must contain a CONNECTION_KEY secret which is the database
                       connection password, and an ENCRYPTION_KEY secret which is the
                       key used to encrypt sensitive data stored within the database,
-                      such as the target credentials keyring. Cannot be updated.
+                      such as the target credentials keyring. This field cannot be
+                      updated. It is recommended that the secret should be marked
+                      as immutable to avoid accidential mutations. More details: https://kubernetes.io/docs/concepts/configuration/secret/#secret-immutable'
                     type: string
                 type: object
               enableCertManager:

--- a/config/crd/bases/operator.cryostat.io_cryostats.yaml
+++ b/config/crd/bases/operator.cryostat.io_cryostats.yaml
@@ -5202,7 +5202,7 @@ spec:
                       secret must contain a CONNECTION_KEY secret which is the database
                       connection password, and an ENCRYPTION_KEY secret which is the
                       key used to encrypt sensitive data stored within the database,
-                      such as the target credentials keyring.
+                      such as the target credentials keyring. Cannot be updated.
                     type: string
                 type: object
               enableCertManager:

--- a/config/crd/bases/operator.cryostat.io_cryostats.yaml
+++ b/config/crd/bases/operator.cryostat.io_cryostats.yaml
@@ -5198,11 +5198,13 @@ spec:
                 description: Options to configure the Cryostat application's database.
                 properties:
                   secretName:
-                    description: Name of the secret containing database keys. This
+                    description: 'Name of the secret containing database keys. This
                       secret must contain a CONNECTION_KEY secret which is the database
                       connection password, and an ENCRYPTION_KEY secret which is the
                       key used to encrypt sensitive data stored within the database,
-                      such as the target credentials keyring. Cannot be updated.
+                      such as the target credentials keyring. This field cannot be
+                      updated. It is recommended that the secret should be marked
+                      as immutable to avoid accidential mutations. More details: https://kubernetes.io/docs/concepts/configuration/secret/#secret-immutable'
                     type: string
                 type: object
               enableCertManager:

--- a/config/crd/bases/operator.cryostat.io_cryostats.yaml
+++ b/config/crd/bases/operator.cryostat.io_cryostats.yaml
@@ -5204,7 +5204,8 @@ spec:
                       key used to encrypt sensitive data stored within the database,
                       such as the target credentials keyring. This field cannot be
                       updated. It is recommended that the secret should be marked
-                      as immutable to avoid accidential mutations. More details: https://kubernetes.io/docs/concepts/configuration/secret/#secret-immutable'
+                      as immutable to avoid accidental changes to secret''s data.
+                      More details: https://kubernetes.io/docs/concepts/configuration/secret/#secret-immutable'
                     type: string
                 type: object
               enableCertManager:

--- a/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
@@ -121,11 +121,12 @@ spec:
       - description: Options to configure the Cryostat application's database.
         displayName: Database Options
         path: databaseOptions
-      - description: Name of the secret containing database keys. This secret must
+      - description: 'Name of the secret containing database keys. This secret must
           contain a CONNECTION_KEY secret which is the database connection password,
           and an ENCRYPTION_KEY secret which is the key used to encrypt sensitive
           data stored within the database, such as the target credentials keyring.
-          Cannot be updated.
+          This field cannot be updated. It is recommended that the secret should be
+          marked as immutable to avoid accidential mutations. More details: https://kubernetes.io/docs/concepts/configuration/secret/#secret-immutable'
         displayName: Secret Name
         path: databaseOptions.secretName
         x-descriptors:

--- a/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
@@ -125,6 +125,7 @@ spec:
           contain a CONNECTION_KEY secret which is the database connection password,
           and an ENCRYPTION_KEY secret which is the key used to encrypt sensitive
           data stored within the database, such as the target credentials keyring.
+          Cannot be updated.
         displayName: Secret Name
         path: databaseOptions.secretName
         x-descriptors:

--- a/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
@@ -126,7 +126,8 @@ spec:
           and an ENCRYPTION_KEY secret which is the key used to encrypt sensitive
           data stored within the database, such as the target credentials keyring.
           This field cannot be updated. It is recommended that the secret should be
-          marked as immutable to avoid accidential mutations. More details: https://kubernetes.io/docs/concepts/configuration/secret/#secret-immutable'
+          marked as immutable to avoid accidental changes to secret''s data. More
+          details: https://kubernetes.io/docs/concepts/configuration/secret/#secret-immutable'
         displayName: Secret Name
         path: databaseOptions.secretName
         x-descriptors:

--- a/internal/controllers/reconciler_test.go
+++ b/internal/controllers/reconciler_test.go
@@ -2352,6 +2352,7 @@ func (t *cryostatTestInput) expectDatabaseSecret() {
 	expectedSecret := t.NewDatabaseSecret()
 	t.checkMetadata(secret, expectedSecret)
 	Expect(secret.StringData).To(Equal(expectedSecret.StringData))
+	Expect(secret.Immutable).To(Equal(expectedSecret.Immutable))
 }
 
 func (t *cryostatTestInput) expectStorageSecret() {

--- a/internal/controllers/secrets.go
+++ b/internal/controllers/secrets.go
@@ -73,7 +73,6 @@ func (r *Reconciler) reconcileDatabaseConnectionSecret(ctx context.Context, cr *
 			Name:      cr.Name + databaseSecretNameSuffix,
 			Namespace: cr.InstallNamespace,
 		},
-		Immutable: &[]bool{true}[0],
 	}
 	secretName := secret.Name
 	secretProvided := cr.Spec.DatabaseOptions != nil && cr.Spec.DatabaseOptions.SecretName != nil
@@ -98,6 +97,8 @@ func (r *Reconciler) reconcileDatabaseConnectionSecret(ctx context.Context, cr *
 				secret.StringData[constants.DatabaseSecretConnectionKey] = r.GenPasswd(32)
 				secret.StringData[constants.DatabaseSecretEncryptionKey] = r.GenPasswd(32)
 			}
+
+			secret.Immutable = &[]bool{true}[0]
 			return nil
 		})
 

--- a/internal/controllers/secrets.go
+++ b/internal/controllers/secrets.go
@@ -73,6 +73,7 @@ func (r *Reconciler) reconcileDatabaseConnectionSecret(ctx context.Context, cr *
 			Name:      cr.Name + databaseSecretNameSuffix,
 			Namespace: cr.InstallNamespace,
 		},
+		Immutable: &[]bool{true}[0],
 	}
 	secretName := secret.Name
 	secretProvided := cr.Spec.DatabaseOptions != nil && cr.Spec.DatabaseOptions.SecretName != nil

--- a/internal/controllers/secrets.go
+++ b/internal/controllers/secrets.go
@@ -16,12 +16,13 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/cryostatio/cryostat-operator/internal/controllers/constants"
 	"github.com/cryostatio/cryostat-operator/internal/controllers/model"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -57,23 +58,35 @@ func (r *Reconciler) reconcileAuthProxyCookieSecret(ctx context.Context, cr *mod
 	})
 }
 
-// databaseSecretNameSuffix is the suffix to be appended to the name of a
-// Cryostat CR to name its database secret
-const databaseSecretNameSuffix = "-db"
+const (
+	// The suffix to be appended to the name of a Cryostat CR to name its database secret
+	databaseSecretNameSuffix          = "-db"
+	eventDatabaseSecretMismatchedType = "DatabaseSecretMismatched"
+	eventDatabaseMismatchMsg          = "\"databaseOptions.secretName\" field cannot be updated, please revert its value or re-create this Cryostat custom resource"
+)
+
+var errDatabaseSecretUpdated = errors.New("database secret cannot be updated, but another secret is specified")
 
 func (r *Reconciler) reconcileDatabaseConnectionSecret(ctx context.Context, cr *model.CryostatInstance) error {
-	var secretName string
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Name + databaseSecretNameSuffix,
+			Namespace: cr.InstallNamespace,
+		},
+	}
+	secretName := secret.Name
 	secretProvided := cr.Spec.DatabaseOptions != nil && cr.Spec.DatabaseOptions.SecretName != nil
 	if secretProvided {
-		// Do not delete default secret to allow reverting to use default if needed
 		secretName = *cr.Spec.DatabaseOptions.SecretName
-	} else {
-		secret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      cr.Name + databaseSecretNameSuffix,
-				Namespace: cr.InstallNamespace,
-			},
-		}
+	}
+
+	// If the CR status contains the secret name, emit an Event in case the configured secret's name does not match.
+	if len(cr.Status.DatabaseSecret) > 0 && cr.Status.DatabaseSecret != secretName {
+		r.EventRecorder.Event(cr.Object, corev1.EventTypeWarning, eventDatabaseSecretMismatchedType, eventDatabaseMismatchMsg)
+		return errDatabaseSecretUpdated
+	}
+
+	if !secretProvided {
 		err := r.createOrUpdateSecret(ctx, secret, cr.Object, func() error {
 			if secret.StringData == nil {
 				secret.StringData = map[string]string{}
@@ -90,8 +103,8 @@ func (r *Reconciler) reconcileDatabaseConnectionSecret(ctx context.Context, cr *
 		if err != nil {
 			return err
 		}
-		secretName = secret.Name
 	}
+
 	cr.Status.DatabaseSecret = secretName
 	return r.Client.Status().Update(ctx, cr.Object)
 }
@@ -150,7 +163,7 @@ func (r *Reconciler) createOrUpdateSecret(ctx context.Context, secret *corev1.Se
 
 func (r *Reconciler) deleteSecret(ctx context.Context, secret *corev1.Secret) error {
 	err := r.Client.Delete(ctx, secret)
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !kerrors.IsNotFound(err) {
 		r.Log.Error(err, "Could not delete secret", "name", secret.Name, "namespace", secret.Namespace)
 		return err
 	}

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -852,6 +852,7 @@ func (r *TestResources) NewDatabaseSecret() *corev1.Secret {
 			"CONNECTION_KEY": "connection_key",
 			"ENCRYPTION_KEY": "encryption_key",
 		},
+		Immutable: &[]bool{true}[0],
 	}
 }
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #475 

## Description of the change:

Updated the reconciler logic to emit an Event to warn against mismatched secret name for database and return an approriate error.

## Motivation for the change:

See #475. The secret used to database encryption must not change (i.e. `databaseOptions.secretName` is immutable).

## How to manually test:

Create a secret:

```bash
cat <<EOF | oc apply -f -
apiVersion: v1
stringData:
  CONNECTION_KEY: connection_key
  ENCRYPTION_KEY: encryption_key
kind: Secret
metadata:
  name: db-secret
type: Opaque
EOF
```

Deploy the operator and create a CR:

```bash
export IMAGE_NAMESPACE=quay.io/some-user
export IMAGE_VERSION=test-version
make oci-build bundle bundle-build
podman push $IMAGE_NAMESPACE/cryostat-operator:$IMAGE_VERSION
podman push $IMAGE_NAMESPACE/cryostat-operator-bundle:$IMAGE_VERSION
make deploy_bundle

cat <<EOF | oc apply -f -
apiVersion: operator.cryostat.io/v1beta2
kind: Cryostat
metadata:
  name: cryostat-sample
spec:
  enableCertManager: true
  databaseOptions:
    secretName: db-secret
EOF
```
Wait for the controller finishes reconciling. Then, update the CR to remove the databaseOptions.secretName spec. The controller should show an error in reconciler loop and an event emitted. Vice versa, create an empty CR, wait for reconciling, and update the CR to specify the databaseOptions.secretName spec. The same behaviour should occur.

### Controller's log:

```
2024-05-31T05:48:59Z	ERROR	Reconciler error	{"controller": "cryostat", "controllerGroup": "operator.cryostat.io", "controllerKind": "Cryostat", "Cryostat": {"name":"cryostat-sample","namespace":"myns"}, "namespace": "myns", "name": "cryostat-sample", "reconcileID": "f2dcb01e-d6a4-4d92-b949-11727633e32b", "error": "database secret cannot be updated, but another secret is specified"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.5/pkg/internal/controller/controller.go:329
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.5/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.5/pkg/internal/controller/controller.go:227
2024-05-31T05:48:59Z	DEBUG	events	"databaseOptions.secretName" field cannot be updated, please revert its value or re-create this Cryostat custom resource	{"type": "Warning", "object": {"kind":"Cryostat","namespace":"myns","name":"cryostat-sample","uid":"21527815-9aa8-4196-8bce-0b0625e28596","apiVersion":"operator.cryostat.io/v1beta2","resourceVersion":"165990"}, "reason": "DatabaseSecretMismatched"}
```

### Events

![image](https://github.com/cryostatio/cryostat-operator/assets/68053619/a746039a-d557-4c6f-b97e-c0c8b0989265)
