### PR TITLE
feat(tls): generate client certificates for agents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -546,7 +546,9 @@ undeploy_bundle: operator-sdk ## Undeploy the controller in the bundle format wi
 
 .PHONY: create_cryostat_cr
 create_cryostat_cr: destroy_cryostat_cr ## Create a namespaced Cryostat instance.
-	$(CLUSTER_CLIENT) create -f config/samples/operator_v1beta2_cryostat.yaml
+	target_ns_json=$$(jq -nc '$$ARGS.positional' --args -- $(TARGET_NAMESPACES)) && \
+	$(CLUSTER_CLIENT) patch -f config/samples/operator_v1beta2_cryostat.yaml --local=true --type=merge \
+	-p "{\"spec\": {\"targetNamespaces\": $$target_ns_json}}" -o yaml | oc apply -f -
 
 .PHONY: destroy_cryostat_cr
 destroy_cryostat_cr: ## Delete a namespaced Cryostat instance.

--- a/internal/controllers/certmanager.go
+++ b/internal/controllers/certmanager.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/cryostatio/cryostat-operator/internal/controllers/common"
@@ -89,25 +90,26 @@ func (r *Reconciler) setupTLS(ctx context.Context, cr *model.CryostatInstance) (
 	if err != nil {
 		return nil, err
 	}
+
+	// List of certificates whose secrets should be owned by this CR
+	certificates := []*certv1.Certificate{caCert, cryostatCert, reportsCert}
+
+	// Get the Cryostat CA certificate bytes from certificate secret
+	caBytes, err := r.getCertficateBytes(ctx, caCert)
+	if err != nil {
+		return nil, err
+	}
+
 	tlsConfig := &resources.TLSConfig{
 		CryostatSecret:     cryostatCert.Spec.SecretName,
 		ReportsSecret:      reportsCert.Spec.SecretName,
 		KeystorePassSecret: cryostatCert.Spec.Keystores.PKCS12.PasswordSecretRef.Name,
-	}
-	certificates := []*certv1.Certificate{caCert, cryostatCert, reportsCert}
-
-	// Update owner references of TLS secrets created by cert-manager to ensure proper cleanup
-	err = r.setCertSecretOwner(ctx, cr.Object, certificates...)
-	if err != nil {
-		return nil, err
+		CACert:             caBytes,
 	}
 
-	secret, err := r.GetCertificateSecret(ctx, caCert)
-	if err != nil {
-		return nil, err
-	}
-	// Copy Cryostat CA secret in each target namespace
+	agentCertsNotReady := []string{}
 	for _, ns := range cr.TargetNamespaces {
+		// Copy Cryostat CA secret in each target namespace
 		if ns != cr.InstallNamespace {
 			namespaceSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -116,14 +118,41 @@ func (r *Reconciler) setupTLS(ctx context.Context, cr *model.CryostatInstance) (
 				},
 				Type: corev1.SecretTypeOpaque,
 			}
-			err = r.createOrUpdateCertSecret(ctx, namespaceSecret, secret.Data[corev1.TLSCertKey])
+			err = r.createOrUpdateCertSecret(ctx, namespaceSecret, caBytes)
 			if err != nil {
 				return nil, err
 			}
 		}
+
+		// Create a certificate for Cryostat agents in each target namespace
+		agentCert := resources.NewAgentCert(cr, ns, r.gvk)
+		err := r.reconcileAgentCertificate(ctx, agentCert, cr, ns)
+		if err != nil {
+			if err == common.ErrCertNotReady {
+				// Continue with other namespaces if the cert isn't ready
+				agentCertsNotReady = append(agentCertsNotReady, agentCert.Name)
+			} else {
+				return nil, err
+			}
+		}
+		certificates = append(certificates, agentCert) // TODO test
 	}
