### PR TITLE
test(scorecard): preserve CR when retrying on conflict

### DIFF
--- a/internal/test/scorecard/common_utils.go
+++ b/internal/test/scorecard/common_utils.go
@@ -516,7 +516,7 @@ func (r *TestResources) updateAndWaitTillCryostatAvailable(cr *operatorv1beta2.C
 }
 
 func (r *TestResources) updateStorageOptions(ctx context.Context, cr *operatorv1beta2.Cryostat) (*operatorv1beta2.Cryostat, error) {
-	result := &operatorv1beta2.Cryostat{}
+	var result *operatorv1beta2.Cryostat
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		cr, err := r.Client.OperatorCRDs().Cryostats(cr.Namespace).Get(ctx, cr.Name)
 		if err != nil {

--- a/internal/test/scorecard/common_utils.go
+++ b/internal/test/scorecard/common_utils.go
@@ -453,29 +453,8 @@ func (r *TestResources) sendHealthRequest(base *url.URL, healthCheck func(resp *
 func (r *TestResources) updateAndWaitTillCryostatAvailable(cr *operatorv1beta2.Cryostat) (*operatorv1beta2.Cryostat, error) {
 	ctx := context.Background()
 
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		var err error
-		cr, err = r.Client.OperatorCRDs().Cryostats(cr.Namespace).Get(ctx, cr.Name)
-		if err != nil {
-			return fmt.Errorf("failed to get Cryostat CR \"%s\": %s", cr.Name, err.Error())
-		}
-
-		cr.Spec.StorageOptions = &operatorv1beta2.StorageConfiguration{
-			PVC: &operatorv1beta2.PersistentVolumeClaimConfig{
-				Spec: &corev1.PersistentVolumeClaimSpec{
-					StorageClassName: nil,
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceStorage: resource.MustParse("1Gi"),
-						},
-					},
-				},
-			},
-		}
-
-		cr, err = r.Client.OperatorCRDs().Cryostats(cr.Namespace).Update(context.Background(), cr)
-		return err
-	})
+	// Change the CR's storage options in order to trigger a redeployment
+	cr, err := r.updateStorageOptions(ctx, cr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update Cryostat CR \"%s\": %s", cr.Name, err.Error())
 	}
@@ -534,6 +513,33 @@ func (r *TestResources) updateAndWaitTillCryostatAvailable(cr *operatorv1beta2.C
 		return nil, fmt.Errorf("failed to look up deployment errors: %s", err.Error())
 	}
 	return cr, err
+}
+
+func (r *TestResources) updateStorageOptions(ctx context.Context, cr *operatorv1beta2.Cryostat) (*operatorv1beta2.Cryostat, error) {
+	result := &operatorv1beta2.Cryostat{}
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		cr, err := r.Client.OperatorCRDs().Cryostats(cr.Namespace).Get(ctx, cr.Name)
+		if err != nil {
+			return fmt.Errorf("failed to get Cryostat CR \"%s\": %s", cr.Name, err.Error())
+		}
+
+		cr.Spec.StorageOptions = &operatorv1beta2.StorageConfiguration{
+			PVC: &operatorv1beta2.PersistentVolumeClaimConfig{
+				Spec: &corev1.PersistentVolumeClaimSpec{
+					StorageClassName: nil,
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			},
+		}
+
+		result, err = r.Client.OperatorCRDs().Cryostats(cr.Namespace).Update(ctx, cr)
+		return err
+	})
+	return result, err
 }
 
 func (r *TestResources) cleanupAndLogs() {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #841 

## Description of the change:
* Avoids overwriting the `cr` variable when calling `Update`. If this fails due to a conflict, the update will be silently retried, but `cr` will now be nil.
* Moves the update and retry to a helper function for convenience

## Motivation for the change:
* Fixes a sporadic scorecard test failure encountered downstream

## How to manually test:
1. `make test-scorecard-local SCORECARD_TEST_SELECTION=cryostat-config-change`
2. In order to reliably reproduce the update conflict, you can use a patch similar to the one listed here: https://github.com/cryostatio/cryostat-operator/issues/841#issuecomment-2221087146
