### PR TITLE
test(sample): update sample application images and configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -436,11 +436,9 @@ sample_app_agent_proxy: undeploy_sample_app_agent_proxy ## Deploy sample app wit
 			echo "'SAMPLE_APP_NAMESPACE' must be specified."; \
 			exit 1; \
 		fi ;\
-		SECRET_HASH=`echo -n ${DEPLOY_NAMESPACE}/cryostat-sample/${SAMPLE_APP_NAMESPACE} | sha256sum`; \
+		SECRET_HASH=`echo -n ${DEPLOY_NAMESPACE}/cryostat-sample/${SAMPLE_APP_NAMESPACE} | sha256sum | cut -d' ' -f 1`; \
 	fi; \
-	$(CLUSTER_CLIENT) patch -f config/samples/sample-app-agent-tls-proxy.yaml --local=true --type=merge \
-	-p "{\"spec\":{\"template\":{\"spec\":{\"\$setElementOrder/volumes\":[{\"name\":\"agent-tls\"}],\"volumes\":[{\"\$retainKeys\":[\"name\",\"secret\"],\"name\":\"agent-tls\",\"secret\":{\"secretName\":\"cryostat-agent-$${SECRET_HASH}\"}}]}}}}" \
-	-o yaml | oc apply -f -
+	sed "s/REPLACEHASH/$${SECRET_HASH}/" < config/samples/sample-app-agent-tls-proxy.yaml | oc apply -f -
 
 .PHONY: undeploy_sample_app_agent
 undeploy_sample_app_agent: ## Undeploy sample app with Cryostat Agent.

--- a/Makefile
+++ b/Makefile
@@ -424,19 +424,10 @@ undeploy_sample_app_agent_proxy: ## Undeploy sample app with Cryostat Agent conf
 .PHONY: sample_app_agent_proxy
 sample_app_agent_proxy: undeploy_sample_app_agent_proxy ## Deploy sample app with Cryostat Agent configured for TLS client auth on nginx proxy.
 	@if [ -z "${SECRET_HASH}" ]; then \
-		if [ -z "${DEPLOY_NAMESPACE}" ]; then \
-			if [ "${CLUSTER_CLIENT}" = "oc" ]; then \
-				DEPLOY_NAMESPACE=`oc project -q`; \
-			else \
-				echo "'DEPLOY_NAMESPACE' must be specified."; \
-				exit 1; \
-			fi; \
-		fi; \
 		if [ -z "${SAMPLE_APP_NAMESPACE}" ]; then \
-			echo "'SAMPLE_APP_NAMESPACE' must be specified."; \
-			exit 1; \
+			SAMPLE_APP_NAMESPACE=`$(CLUSTER_CLIENT) config view --minify -o 'jsonpath={.contexts[0].context.namespace}'`; \
 		fi ;\
-		SECRET_HASH=`echo -n ${DEPLOY_NAMESPACE}/cryostat-sample/${SAMPLE_APP_NAMESPACE} | sha256sum | cut -d' ' -f 1`; \
+		SECRET_HASH=`echo -n ${DEPLOY_NAMESPACE}/cryostat-sample/${namespace} | sha256sum | cut -d' ' -f 1`; \
 	fi; \
 	sed "s/REPLACEHASH/$${SECRET_HASH}/" < config/samples/sample-app-agent-tls-proxy.yaml | oc apply -f -
 

--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ SAMPLE_APP_FLAGS += -n $(SAMPLE_APP_NAMESPACE)
 endif
 
 .PHONY: sample_app
-sample_app: ## Deploy sample app.
+sample_app: undeploy_sample_app ## Deploy sample app.
 	$(CLUSTER_CLIENT) apply $(SAMPLE_APP_FLAGS) -f config/samples/sample-app.yaml
 
 .PHONY: undeploy_sample_app
@@ -416,6 +416,14 @@ sample_app_agent: undeploy_sample_app_agent ## Deploy sample app with Cryostat A
 	fi; \
 	$(CLUSTER_CLIENT) apply $(SAMPLE_APP_FLAGS) -f config/samples/sample-app-agent.yaml; \
 	$(CLUSTER_CLIENT) set env $(SAMPLE_APP_FLAGS) deployment/quarkus-cryostat-agent CRYOSTAT_AGENT_AUTHORIZATION="Bearer $(AUTH_TOKEN)"