-	// Delete any Cryostat CA secrets in target namespaces that are no longer requested
+
+	if len(agentCertsNotReady) > 0 {
+		// One or more agent certificates weren't ready, so log a message and return
+		r.Log.Info("Not all agent certificates were ready", "not ready", strings.Join(agentCertsNotReady, ", "))
+		return nil, common.ErrCertNotReady
+	}
+
+	// Update owner references of TLS secrets created by cert-manager to ensure proper cleanup
+	err = r.setCertSecretOwner(ctx, cr.Object, certificates...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Clean up resources from target namespaces that are no longer requested
 	for _, ns := range toDelete(cr) {
+		// Delete any Cryostat CA secret copies in removed namespaces
 		if ns != cr.InstallNamespace {
 			namespaceSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -136,14 +165,27 @@ func (r *Reconciler) setupTLS(ctx context.Context, cr *model.CryostatInstance) (
 				return nil, err
 			}
 		}
+
+		// Delete any agent certificates removed target namespaces
+		agentCert := resources.NewAgentCert(cr, ns, r.gvk)
+		// Delete namespace copy
+		namespaceAgentSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      agentCert.Spec.SecretName,
+				Namespace: ns,
+			},
+		}
+		err = r.deleteSecret(ctx, namespaceAgentSecret)
+		if err != nil {
+			return nil, err
+		}
+		// Delete certificate with original secret
+		err := r.deleteCertWithSecret(ctx, agentCert)
+		if err != nil {
+			return nil, err
+		} // TODO test
 	}
 
-	// Get the Cryostat CA certificate bytes from certificate secret
-	caBytes, err := r.getCertficateBytes(ctx, caCert)
-	if err != nil {
-		return nil, err
-	}
-	tlsConfig.CACert = caBytes
 	return tlsConfig, nil
 }
 
@@ -162,7 +204,21 @@ func (r *Reconciler) finalizeTLS(ctx context.Context, cr *model.CryostatInstance
 				return err
 			}
 		}
+
+		// Delete any agent certificate secrets in target namespaces
+		agentCert := resources.NewAgentCert(cr, ns, r.gvk)
+		namespaceAgentSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      agentCert.Spec.SecretName,
+				Namespace: ns,
+			},
+		}
+		err := r.deleteSecret(ctx, namespaceAgentSecret)
+		if err != nil {
+			return err
+		} // TODO test
 	}
+
 	return nil
 }
 
