### PR TITLE
fix(db): correct hibernate config after Flyway introduction

### DIFF
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -930,7 +930,11 @@ func NewCoreContainer(cr *model.CryostatInstance, specs *ServiceSpecs, imageTag 
 		},
 		{
 			Name:  "QUARKUS_HIBERNATE_ORM_DATABASE_GENERATION",
-			Value: "drop-and-create",
+			Value: "none",
+		},
+		{
+			Name:  "QUARKUS_HIBERNATE_ORM_SQL_LOAD_SCRIPT",
+			Value: "no-file",
 		},
 		{
 			Name:  "QUARKUS_DATASOURCE_USERNAME",

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -1228,7 +1228,11 @@ func (r *TestResources) NewCoreEnvironmentVariables(reportsUrl string, ingress b
 		},
 		{
 			Name:  "QUARKUS_HIBERNATE_ORM_DATABASE_GENERATION",
-			Value: "drop-and-create",
+			Value: "none",
+		},
+		{
+			Name:  "QUARKUS_HIBERNATE_ORM_SQL_LOAD_SCRIPT",
+			Value: "no-file",
 		},
 		{
 			Name:  "QUARKUS_DATASOURCE_USERNAME",


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #937
See also https://github.com/cryostatio/cryostat-helm/pull/193

## Description of the change:
Corrects Hibernate-related environment variables for new configuration settings after Flyway was introduced in the main Cryostat container.

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. Check out, build, and deploy PR as usual
2. Open Web UI, go to Recordings, select Target dropdown and click "Create" (to create a custom target)
3. Enter `localhost:0`, click the connection test, then submit the creation request.
4. Before this PR an error notification would appear alongside the target discovery notifications and the custom target creation form would remain visible. After this PR there should be no error notification and the UI should advance to the Topology view automatically, displaying the newly-defined custom target.