+
+.PHONY: undeploy_sample_app_agent_proxy
+undeploy_sample_app_agent_proxy: ## Undeploy sample app with Cryostat Agent configured for TLS client auth on nginx proxy.
+	- $(CLUSTER_CLIENT) delete $(SAMPLE_APP_FLAGS) --ignore-not-found=$(ignore-not-found) -f config/samples/sample-app-agent-tls-proxy.yaml
+
+.PHONY: sample_app_agent_proxy
+sample_app_agent_proxy: undeploy_sample_app_agent_proxy ## Deploy sample app with Cryostat Agent configured for TLS client auth on nginx proxy.
+	$(CLUSTER_CLIENT) apply $(SAMPLE_APP_FLAGS) -f config/samples/sample-app-agent-tls-proxy.yaml
 
 .PHONY: undeploy_sample_app_agent
 undeploy_sample_app_agent: ## Undeploy sample app with Cryostat Agent.

--- a/Makefile
+++ b/Makefile
@@ -424,10 +424,13 @@ undeploy_sample_app_agent_proxy: ## Undeploy sample app with Cryostat Agent conf
 .PHONY: sample_app_agent_proxy
 sample_app_agent_proxy: undeploy_sample_app_agent_proxy ## Deploy sample app with Cryostat Agent configured for TLS client auth on nginx proxy.
 	@if [ -z "${SECRET_HASH}" ]; then \
-		if [ -z "${SAMPLE_APP_NAMESPACE}" ]; then \
+		if [ -z "$${SAMPLE_APP_NAMESPACE}" ]; then \
 			SAMPLE_APP_NAMESPACE=`$(CLUSTER_CLIENT) config view --minify -o 'jsonpath={.contexts[0].context.namespace}'`; \
 		fi ;\
-		SECRET_HASH=`echo -n ${DEPLOY_NAMESPACE}/cryostat-sample/${namespace} | sha256sum | cut -d' ' -f 1`; \
+		if [ -z "$${CRYOSTAT_CR_NAME}" ]; then \
+			CRYOSTAT_CR_NAME="cryostat-sample"; \
+		fi ;\
+		SECRET_HASH=`echo -n ${DEPLOY_NAMESPACE}/$${CRYOSTAT_CR_NAME}/$${SAMPLE_APP_NAMESPACE} | sha256sum | cut -d' ' -f 1`; \
 	fi; \
 	sed "s/REPLACEHASH/$${SECRET_HASH}/" < config/samples/sample-app-agent-tls-proxy.yaml | oc apply -f -
 

--- a/Makefile
+++ b/Makefile
@@ -408,7 +408,7 @@ undeploy_sample_app: ## Undeploy sample app.
 sample_app_agent: undeploy_sample_app_agent ## Deploy sample app with Cryostat Agent.
 	@if [ -z "${AUTH_TOKEN}" ]; then \
 		if [ "${CLUSTER_CLIENT}" = "oc" ]; then\
-			AUTH_TOKEN=`oc whoami -t | base64`; \
+			AUTH_TOKEN=`oc whoami -t`; \
 		else \
 			echo "'AUTH_TOKEN' must be specified."; \
 			exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -415,7 +415,7 @@ sample_app_agent: undeploy_sample_app_agent ## Deploy sample app with Cryostat A
 		fi; \
 	fi; \
 	$(CLUSTER_CLIENT) apply $(SAMPLE_APP_FLAGS) -f config/samples/sample-app-agent.yaml; \
-	$(CLUSTER_CLIENT) set env $(SAMPLE_APP_FLAGS) deployment/quarkus-test-agent CRYOSTAT_AGENT_AUTHORIZATION="Bearer $(AUTH_TOKEN)"
+	$(CLUSTER_CLIENT) set env $(SAMPLE_APP_FLAGS) deployment/quarkus-cryostat-agent CRYOSTAT_AGENT_AUTHORIZATION="Bearer $(AUTH_TOKEN)"
 
 .PHONY: undeploy_sample_app_agent
 undeploy_sample_app_agent: ## Undeploy sample app with Cryostat Agent.

