### PR TITLE
fix(grafana): use relative dashboard path

### DIFF
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -1133,7 +1133,7 @@ func NewCoreContainer(cr *model.CryostatInstance, specs *ServiceSpecs, imageTag 
 		grafanaVars = append(grafanaVars,
 			corev1.EnvVar{
 				Name:  "GRAFANA_DASHBOARD_EXT_URL",
-				Value: fmt.Sprintf("%s/grafana/", specs.AuthProxyURL.String()),
+				Value: "/grafana/",
 			},
 			corev1.EnvVar{
 				Name:  "GRAFANA_DASHBOARD_URL",

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -1338,19 +1338,10 @@ func (r *TestResources) newNetworkEnvironmentVariables() []corev1.EnvVar {
 			Name:  "GRAFANA_DASHBOARD_URL",
 			Value: "http://localhost:3000",
 		},
-	}
-	if r.ExternalTLS {
-		envs = append(envs,
-			corev1.EnvVar{
-				Name:  "GRAFANA_DASHBOARD_EXT_URL",
-				Value: fmt.Sprintf("https://%s.example.com/grafana/", r.Name),
-			})
-	} else {
-		envs = append(envs,
-			corev1.EnvVar{
-				Name:  "GRAFANA_DASHBOARD_EXT_URL",
-				Value: fmt.Sprintf("http://%s.example.com/grafana/", r.Name),
-			})
+		{
+			Name:  "GRAFANA_DASHBOARD_EXT_URL",
+			Value: "/grafana/",
+		},
 	}
 	return envs
 }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to #726

## Description of the change:
Sets the `GRAFANA_DASHBOARD_EXT_URL` to the simple relative `/grafana/` path, rather than the full Route URL.

## Motivation for the change:
Since Grafana and Cryostat are now deployed together behind a common auth proxy instance, the client accesses Grafana simply by navigating to `/grafana/` on the Cryostat UI URL. This change simplifies the setup so that there are now no more references to the full Route URL in the Deployment, so it is overall more dynamic and flexible. This will support cases where the user wishes to deploy Cryostat on a custom domain or custom subpath.
