### PR TITLE
chore(api): deprecate v1beta1 API version

### DIFF
--- a/api/v1beta1/cryostat_types.go
+++ b/api/v1beta1/cryostat_types.go
@@ -425,6 +425,7 @@ type JmxCacheOptions struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=cryostats,scope=Namespaced
+// +kubebuilder:deprecatedversion:warning="use v1beta2 API version"
 
 // Cryostat allows you to install Cryostat for a single namespace.
 // It contains configuration options for controlling the Deployment of the Cryostat

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -30,7 +30,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:4.0.0-dev
-    createdAt: "2024-06-10T06:01:52Z"
+    createdAt: "2024-06-10T14:47:15Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {

--- a/bundle/manifests/operator.cryostat.io_cryostats.yaml
+++ b/bundle/manifests/operator.cryostat.io_cryostats.yaml
@@ -32,6 +32,8 @@ spec:
     - jsonPath: .status.grafanaSecret
       name: Grafana Secret
       type: string
+    deprecated: true
+    deprecationWarning: use v1beta2 API version
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/operator.cryostat.io_cryostats.yaml
+++ b/config/crd/bases/operator.cryostat.io_cryostats.yaml
@@ -21,6 +21,8 @@ spec:
     - jsonPath: .status.grafanaSecret
       name: Grafana Secret
       type: string
+    deprecated: true
+    deprecationWarning: use v1beta2 API version
     name: v1beta1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #879 

## Description of the change:
* Applies `deprecatedversion` marker to v1beta1 Cryostat

## Motivation for the change:
* Warns users that they should be using the v1beta2 version and the v1beta1 version is subject to future removal

## How to manually test:
1. Install new CRDs
2. 
    ```
    $ kubectl get cryostat.v1beta1.operator.cryostat.io
    W0607 18:14:15.186540  144477 warnings.go:67] use v1beta2 API version
    ```
