### PR TITLE
fix(tls): detect modified CA and reissue certs

### DIFF
--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -30,7 +30,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:4.0.0-dev
-    createdAt: "2024-06-10T14:47:15Z"
+    createdAt: "2024-06-15T00:21:26Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {

--- a/internal/controllers/reconciler_test.go
+++ b/internal/controllers/reconciler_test.go
@@ -1711,6 +1711,36 @@ func (c *controllerTest) commonTests() {
 				})
 			})
 		})
+		Context("with a modified CA certificate", func() {
+			var oldCerts []*certv1.Certificate
+			BeforeEach(func() {
+				t.objs = append(t.objs, t.NewCryostat().Object, t.OtherCAIssuer())
+				oldCerts = []*certv1.Certificate{
+					t.NewCryostatCert(),
+					t.NewReportsCert(),
+				}
+				// Add an annotation for each cert, the test will assert that
+				// the annotation is gone.
+				for i, cert := range oldCerts {
+					metav1.SetMetaDataAnnotation(&oldCerts[i].ObjectMeta, "bad", "cert")
+					t.objs = append(t.objs, cert)
+				}
+			})
+			JustBeforeEach(func() {
+				cr := t.getCryostatInstance()
+				for _, cert := range oldCerts {
+					// Make the old certs owned by the Cryostat CR
+					err := controllerutil.SetControllerReference(cr.Object, cert, t.Client.Scheme())
+					Expect(err).ToNot(HaveOccurred())
+					err = t.Client.Update(context.Background(), cert)
+					Expect(err).ToNot(HaveOccurred())
+				}
+				t.reconcileCryostatFully()
+			})
+			It("should recreate certificates", func() {
+				t.expectCertificates()
+			})
+		})
 
 		Context("reconciling a multi-namespace request", func() {
 			targetNamespaces := []string{"multi-test-one", "multi-test-two"}

--- a/internal/controllers/secrets.go
+++ b/internal/controllers/secrets.go
@@ -165,7 +165,10 @@ func (r *Reconciler) createOrUpdateSecret(ctx context.Context, secret *corev1.Se
 
 func (r *Reconciler) deleteSecret(ctx context.Context, secret *corev1.Secret) error {
 	err := r.Client.Delete(ctx, secret)
-	if err != nil && !kerrors.IsNotFound(err) {
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
 		r.Log.Error(err, "Could not delete secret", "name", secret.Name, "namespace", secret.Namespace)
 		return err
 	}

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -1039,6 +1039,22 @@ func (r *TestResources) NewCryostatCAIssuer() *certv1.Issuer {
 	}
 }
 
+func (r *TestResources) OtherCAIssuer() *certv1.Issuer {
+	return &certv1.Issuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      r.Name + "-ca",
+			Namespace: r.Namespace,
+		},
+		Spec: certv1.IssuerSpec{
+			IssuerConfig: certv1.IssuerConfig{
+				CA: &certv1.CAIssuer{
+					SecretName: r.Name + "-ca",
+				},
+			},
+		},
+	}
+}
+
 func (r *TestResources) newPVC(spec *corev1.PersistentVolumeClaimSpec, labels map[string]string,
 	annotations map[string]string) *corev1.PersistentVolumeClaim {
 	return &corev1.PersistentVolumeClaim{


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #896 

## Description of the change:
* Detects when updating our CA Issuer causes its secret name to change
* If the secret has changed, delete any certificates owned by the CR (other than the CA), along with the secrets backing those certificates
* The certificates and their secrets will be recreated by the existing reconciliation logic 

## Motivation for the change:
* Fixes a bug where Cryostat was serving an old certificate after upgrading from 2.4 to 3.0. This could prevent users from accessing the Cryostat application.

## How to manually test:
I tested on an OpenShift cluster, since the bug was very apparent when trying to access Cryostat using the route.

1. Build and push an operator controller and bundle image for this PR. (I had to use Docker to make the bundle-upgrade work for some reason.)
   * Feel free to use mine: `quay.io/ebaron/cryostat-operator-bundle:delete-cert-chain-01`
2. `make deploy_bundle BUNDLE_IMG=quay.io/cryostat/cryostat-operator-bundle:2.4.0`
3. `oc create -f config/samples/operator_v1beta1_cryostat.yaml`
4. Wait for Cryostat to be ready
5. `./bin/operator-sdk run bundle-upgrade <bundle image for this PR>`
6. Wait for upgraded Cryostat to be ready
7. `curl -k -sSI https://cryostat-sample-cryostat-operator-system.apps.example.com`
   ```
   HTTP/1.1 302 Found
   [...]
   ```

