### PR TITLE
chore(csv): bump csv min k8s version to 1.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ for the Grafana dashboard.
 
 ### Requirements
 
-- `kubernetes` v1.21+ with [`Operator Lifecycle Manager`](https://olm.operatorframework.io/)
+- `kubernetes` v1.25+ with [`Operator Lifecycle Manager`](https://olm.operatorframework.io/)
 - [`cert-manager`](https://github.com/cert-manager/cert-manager) v1.11.5+ (Recommended)
 
 ### Instructions

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -30,7 +30,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:4.0.0-dev
-    createdAt: "2024-06-15T00:21:26Z"
+    createdAt: "2024-07-08T19:33:12Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {
@@ -1165,7 +1165,7 @@ spec:
     - email: cryostat-development@googlegroups.com
       name: The Cryostat Authors
   maturity: stable
-  minKubeVersion: 1.21.0
+  minKubeVersion: 1.25.0
   provider:
     name: The Cryostat Community
   relatedImages:

--- a/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
@@ -907,7 +907,7 @@ spec:
   - email: cryostat-development@googlegroups.com
     name: The Cryostat Authors
   maturity: stable
-  minKubeVersion: 1.21.0
+  minKubeVersion: 1.25.0
   provider:
     name: The Cryostat Community
   version: 0.0.0


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: https://github.com/cryostatio/cryostatio.github.io/issues/194

## Description of the change:

Bumped min k8s version in CSV to 1.25.0

## Motivation for the change:

See https://github.com/cryostatio/cryostatio.github.io/issues/194#issuecomment-2214103996. Might be a little odd if anyone already installs cryostat-operator with 1.21-1.24 k8s.