### PR TITLE
fix(proxy): do not pass unused credentials upstream

### DIFF
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -647,6 +647,9 @@ func NewOpenShiftAuthProxyContainer(cr *model.CryostatInstance, specs *ServiceSp
 	}
 
 	args := []string{
+		"--pass-access-token=false",
+		"--pass-user-bearer-token=false",
+		"--pass-basic-auth=false",
 		fmt.Sprintf("--upstream=http://localhost:%d/", constants.CryostatHTTPContainerPort),
 		fmt.Sprintf("--upstream=http://localhost:%d/grafana/", constants.GrafanaContainerPort),
 		fmt.Sprintf("--upstream=http://localhost:%d/storage/", constants.StoragePort),


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #838

## Description of the change:
Explicitly sets some flags on the OpenShift OAuth Proxy to prevent it from passing headers to upstream servers (Cryostat, Grafana dashboard, storage) containing Basic credentials or auth tokens which the upstreams do not use and should not have access to if they don't have a particular need.

According to https://oauth2-proxy.github.io/oauth2-proxy/configuration/alpha-config#removed-options , the `oauth2-proxy`'s equivalent flags are not accessible when using the alpha configuration. We use alpha configuration because it is the only way to turn on the `proxyRawPath` setting (https://oauth2-proxy.github.io/oauth2-proxy/configuration/alpha-config#upstreamconfig), which is the switch for this proxy to avoid the path encoding redirect bug. When using alpha configuration it seems that none of these flags are enabled by default, they must each be configured explicitly using the new https://oauth2-proxy.github.io/oauth2-proxy/configuration/alpha-config#header options.

## Motivation for the change:
This enhances security, but also fixes a bug where Grafana 9 seems to attempt to validate credentials provided to it even if it is configured for anonymous access. Since we *only* configure it for anonymous access, passing along unexpected headers to it causes it to fail to evaluate these credentials and block the request, despite the anonymous access configuration.

## How to manually test:
1. *Insert steps here...*
2. *...*
