### PR TITLE
chore(csv): bump csv minKubeVersion to 1.21.0

### DIFF
--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -30,7 +30,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:4.0.0-dev
-    createdAt: "2024-06-07T19:32:36Z"
+    createdAt: "2024-06-10T06:01:52Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {
@@ -1165,7 +1165,7 @@ spec:
     - email: cryostat-development@googlegroups.com
       name: The Cryostat Authors
   maturity: stable
-  minKubeVersion: 1.19.0
+  minKubeVersion: 1.21.0
   provider:
     name: The Cryostat Community
   relatedImages:

--- a/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
@@ -907,7 +907,7 @@ spec:
   - email: cryostat-development@googlegroups.com
     name: The Cryostat Authors
   maturity: stable
-  minKubeVersion: 1.19.0
+  minKubeVersion: 1.21.0
   provider:
     name: The Cryostat Community
   version: 0.0.0


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to #831 

## Description of the change:

- Bump csv minKubeVersion to 1.21.0

## Motivation for the change:

After #831, the minimum supported k8s version is 1.21.

Reference: https://olm.operatorframework.io/docs/best-practices/common/#provide-what-are-the-k8s-versions-supported-by-your-project

