### PR TITLE
ci(build): query scorecard image tags with registry v2 api

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -107,9 +107,14 @@ jobs:
       id: check-tag-exists
       run: |
         EXIST=false
-        if [ -n "$(podman search --list-tags ${CI_SCORECARD_IMG} --format json | jq --arg TAG ${{ steps.get-image-tag.outputs.tag }} '.[0].Tags[] | select( . == $TAG)')" ]; then
+        STATUS_CODE=$(curl -ILs -o /dev/null https://quay.io/v2/${CI_SCORECARD_IMG/"quay.io/"/}/manifests/${{ steps.get-image-tag.outputs.tag }} -w "%{http_code}")
+        if [ ${STATUS_CODE} -eq 200 ]; then
           EXIST=true
+        elif [ ${STATUS_CODE} -ne 404 ]; then
+          echo "Failed to query image's existence with status code ${STATUS_CODE}"
+          exit 1
         fi
+        echo "${CI_SCORECARD_IMG}:${{ steps.get-image-tag.outputs.tag }} exists: $EXIST"
         echo "exist=$EXIST" >> $GITHUB_OUTPUT
     - name: Install podman v4
       run: |


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #914 

## Description of the change:

- Replaced `podman search` with `curl` to registry v2 api (`quay.io` is compatible). References: https://docker-docs.uclv.cu/registry/spec/api/#existing-manifests
- This sends `HEAD` request to `/v2/<name>/manifests/<reference>` to check if an image exists for the specified tag.

## Motivation for the change:

See #914. I avoided fetching tags since the tag list can grow rather large with time. This method should basically query in constant time and also skip pulling the image layers.

## How to manually test:

Check if a image for specified tag exists:

```bash
TAG=3.0.1-20240704162318
curl -ILs -o /dev/null https://quay.io/v2/cryostat/cryostat-operator-scorecard/manifests/$TAG -w "%{http_code}"
```


Sample run: https://github.com/tthvo/cryostat-operator/actions/runs/9884455121/job/27300862066