@@ -265,20 +321,7 @@ func (r *Reconciler) deleteCertChain(ctx context.Context, namespace string, caSe
 	for i, cert := range certs.Items {
 		// Is the certificate owned by this CR, and not the CA itself?
 		if metav1.IsControlledBy(&certs.Items[i], owner) && cert.Spec.SecretName != caSecretName {
-			// Clean up secret referenced by the cert
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      cert.Spec.SecretName,
-					Namespace: cert.Namespace,
-				},
-			}
-
-			err := r.deleteSecret(ctx, secret)
-			if err != nil {
-				return err
-			}
-			// Delete the certificate
-			err = r.deleteCertificate(ctx, &certs.Items[i])
+			err := r.deleteCertWithSecret(ctx, &certs.Items[i])
 			if err != nil {
 				return err
 			}
@@ -288,11 +331,59 @@ func (r *Reconciler) deleteCertChain(ctx context.Context, namespace string, caSe
 	return nil
 }
 
+func (r *Reconciler) deleteCertWithSecret(ctx context.Context, cert *certv1.Certificate) error {
+	// Clean up secret referenced by the cert
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cert.Spec.SecretName,
+			Namespace: cert.Namespace,
+		},
+	}
+
+	err := r.deleteSecret(ctx, secret)
+	if err != nil {
+		return err
+	}
+	// Delete the certificate
+	err = r.deleteCertificate(ctx, cert)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *Reconciler) reconcileAgentCertificate(ctx context.Context, cert *certv1.Certificate, cr *model.CryostatInstance, namespace string) error {
+	// Create the Agent certificate in the install namespace
+	err := r.createOrUpdateCertificate(ctx, cert, cr.Object)
+	if err != nil {
+		return err
+	}
+
+	// Fetch the certificate secret and create a copy in the target namespace
+	secret, err := r.GetCertificateSecret(ctx, cert)
+	if err != nil {
+		return err
+	}
+
+	targetSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secret.Name,
+			Namespace: namespace,
+		},
+	}
+	return r.createOrUpdateSecret(ctx, targetSecret, nil, func() error {
+		targetSecret.Data = secret.Data
+		return nil
+	})
+}
+
 func (r *Reconciler) createOrUpdateCertificate(ctx context.Context, cert *certv1.Certificate, owner metav1.Object) error {
 	certSpec := cert.Spec.DeepCopy()
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, cert, func() error {
-		if err := controllerutil.SetControllerReference(owner, cert, r.Scheme); err != nil {
-			return err
+		if owner != nil {
+			if err := controllerutil.SetControllerReference(owner, cert, r.Scheme); err != nil {
+				return err
+			}
 		}
 		// Update Certificate spec
 		cert.Spec = *certSpec

--- a/internal/controllers/common/common_utils.go
+++ b/internal/controllers/common/common_utils.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -69,17 +68,28 @@ func ClusterUniqueName(gvk *schema.GroupVersionKind, name string, namespace stri
 	return ClusterUniqueNameWithPrefix(gvk, "", name, namespace)
 }
 
-// ClusterUniqueName returns a name for cluster-scoped objects that is
+// ClusterUniqueNameWithPrefix returns a name for cluster-scoped objects that is
 // uniquely identified by a namespace and name. Appends the prefix to the
 // provided Kind.
 func ClusterUniqueNameWithPrefix(gvk *schema.GroupVersionKind, prefix string, name string, namespace string) string {
+	return ClusterUniqueNameWithPrefixTargetNS(gvk, prefix, name, namespace, "")
+}
+
+// ClusterUniqueNameWithPrefixTargetNS returns a name for cluster-scoped objects that is
+// uniquely identified by a namespace and name, and a target namespace.
+// Appends the prefix to the provided Kind.
+func ClusterUniqueNameWithPrefixTargetNS(gvk *schema.GroupVersionKind, prefix string, name string, namespace string,
+	targetNS string) string {
 	prefixWithKind := strings.ToLower(gvk.Kind)
 	if len(prefix) > 0 {
 		prefixWithKind += "-" + prefix
 	}
+	toHash := namespace + "/" + name
+	if len(targetNS) > 0 {
+		toHash += "/" + targetNS
+	}
 	// Use the SHA256 checksum of the namespaced name as a suffix
-	nn := types.NamespacedName{Namespace: namespace, Name: name}
-	suffix := fmt.Sprintf("%x", sha256.Sum256([]byte(nn.String())))
+	suffix := fmt.Sprintf("%x", sha256.Sum256([]byte(toHash)))
 	return prefixWithKind + "-" + suffix
 }
 

--- a/internal/controllers/common/resource_definitions/certificates.go
+++ b/internal/controllers/common/resource_definitions/certificates.go
@@ -131,3 +131,27 @@ func NewReportsCert(cr *model.CryostatInstance) *certv1.Certificate {
 		},
 	}
 }
+
+func NewAgentCert(cr *model.CryostatInstance, namespace string, gvk *schema.GroupVersionKind) *certv1.Certificate {
+	name := common.ClusterUniqueNameWithPrefixTargetNS(gvk, "agent", cr.Name, cr.InstallNamespace, namespace)
+	return &certv1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cr.InstallNamespace,
+		},
+		Spec: certv1.CertificateSpec{
+			CommonName: fmt.Sprintf("*.%s.pod", namespace),
+			DNSNames: []string{
+				fmt.Sprintf("*.%s.pod", namespace),
+			},
+			SecretName: name,
+			IssuerRef: certMeta.ObjectReference{
+				Name: cr.Name + "-ca",
+			},
+			Usages: append(certv1.DefaultKeyUsages(),
+				certv1.UsageServerAuth,
+				certv1.UsageClientAuth,
+			),
+		},
+	}
+}