--- a/Makefile
+++ b/Makefile
@@ -402,7 +402,7 @@ sample_app: undeploy_sample_app ## Deploy sample app.
 
 .PHONY: undeploy_sample_app
 undeploy_sample_app: ## Undeploy sample app.
-	$(CLUSTER_CLIENT) delete $(SAMPLE_APP_FLAGS) --ignore-not-found=$(ignore-not-found) -f config/samples/sample-app.yaml
+	- $(CLUSTER_CLIENT) delete $(SAMPLE_APP_FLAGS) --ignore-not-found=$(ignore-not-found) -f config/samples/sample-app.yaml
 
 .PHONY: sample_app_agent
 sample_app_agent: undeploy_sample_app_agent ## Deploy sample app with Cryostat Agent.

--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ install/remove cert-manager from your cluster.
 
 ### User Authentication
 
-Users can use `oc whoami --show-token | base64` to retrieve their encoded OpenShift OAuth token
-for the currently logged in user account. This encoded token can be used when directly
+Users can use `oc whoami --show-token` to retrieve their OpenShift OAuth token
+for the currently logged in user account. This token can be used when directly
 interacting with the deployed Cryostat instance(s).
 
 When using the web-client, users can login with their username and password associated with their OpenShift account. User credentials will be remembered for the duration of the session.

--- a/config/samples/sample-app-agent-tls-proxy.yaml
+++ b/config/samples/sample-app-agent-tls-proxy.yaml
@@ -71,7 +71,7 @@ spec:
       volumes:
       - name: agent-tls
         secret:
-          secretName: cryostat-agent-abcd1234
+          secretName: cryostat-agent-REPLACEHASH
           defaultMode: 420
 ---
 apiVersion: v1

--- a/config/samples/sample-app-agent-tls-proxy.yaml
+++ b/config/samples/sample-app-agent-tls-proxy.yaml
@@ -3,17 +3,17 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: quarkus-cryostat-agent
-  name: quarkus-cryostat-agent
+    app: quarkus-cryostat-agent-tls-proxy
+  name: quarkus-cryostat-agent-tls-proxy
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: quarkus-cryostat-agent
+      app: quarkus-cryostat-agent-tls-proxy
   template:
     metadata:
       labels:
-        app: quarkus-cryostat-agent
+        app: quarkus-cryostat-agent-tls-proxy
     spec:
       containers:
       - env:
@@ -27,7 +27,7 @@ spec:
         - name: CRYOSTAT_AGENT_API_WRITES_ENABLED
           value: "true"
         - name: CRYOSTAT_AGENT_BASEURI
-          value: https://cryostat-sample.$(NAMESPACE).svc:4180
+          value: https://cryostat-sample-agent.$(NAMESPACE).svc:8282
         - name: POD_IP
           valueFrom:
             fieldRef:
@@ -35,65 +35,56 @@ spec:
               fieldPath: status.podIP
         - name: CRYOSTAT_AGENT_CALLBACK
           value: http://$(POD_IP):9977
-        - name: CRYOSTAT_AGENT_AUTHORIZATION
-          value: Bearer abcd1234
         - name: JAVA_OPTS_APPEND
           value: |-
             -Dquarkus.http.host=0.0.0.0
             -Djava.util.logging.manager=org.jboss.logmanager.LogManager
-            -Dcom.sun.management.jmxremote.port=9097
-            -Dcom.sun.management.jmxremote.ssl=false
-            -Dcom.sun.management.jmxremote.authenticate=false
             -javaagent:/deployments/app/cryostat-agent.jar
