### PR TITLE
fix(webhook): make label selectors unambiguous

### DIFF
--- a/bundle/manifests/cryostat-operator-cryostat-namespaced_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/cryostat-operator-cryostat-namespaced_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: cryostat-operator
   name: cryostat-operator-cryostat-namespaced
 rules:
 - apiGroups:

--- a/bundle/manifests/cryostat-operator-cryostat_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/cryostat-operator-cryostat_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: cryostat-operator
   name: cryostat-operator-cryostat
 rules:
 - apiGroups:

--- a/bundle/manifests/cryostat-operator-manager-config_v1_configmap.yaml
+++ b/bundle/manifests/cryostat-operator-manager-config_v1_configmap.yaml
@@ -14,4 +14,6 @@ data:
       resourceName: d696d7ab.redhat.com
 kind: ConfigMap
 metadata:
+  labels:
+    app.kubernetes.io/name: cryostat-operator
   name: cryostat-operator-manager-config

--- a/bundle/manifests/cryostat-operator-oauth-client_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/cryostat-operator-oauth-client_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: cryostat-operator
   name: cryostat-operator-oauth-client
 rules:
 - apiGroups:

--- a/bundle/manifests/cryostat-operator-webhook-service_v1_service.yaml
+++ b/bundle/manifests/cryostat-operator-webhook-service_v1_service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/created-by: cryostat-operator
     app.kubernetes.io/instance: webhook-service
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: service
+    app.kubernetes.io/name: cryostat-operator
     app.kubernetes.io/part-of: cryostat-operator
   name: cryostat-operator-webhook-service
 spec:
@@ -16,6 +16,7 @@ spec:
     protocol: TCP
     targetPort: 9443
   selector:
+    app.kubernetes.io/name: cryostat-operator
     control-plane: controller-manager
 status:
   loadBalancer: {}

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -30,7 +30,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:4.0.0-dev
-    createdAt: "2024-07-08T19:33:12Z"
+    createdAt: "2024-07-30T21:00:58Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {
@@ -970,12 +970,14 @@ spec:
           serviceAccountName: cryostat-operator-service-account
       deployments:
         - label:
+            app.kubernetes.io/name: cryostat-operator
             control-plane: controller-manager
           name: cryostat-operator-controller-manager
           spec:
             replicas: 1
             selector:
               matchLabels:
+                app.kubernetes.io/name: cryostat-operator
                 control-plane: controller-manager
             strategy: {}
             template:
@@ -983,6 +985,7 @@ spec:
                 annotations:
                   kubectl.kubernetes.io/default-container: manager
                 labels:
+                  app.kubernetes.io/name: cryostat-operator
                   control-plane: controller-manager
               spec:
                 containers:
@@ -1046,21 +1049,12 @@ spec:
                       capabilities:
                         drop:
                           - ALL
-                    volumeMounts:
-                      - mountPath: /tmp/k8s-webhook-server/serving-certs
-                        name: cert
-                        readOnly: true
                 securityContext:
                   runAsNonRoot: true
                   seccompProfile:
                     type: RuntimeDefault
                 serviceAccountName: cryostat-operator-service-account
                 terminationGracePeriodSeconds: 10
-                volumes:
-                  - name: cert
-                    secret:
-                      defaultMode: 420
-                      secretName: webhook-server-cert
       permissions:
         - rules:
             - apiGroups:

--- a/bundle/manifests/operator.cryostat.io_cryostats.yaml
+++ b/bundle/manifests/operator.cryostat.io_cryostats.yaml
@@ -5,6 +5,8 @@ metadata:
     cert-manager.io/inject-ca-from: cryostat-operator-system/cryostat-operator-serving-cert
     controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: cryostat-operator
   name: cryostats.operator.cryostat.io
 spec:
   conversion:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -9,8 +9,8 @@ namespace: cryostat-operator-system
 namePrefix: cryostat-operator-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  app.kubernetes.io/name: cryostat-operator
 
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -11,18 +11,18 @@ patchesJson6902:
     version: v1alpha1
     kind: ClusterServiceVersion
     name: cryostat-operator.v0.0.0
-#- target:
-#    group: apps
-#    version: v1
-#    kind: Deployment
-#    name: controller-manager
-#    namespace: system
-#  patch: |-
-#    # Remove the manager container's "cert" volumeMount, since OLM will create and mount a set of certs.
-#    # Update the indices in this path if adding or removing containers/volumeMounts in the manager's Deployment.
-#    - op: remove
-#      path: /spec/template/spec/containers/1/volumeMounts/0
-#    # Remove the "cert" volume, since OLM will create and mount a set of certs.
-#    # Update the indices in this path if adding or removing volumes in the manager's Deployment.
-#    - op: remove
-#      path: /spec/template/spec/volumes/0
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: controller-manager
+    namespace: system
+  patch: |-
+    # Remove the manager container's "cert" volumeMount, since OLM will create and mount a set of certs.
+    # Update the indices in this path if adding or removing containers/volumeMounts in the manager's Deployment.
+    - op: remove
+      path: /spec/template/spec/containers/0/volumeMounts/0
+    # Remove the "cert" volume, since OLM will create and mount a set of certs.
+    # Update the indices in this path if adding or removing volumes in the manager's Deployment.
+    - op: remove
+      path: /spec/template/spec/volumes/0


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #924 

## Description of the change:
* Adds `app.kubernetes.io/name` label to all operator objects using `commonLabels` Kustomize property
* Cleanup: uncomments patch to remove `cert` volume and mount from bundle manifests, which is unneeded when run as a bundle

## Motivation for the change:
* Fixes a bug where webhook requests may be sent to other operators in the same namespace

## How to manually test:
1. Install another operator with a webhook (e.g. Infinispan Operator)
2. Deploy this PR into the same namespace
3. Exercise webhooks by creating and modifying Cryostat CRs