--- a/internal/controllers/reconciler.go
+++ b/internal/controllers/reconciler.go
@@ -165,10 +165,12 @@ func (r *Reconciler) reconcileCryostat(ctx context.Context, cr *model.CryostatIn
 				return reconcile.Result{}, err
 			}
 
-			// Finalizer for CA Cert secrets
-			err = r.finalizeTLS(ctx, cr)
-			if err != nil {
-				return reconcile.Result{}, err
+			// Finalizer for certificates and associated secrets
+			if r.IsCertManagerEnabled(cr) {
+				err = r.finalizeTLS(ctx, cr)
+				if err != nil {
+					return reconcile.Result{}, err
+				}
 			}
 
 			err = common.RemoveFinalizer(ctx, r.Client, cr.Object, cryostatFinalizer)

--- a/internal/controllers/reconciler_test.go
+++ b/internal/controllers/reconciler_test.go
@@ -1804,21 +1804,40 @@ func (c *controllerTest) commonTests() {
 							t.expectNoCryostat()
 						})
 					})
+					Context("with cert-manager enabled", func() {
+						JustBeforeEach(func() {
+							err := t.Client.Delete(context.Background(), t.NewRoleBinding(targetNamespaces[0]))
+							Expect(err).ToNot(HaveOccurred())
+							t.reconcileDeletedCryostat()
+						})
+						It("should delete CA cert secrets from each namespace", func() {
+							t.checkCASecretsDeleted()
+						})
+						It("should delete agent cert secrets from each namespace", func() {
+							t.checkAgentCertSecretsDeleted()
+						})
+						It("should delete Cryostat", func() {
+							t.expectNoCryostat()
+						})
+					})
 				})
 			})
 
 			Context("with removed target namespaces", func() {
 				BeforeEach(func() {
+					t.TargetNamespaces = targetNamespaces
+					t.objs = append(t.objs, t.NewCryostat().Object)
+				})
+				JustBeforeEach(func() {
 					// Begin with RBAC set up for two namespaces,
 					// and remove the second namespace from the spec
 					t.TargetNamespaces = targetNamespaces[:1]
-					cr := t.NewCryostat()
-					*cr.TargetNamespaceStatus = targetNamespaces
-					t.objs = append(t.objs, cr.Object,
-						t.NewRoleBinding(targetNamespaces[0]),
-						t.NewRoleBinding(targetNamespaces[1]),
-						t.NewCACertSecret(targetNamespaces[0]),
-						t.NewCACertSecret(targetNamespaces[1]))
+					cr := t.getCryostatInstance()
+					cr.Spec.TargetNamespaces = t.TargetNamespaces
+					t.updateCryostatInstance(cr)
+
+					// Reconcile again
+					t.reconcileCryostatFully()
 				})
 				It("should create the expected main deployment", func() {
 					t.expectMainDeployment()
@@ -1832,11 +1851,29 @@ func (c *controllerTest) commonTests() {
 					Expect(err).ToNot(BeNil())
 					Expect(kerrors.IsNotFound(err)).To(BeTrue())
 				})
-				It("leave CA Cert secret for the first namespace", func() {
+				It("leave certficate secrets for the first namespace", func() {
 					t.expectCertificates()
 				})
-				It("should remove CA Cert secret from the second namespace", func() {
+				It("should remove CA cert secret from the second namespace", func() {
 					secret := t.NewCACertSecret(targetNamespaces[1])
+					err := t.Client.Get(context.Background(), types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}, secret)
+					Expect(err).ToNot(BeNil())
+					Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				})
+				It("should remove agent certificate for the second namespace", func() {
+					cert := t.NewAgentCert(targetNamespaces[1])
+					err := t.Client.Get(context.Background(), types.NamespacedName{Name: cert.Name, Namespace: cert.Namespace}, cert)
+					Expect(err).ToNot(BeNil())
+					Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				})
+				It("should remove agent cert secret for the second namespace", func() {
+					secret := t.NewAgentCertSecret(targetNamespaces[1])
+					err := t.Client.Get(context.Background(), types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}, secret)
+					Expect(err).ToNot(BeNil())
+					Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				})
+				It("should remove agent cert secret copy from the second namespace", func() {
+					secret := t.NewAgentCertSecretCopy(targetNamespaces[1])
 					err := t.Client.Get(context.Background(), types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}, secret)
 					Expect(err).ToNot(BeNil())
 					Expect(kerrors.IsNotFound(err)).To(BeTrue())
@@ -2281,6 +2318,36 @@ func (t *cryostatTestInput) expectCertificates() {
 			Expect(secret.Type).To(Equal(expectedSecret.Type))
 		}
 	}
+
+	// Check agent certificates and secrets
+	for _, ns := range t.TargetNamespaces {
+		// Check certificate object
+		expectedCert := t.NewAgentCert(ns)
+		cert := &certv1.Certificate{}
+		err := t.Client.Get(context.Background(), types.NamespacedName{Name: expectedCert.Name, Namespace: expectedCert.Namespace}, cert)
+		Expect(err).ToNot(HaveOccurred())
+		t.checkMetadata(cert, expectedCert)
+		Expect(cert.Spec).To(Equal(expectedCert.Spec))
+
+		// Check certificate secret is created and owned by CR
+		expectedSecret := t.NewAgentCertSecret(ns)
+		secret := &corev1.Secret{}
+		err = t.Client.Get(context.Background(), types.NamespacedName{Name: expectedSecret.Name, Namespace: expectedSecret.Namespace}, secret)
+		Expect(err).ToNot(HaveOccurred())
+		t.checkMetadata(secret, expectedSecret)
+		Expect(secret.Data).To(Equal(expectedSecret.Data))
+
+		if ns != t.Namespace {
+			// Ensure secret is copied into the target namespace
+			expectedSecret = t.NewAgentCertSecretCopy(ns)
+			secret = &corev1.Secret{}
+			err = t.Client.Get(context.Background(), types.NamespacedName{Name: expectedSecret.Name, Namespace: expectedSecret.Namespace}, secret)
+			Expect(err).ToNot(HaveOccurred())
+			t.checkMetadataNoOwner(secret, expectedSecret)
+			Expect(secret.GetOwnerReferences()).To(BeEmpty())
+			Expect(secret.Data).To(Equal(expectedSecret.Data))
+		}
+	}
 }
 
 func (t *cryostatTestInput) expectRBAC() {
@@ -2329,6 +2396,24 @@ func (t *cryostatTestInput) checkRoleBindingsDeleted() {
 		expected := t.NewRoleBinding(ns)
 		binding := &rbacv1.RoleBinding{}
 		err := t.Client.Get(context.Background(), types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, binding)
+		Expect(kerrors.IsNotFound(err)).To(BeTrue())
+	}
+}
+
+func (t *cryostatTestInput) checkCASecretsDeleted() {
+	for _, ns := range t.TargetNamespaces {
+		expected := t.NewCACertSecret(ns)
+		secret := &corev1.Secret{}
+		err := t.Client.Get(context.Background(), types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, secret)
+		Expect(kerrors.IsNotFound(err)).To(BeTrue())
+	}
+}
+
+func (t *cryostatTestInput) checkAgentCertSecretsDeleted() {
+	for _, ns := range t.TargetNamespaces {
+		expected := t.NewAgentCertSecretCopy(ns)
+		secret := &corev1.Secret{}
+		err := t.Client.Get(context.Background(), types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, secret)
 		Expect(kerrors.IsNotFound(err)).To(BeTrue())
 	}
 }

--- a/internal/controllers/secrets.go
+++ b/internal/controllers/secrets.go
@@ -149,9 +149,11 @@ func (r *Reconciler) reconcileStorageSecret(ctx context.Context, cr *model.Cryos
 func (r *Reconciler) createOrUpdateSecret(ctx context.Context, secret *corev1.Secret, owner metav1.Object,
 	delegate controllerutil.MutateFn) error {
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
-		// Set the Cryostat CR as controller
-		if err := controllerutil.SetControllerReference(owner, secret, r.Scheme); err != nil {
-			return err
+		if owner != nil {
+			// Set the Cryostat CR as controller
+			if err := controllerutil.SetControllerReference(owner, secret, r.Scheme); err != nil {
+				return err
+			}
 		}
 		// Call the delegate for secret-specific mutations
 		return delegate()

--- a/internal/test/clients.go
+++ b/internal/test/clients.go
@@ -16,6 +16,7 @@ package test
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -70,8 +71,7 @@ func (c *testClient) makeCertificatesReady(ctx context.Context, obj runtime.Obje
 	// If this object is one of the operator-managed certificates, mock the behaviour
 	// of cert-manager processing those certificates
 	cert, ok := obj.(*certv1.Certificate)
-	if ok && c.matchesName(cert, c.NewCryostatCert(), c.NewCACert(), c.NewReportsCert()) &&
-		len(cert.Status.Conditions) == 0 {
+	if ok && c.matchesCert(cert) && len(cert.Status.Conditions) == 0 {
 		// Create certificate secret
 		c.createCertSecret(ctx, cert)
 		// Mark certificate as ready
@@ -112,6 +112,11 @@ func (c *testClient) updateRouteStatus(ctx context.Context, obj runtime.Object) 
 		err := c.Status().Update(context.Background(), route)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	}
+}
+
+func (c *testClient) matchesCert(cert *certv1.Certificate) bool {
+	return c.matchesName(cert, c.NewCryostatCert(), c.NewCACert(), c.NewReportsCert()) ||
+		c.matchesPrefix(cert, c.GetAgentCertPrefix())
 }
 
 // TODO When using envtest instead of fake client, this is probably no longer needed
@@ -207,4 +212,8 @@ func (c *commonTestClient) matchesName(obj ctrlclient.Object, expectedObjs ...ct
 		}
 	}
 	return false
+}
+
+func (c *commonTestClient) matchesPrefix(obj ctrlclient.Object, prefix string) bool {
+	return strings.HasPrefix(obj.GetName(), prefix)
 }

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -852,6 +852,26 @@ func (r *TestResources) NewCACertSecret(ns string) *corev1.Secret {
 	}
 }
 
+func (r *TestResources) NewAgentCertSecret(ns string) *corev1.Secret {
+	name := r.getClusterUniqueNameForAgent(ns)
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: r.Namespace,
+		},
+		Data: map[string][]byte{
+			corev1.TLSPrivateKeyKey: []byte(name + "-key"),
+			corev1.TLSCertKey:       []byte(name + "-bytes"),
+		},
+	}
+}
+
+func (r *TestResources) NewAgentCertSecretCopy(ns string) *corev1.Secret {
+	secret := r.NewAgentCertSecret(ns)
+	secret.Namespace = ns
+	return secret
+}
+
 func (r *TestResources) NewDatabaseSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #936 

## Description of the change:
* Creates a uniquely-named certificate for each target namespace for use by Cryostat agents within it. The certificate has a wildcard hostname within the [namespace subdomain](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records-1), and supports client and server usages.
   1. Create a Certificate in the install namespace with a cluster unique name (hashed `install_namespace/cr_name/target_namespace`)
   2. Once cert-manager creates the secret in the install namespace, copy it to the target namespace
   3. If the target namespace is removed, the Certificate and its secret will be deleted, along with the copy in the target namespace
   4. If the CR is deleted, the finalizer allows the operator to delete the secret copies from all target namespaces
* Adds a test for finalizing CA cert secret copies in target namespaces
* Makes use of the `TARGET_NAMESPACES` variable in the Makefile, previously used for ClusterCryostat

## Motivation for the change:
* This PR is part of the work to allow auto-configuration of the agent (#784) using client certificates as an alternative authentication mechanism. The certificate and key can also be used to set up TLS for the agents' HTTP servers.

## How to manually test:
1. Deploy PR
2. Create multi-namespace Cryostat
3. Add/remove namespaces
4. Verify certificates/secrets are created/deleted in expected namespaces