-            -Dcryostat.agent.webclient.tls.truststore.cert[0].path=/var/run/secrets/myapp/ca.crt
+            -Dcryostat.agent.webclient.tls.client-auth.cert.path=/var/run/secrets/io.cryostat/cryostat-agent/tls.crt
+            -Dcryostat.agent.webclient.tls.client-auth.key.path=/var/run/secrets/io.cryostat/cryostat-agent/tls.key
+            -Dcryostat.agent.webclient.tls.truststore.cert[0].path=/var/run/secrets/io.cryostat/cryostat-agent/ca.crt
             -Dcryostat.agent.webclient.tls.truststore.cert[0].type=X.509
-            -Dcryostat.agent.webclient.tls.truststore.cert[0].alias=cryostat-sample
+            -Dcryostat.agent.webclient.tls.truststore.cert[0].alias=cryostat
         image: quay.io/redhat-java-monitoring/quarkus-cryostat-agent:latest
         imagePullPolicy: Always
-        name: quarkus-cryostat-agent
+        name: quarkus-cryostat-agent-tls-proxy
         ports:
         - containerPort: 10010
           protocol: TCP
         - containerPort: 9097
           protocol: TCP
         resources:
-          requests:
-            cpu: 200m
-            memory: 96Mi
           limits:
             cpu: 500m
-            memory: 192Mi
+            memory: 256Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
             - ALL
         volumeMounts:
-        - mountPath: /var/run/secrets/myapp/ca.crt
-          name: truststore
-          subPath: ca.crt
+        - mountPath: /var/run/secrets/io.cryostat/cryostat-agent
+          name: agent-tls
       restartPolicy: Always
       securityContext:
         runAsNonRoot: true
       volumes:
-      - name: truststore
+      - name: agent-tls
         secret:
-          secretName: cryostat-sample-tls
+          # FIXME determine the secretName at deployment time in the Makefile and patch it here
+          secretName: cryostat-agent-f46ed1c40de4d61ac533fef337f7705ac39c8690f91a9cdca5185140f0455563
+          defaultMode: 420
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: quarkus-cryostat-agent
-  name: quarkus-cryostat-agent
+    app: quarkus-cryostat-agent-tls-proxy
+  name: quarkus-cryostat-agent-tls-proxy
 spec:
   selector:
-    app: quarkus-cryostat-agent
+    app: quarkus-cryostat-agent-tls-proxy
   ports:
-  - name: jfr-jmx
-    port: 9097
-    protocol: TCP
-    targetPort: 9097
   - name: agent-http
     port: 9977
     protocol: TCP

--- a/config/samples/sample-app-agent-tls-proxy.yaml
+++ b/config/samples/sample-app-agent-tls-proxy.yaml
@@ -71,8 +71,7 @@ spec:
       volumes:
       - name: agent-tls
         secret:
-          # FIXME determine the secretName at deployment time in the Makefile and patch it here
-          secretName: cryostat-agent-f46ed1c40de4d61ac533fef337f7705ac39c8690f91a9cdca5185140f0455563
+          secretName: cryostat-agent-abcd1234
           defaultMode: 420
 ---
 apiVersion: v1

--- a/config/samples/sample-app-agent.yaml
+++ b/config/samples/sample-app-agent.yaml
@@ -37,22 +37,12 @@ spec:
           value: http://$(POD_IP):9977
         - name: CRYOSTAT_AGENT_AUTHORIZATION
           value: Bearer abcd1234
-        - name: KEYSTORE_PASS
-          valueFrom:
-            secretKeyRef:
-              key: KEYSTORE_PASS
-              name: cryostat-sample-keystore
-        - name: JAVA_OPTS_APPEND
-          value: |-
-            -Dquarkus.http.host=0.0.0.0
-            -Djava.util.logging.manager=org.jboss.logmanager.LogManager
-            -Dcom.sun.management.jmxremote.port=9097
-            -Dcom.sun.management.jmxremote.ssl=false
-            -Dcom.sun.management.jmxremote.authenticate=false
-            -javaagent:/deployments/app/cryostat-agent.jar
-            -Dcryostat.agent.webclient.tls.truststore.cert[0].path=/var/run/secrets/myapp/truststore.p12
-            -Dcryostat.agent.webclient.tls.truststore.cert[0].type=X.509
-            -Dcryostat.agent.webclient.tls.truststore.cert[0].alias=cryostat-sample
+        - name: CRYOSTAT_AGENT_WEBCLIENT_TLS_TRUSTSTORE_CERT_0__PATH
+          value: /var/run/secrets/myapp/truststore.p12
+        - name: CRYOSTAT_AGENT_WEBCLIENT_TLS_TRUSTSTORE_CERT_0__TYPE
+          value: X.509
+        - name: CRYOSTAT_AGENT_WEBCLIENT_TLS_TRUSTSTORE_CERT_0__ALIAS
+          value: cryostat-sample
         image: quay.io/redhat-java-monitoring/quarkus-cryostat-agent:latest
         imagePullPolicy: Always
         name: quarkus-cryostat-agent

