### PR TITLE
chore(scorecard): bump Scorecard image tag

### DIFF
--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -30,7 +30,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:4.0.0-dev
-    createdAt: "2024-09-11T16:26:11Z"
+    createdAt: "2024-09-11T17:33:08Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -70,7 +70,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - operator-install
-    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726
+    image: quay.io/cryostat/cryostat-operator-scorecard:4.0.0-20240911172313
     labels:
       suite: cryostat
       test: operator-install
@@ -80,7 +80,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-cr
-    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726
+    image: quay.io/cryostat/cryostat-operator-scorecard:4.0.0-20240911172313
     labels:
       suite: cryostat
       test: cryostat-cr
@@ -90,7 +90,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-multi-namespace
-    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726
+    image: quay.io/cryostat/cryostat-operator-scorecard:4.0.0-20240911172313
     labels:
       suite: cryostat
       test: cryostat-multi-namespace
@@ -100,7 +100,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-recording
-    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726
+    image: quay.io/cryostat/cryostat-operator-scorecard:4.0.0-20240911172313
     labels:
       suite: cryostat
       test: cryostat-recording
@@ -110,7 +110,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-config-change
-    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726
+    image: quay.io/cryostat/cryostat-operator-scorecard:4.0.0-20240911172313
     labels:
       suite: cryostat
       test: cryostat-config-change
@@ -120,7 +120,7 @@ stages:
   - entrypoint:
     - cryostat-scorecard-tests
     - cryostat-report
-    image: quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726
+    image: quay.io/cryostat/cryostat-operator-scorecard:4.0.0-20240911172313
     labels:
       suite: cryostat
       test: cryostat-report

--- a/config/scorecard/patches/custom.config.yaml
+++ b/config/scorecard/patches/custom.config.yaml
@@ -8,7 +8,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - operator-install
-    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:4.0.0-20240911172313"
     labels:
       suite: cryostat
       test: operator-install
@@ -18,7 +18,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-cr
-    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:4.0.0-20240911172313"
     labels:
       suite: cryostat
       test: cryostat-cr
@@ -28,7 +28,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-multi-namespace
-    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:4.0.0-20240911172313"
     labels:
       suite: cryostat
       test: cryostat-multi-namespace
@@ -38,7 +38,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-recording
-    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:4.0.0-20240911172313"
     labels:
       suite: cryostat
       test: cryostat-recording
@@ -48,7 +48,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-config-change
-    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:4.0.0-20240911172313"
     labels:
       suite: cryostat
       test: cryostat-config-change
@@ -58,7 +58,7 @@
     entrypoint:
     - cryostat-scorecard-tests
     - cryostat-report
-    image: "quay.io/cryostat/cryostat-operator-scorecard:3.0.0-20240511064726"
+    image: "quay.io/cryostat/cryostat-operator-scorecard:4.0.0-20240911172313"
     labels:
       suite: cryostat
       test: cryostat-report


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to: #942 

#943 included a Scorecard change to lookup the renamed operator deployment, this PR bumps the Scorecard image tag so our CI will build and push a new image.
