### PR TITLE
fix(olm): rename deployment to handle immutable selector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -514,7 +514,7 @@ deploy: check_cert_manager manifests kustomize predeploy undeploy ## Deploy cont
 	$(KUSTOMIZE) build $(KUSTOMIZE_DIR) | $(CLUSTER_CLIENT) create -f -
 ifeq ($(DISABLE_SERVICE_TLS), true)
 	@echo "Disabling TLS for in-cluster communication between Services"
-	@$(CLUSTER_CLIENT) -n $(DEPLOY_NAMESPACE) set env deployment/cryostat-operator-controller-manager DISABLE_SERVICE_TLS=true
+	@$(CLUSTER_CLIENT) -n $(DEPLOY_NAMESPACE) set env deployment/cryostat-operator-controller DISABLE_SERVICE_TLS=true
 endif
 
 .PHONY: undeploy

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -30,7 +30,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:4.0.0-dev
-    createdAt: "2024-08-07T21:05:35Z"
+    createdAt: "2024-09-11T16:26:11Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {
@@ -972,7 +972,7 @@ spec:
         - label:
             app.kubernetes.io/name: cryostat-operator
             control-plane: controller-manager
-          name: cryostat-operator-controller-manager
+          name: cryostat-operator-controller
           spec:
             replicas: 1
             selector:
@@ -1186,7 +1186,7 @@ spec:
       containerPort: 443
       conversionCRDs:
         - cryostats.operator.cryostat.io
-      deploymentName: cryostat-operator-controller-manager
+      deploymentName: cryostat-operator-controller
       generateName: ccryostats.kb.io
       sideEffects: None
       targetPort: 9443
@@ -1195,7 +1195,7 @@ spec:
     - admissionReviewVersions:
         - v1
       containerPort: 443
-      deploymentName: cryostat-operator-controller-manager
+      deploymentName: cryostat-operator-controller
       failurePolicy: Fail
       generateName: mcryostat.kb.io
       rules:
@@ -1215,7 +1215,7 @@ spec:
     - admissionReviewVersions:
         - v1
       containerPort: 443
-      deploymentName: cryostat-operator-controller-manager
+      deploymentName: cryostat-operator-controller
       failurePolicy: Fail
       generateName: vcryostat.kb.io
       rules:

--- a/config/default/image_pull_patch.yaml
+++ b/config/default/image_pull_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller
   namespace: system
 spec:
   template:

--- a/config/default/image_tag_patch.yaml
+++ b/config/default/image_tag_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller
   namespace: system
 spec:
   template:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller
   namespace: system
 spec:
   template:

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller
   namespace: system
 spec:
   template:

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller
   namespace: system
 spec:
   template:

--- a/config/insights/insights_patch.yaml
+++ b/config/insights/insights_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller
   namespace: system
 spec:
   template:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -9,7 +9,7 @@ generatorOptions:
 #   target:
 #     group: apps
 #     kind: Deployment
-#     name: controller-manager
+#     name: controller
 #     namespace: system
 #     version: v1
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller
   namespace: system
   labels:
     control-plane: controller-manager

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -15,7 +15,7 @@ patchesJson6902:
     group: apps
     version: v1
     kind: Deployment
-    name: controller-manager
+    name: controller
     namespace: system
   patch: |-
     # Remove the manager container's "cert" volumeMount, since OLM will create and mount a set of certs.

--- a/hack/image_pull_patch.yaml.in
+++ b/hack/image_pull_patch.yaml.in
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller
   namespace: system
 spec:
   template:

--- a/hack/image_tag_patch.yaml.in
+++ b/hack/image_tag_patch.yaml.in
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller
   namespace: system
 spec:
   template:

--- a/hack/insights_patch.yaml.in
+++ b/hack/insights_patch.yaml.in
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller
   namespace: system
 spec:
   template:

--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -98,7 +98,7 @@ func NewDeploymentForCR(cr *model.CryostatInstance, specs *ServiceSpecs, imageTa
 		"app.kubernetes.io/name": "cryostat",
 	}
 	defaultDeploymentAnnotations := map[string]string{
-		"app.openshift.io/connects-to": "cryostat-operator-controller-manager",
+		"app.openshift.io/connects-to": constants.OperatorDeploymentName,
 	}
 	defaultPodLabels := map[string]string{
 		"app":       cr.Name,

--- a/internal/controllers/constants/constants.go
+++ b/internal/controllers/constants/constants.go
@@ -29,7 +29,7 @@ const (
 	DatabasePort               int32  = 5432
 	LoopbackAddress            string = "127.0.0.1"
 	OperatorNamePrefix         string = "cryostat-operator-"
-	OperatorDeploymentName     string = "cryostat-operator-controller-manager"
+	OperatorDeploymentName     string = "cryostat-operator-controller"
 	HttpPortName               string = "http"
 	// CAKey is the key for a CA certificate within a TLS secret
 	CAKey = certMeta.TLSCAKey

--- a/internal/controllers/reconciler_test.go
+++ b/internal/controllers/reconciler_test.go
@@ -312,7 +312,7 @@ func (c *controllerTest) commonTests() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(deploy.Annotations).To(Equal(map[string]string{
-					"app.openshift.io/connects-to": "cryostat-operator-controller-manager",
+					"app.openshift.io/connects-to": "cryostat-operator-controller",
 					"other":                        "annotation",
 				}))
 				Expect(deploy.Labels).To(Equal(map[string]string{
@@ -2648,7 +2648,7 @@ func (t *cryostatTestInput) expectMainDeployment() {
 	Expect(deployment.Name).To(Equal(t.Name))
 	Expect(deployment.Namespace).To(Equal(t.Namespace))
 	Expect(deployment.Annotations).To(Equal(map[string]string{
-		"app.openshift.io/connects-to": "cryostat-operator-controller-manager",
+		"app.openshift.io/connects-to": "cryostat-operator-controller",
 	}))
 	Expect(deployment.Labels).To(Equal(map[string]string{
 		"app":                    t.Name,
@@ -2674,7 +2674,7 @@ func (t *cryostatTestInput) expectMainDeploymentHasExtraMetadata() {
 	cr := t.getCryostatInstance()
 
 	Expect(deployment.Annotations).To(Equal(map[string]string{
-		"app.openshift.io/connects-to":      "cryostat-operator-controller-manager",
+		"app.openshift.io/connects-to":      "cryostat-operator-controller",
 		"myDeploymentExtraAnnotation":       "myDeploymentAnnotation",
 		"mySecondDeploymentExtraAnnotation": "mySecondDeploymentAnnotation",
 	}))

--- a/internal/test/scorecard/common_utils.go
+++ b/internal/test/scorecard/common_utils.go
@@ -41,7 +41,7 @@ import (
 )
 
 const (
-	operatorDeploymentName string        = "cryostat-operator-controller-manager"
+	operatorDeploymentName string        = "cryostat-operator-controller"
 	testTimeout            time.Duration = time.Minute * 10
 )
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #942 

## Description of the change:
* Renames the operator's deployment from `cryostat-operator-controller-manager` to `cryostat-operator-controller`

## Motivation for the change:
* OLM attempts to patch the deployment during an upgrade. Because we've changed the label selector for the deployment, which is immutable, the upgrade fails. By changing the name of the deployment, OLM will recreate the deployment, instead of patching it, when upgrading the operator.

## How to manually test:
1. `make deploy_bundle BUNDLE_IMG=quay.io/cryostat/cryostat-operator-bundle:3.0.0`
2. `./bin/operator-sdk run bundle-upgrade quay.io/ebaron/cryostat-operator-bundle:rename-deployment-01`
3. Upgrade should succeed