--- a/config/samples/sample-app-agent.yaml
+++ b/config/samples/sample-app-agent.yaml
@@ -3,17 +3,17 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: quarkus-test-agent
-  name: quarkus-test-agent
+    app: quarkus-cryostat-agent
+  name: quarkus-cryostat-agent
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: quarkus-test-agent
+      app: quarkus-cryostat-agent
   template:
     metadata:
       labels:
-        app: quarkus-test-agent
+        app: quarkus-cryostat-agent
     spec:
       containers:
       - env:
@@ -50,11 +50,12 @@ spec:
             -Dcom.sun.management.jmxremote.ssl=false
             -Dcom.sun.management.jmxremote.authenticate=false
             -javaagent:/deployments/app/cryostat-agent.jar
-            -Djavax.net.ssl.trustStore=/var/run/secrets/myapp/truststore.p12
-            -Djavax.net.ssl.trustStorePassword=$(KEYSTORE_PASS)
-        image: quay.io/andrewazores/quarkus-test:latest
+            -Dcryostat.agent.webclient.tls.truststore.cert[0].path=/var/run/secrets/myapp/truststore.p12
+            -Dcryostat.agent.webclient.tls.truststore.cert[0].type=X.509
+            -Dcryostat.agent.webclient.tls.truststore.cert[0].alias=cryostat-sample
+        image: quay.io/redhat-java-monitoring/quarkus-cryostat-agent:latest
         imagePullPolicy: Always
-        name: quarkus-test-agent
+        name: quarkus-cryostat-agent
         ports:
         - containerPort: 10010
           protocol: TCP
@@ -88,11 +89,11 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: quarkus-test-agent
-  name: quarkus-test-agent
+    app: quarkus-cryostat-agent
+  name: quarkus-cryostat-agent
 spec:
   selector:
-    app: quarkus-test-agent
+    app: quarkus-cryostat-agent
   ports:
   - name: jfr-jmx
     port: 9097

--- a/config/samples/sample-app.yaml
+++ b/config/samples/sample-app.yaml
@@ -16,7 +16,7 @@ spec:
         app: quarkus-test
     spec:
       containers:
-        - image: quay.io/andrewazores/quarkus-test:latest
+        - image: quay.io/redhat-java-monitoring/quarkus-cryostat-agent:latest
           imagePullPolicy: Always
           name: quarkus-test
           ports:


### PR DESCRIPTION
- **test(sample): update sample application image**
- **test(sample): set up Agent sample application with new image and TLS config**

# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

See https://github.com/cryostatio/test-applications/issues/1
See https://github.com/cryostatio/test-applications/issues/7
Related to https://github.com/cryostatio/cryostat-agent/issues/139
Depends on https://github.com/cryostatio/cryostat-agent/pull/491

## Description of the change:
Updates the two existing sample app definitions for the newer split TLS truststore/keystore where the Agent's stores are now independent from the host application's stores. Also adds a new sample app definition for an Agent that uses the nginx TLS client auth proxy, rather than the standard OAuth proxy.

## How to manually test:
1. `make sample_app sample_app_agent sample_app_agent_proxy` and ensure all three cases become discovered and are interactable as usual.
2. `make undeploy_sample_app undeploy_sample_app_agent undeploy_sample_app_agent_proxy` and ensure all three cases are correctly torn down and removed from discovery.