### PR TITLE
fix(watch): enqueue CR when target namespace is deleted

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -21,5 +21,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/cryostat/cryostat-operator
-  newTag: 4.0.0-dev
+  newName: quay.io/ebaron/cryostat-operator
+  newTag: target-ns-watch-01

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -21,5 +21,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/ebaron/cryostat-operator
-  newTag: target-ns-watch-01
+  newName: quay.io/cryostat/cryostat-operator
+  newTag: 4.0.0-dev

--- a/internal/controllers/common/builder.go
+++ b/internal/controllers/common/builder.go
@@ -1,0 +1,81 @@
+// Copyright The Cryostat Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// ControllerBuilder wraps controller-runtime's builder.Builder
+// as an interface to aid testing.
+type ControllerBuilder interface {
+	For(object client.Object, opts ...builder.ForOption) ControllerBuilder
+	Owns(object client.Object, opts ...builder.OwnsOption) ControllerBuilder
+	Watches(object client.Object, eventHandler handler.EventHandler, opts ...builder.WatchesOption) ControllerBuilder
+	Complete(r reconcile.Reconciler) error
+	EnqueueRequestsFromMapFunc(fn handler.MapFunc) handler.EventHandler
+	WithPredicates(predicates ...predicate.Predicate) builder.Predicates
+}
+
+type ctrlBuilder struct {
+	impl *builder.Builder
+}
+
+var _ ControllerBuilder = (*ctrlBuilder)(nil)
+
+// NewControllerBuilder returns a new ControllerBuilder for the provided manager.
+func NewControllerBuilder(mgr ctrl.Manager) ControllerBuilder {
+	return &ctrlBuilder{
+		impl: ctrl.NewControllerManagedBy(mgr),
+	}
+}
+
+// For wraps the [builder.Builder.For] method
+func (b *ctrlBuilder) For(object client.Object, opts ...builder.ForOption) ControllerBuilder {
+	b.impl = b.impl.For(object, opts...)
+	return b
+}
+
+// Owns wraps the [builder.Builder.Owns] method
+func (b *ctrlBuilder) Owns(object client.Object, opts ...builder.OwnsOption) ControllerBuilder {
+	b.impl = b.impl.Owns(object, opts...)
+	return b
+}
+
+// Watches wraps the [builder.Builder.Watches] method
+func (b *ctrlBuilder) Watches(object client.Object, eventHandler handler.EventHandler, opts ...builder.WatchesOption) ControllerBuilder {
+	b.impl = b.impl.Watches(object, eventHandler, opts...)
+	return b
+}
+
+// Complete wraps the [builder.Builder.Complete] method
+func (b *ctrlBuilder) Complete(r reconcile.Reconciler) error {
+	return b.impl.Complete(r)
+}
+
+// EnqueueRequestsFromMapFunc wraps the [handler.EnqueueRequestsFromMapFunc] function
+func (b *ctrlBuilder) EnqueueRequestsFromMapFunc(fn handler.MapFunc) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(fn)
+}
+
+// WithPredicates wraps the [builder.WithPredicates] function
+func (b *ctrlBuilder) WithPredicates(predicates ...predicate.Predicate) builder.Predicates {
+	return builder.WithPredicates(predicates...)
+}

--- a/internal/controllers/common/common_utils.go
+++ b/internal/controllers/common/common_utils.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cryostatio/cryostat-operator/internal/controllers/constants"
+	"github.com/cryostatio/cryostat-operator/internal/controllers/model"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -111,6 +113,15 @@ func MergeLabelsAndAnnotations(dest *metav1.ObjectMeta, srcLabels, srcAnnotation
 	}
 	for k, v := range srcAnnotations {
 		dest.Annotations[k] = v
+	}
+}
+
+// LabelsForTargetNamespaceObject returns a set of labels for an object in a
+// target namespace that refer back to the CR associated with the object.
+func LabelsForTargetNamespaceObject(cr *model.CryostatInstance) map[string]string {
+	return map[string]string{
+		constants.TargetNamespaceCRNameLabel:      cr.Name,
+		constants.TargetNamespaceCRNamespaceLabel: cr.InstallNamespace,
 	}
 }
 

--- a/internal/controllers/constants/constants.go
+++ b/internal/controllers/constants/constants.go
@@ -41,4 +41,8 @@ const (
 	DatabaseSecretConnectionKey = "CONNECTION_KEY"
 	// DatabaseSecretEncryptionKey indexes the database encryption key within the Cryostat database Secret
 	DatabaseSecretEncryptionKey = "ENCRYPTION_KEY"
+
+	targetNamespaceCRLabelPrefix    = "operator.cryostat.io/"
+	TargetNamespaceCRNameLabel      = targetNamespaceCRLabelPrefix + "name"
+	TargetNamespaceCRNamespaceLabel = targetNamespaceCRLabelPrefix + "namespace"
 )

--- a/internal/controllers/cryostat_controller.go
+++ b/internal/controllers/cryostat_controller.go
@@ -104,7 +104,7 @@ func (r *CryostatReconciler) Reconcile(ctx context.Context, request ctrl.Request
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *CryostatReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return r.delegate.setupWithManager(mgr, r)
+	return r.delegate.setupWithManager(r.NewControllerBuilder(mgr), r)
 }
 
 func (r *CryostatReconciler) GetConfig() *ReconcilerConfig {

--- a/internal/controllers/reconciler_test.go
+++ b/internal/controllers/reconciler_test.go
@@ -23,6 +23,7 @@ import (
 	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
 	configv1 "github.com/openshift/api/config/v1"
 	consolev1 "github.com/openshift/api/console/v1"
 	openshiftv1 "github.com/openshift/api/route/v1"
@@ -39,10 +40,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	operatorv1beta2 "github.com/cryostatio/cryostat-operator/api/v1beta2"
@@ -67,6 +72,7 @@ func (c *controllerTest) commonBeforeEach() *cryostatTestInput {
 	t := &cryostatTestInput{
 		TestReconcilerConfig: test.TestReconcilerConfig{
 			GeneratedPasswords: []string{"auth_cookie_secret", "connection_key", "encryption_key", "object_storage", "keystore"},
+			ControllerBuilder:  &test.TestCtrlBuilder{},
 		},
 		TestResources: &test.TestResources{
 			Name:        "cryostat",
@@ -115,14 +121,16 @@ func (t *cryostatTestInput) newReconcilerConfig(scheme *runtime.Scheme, client c
 		insightsURL = url
 	}
 	return &controllers.ReconcilerConfig{
-		Client:        test.NewClientWithTimestamp(test.NewTestClient(client, t.TestResources)),
-		Scheme:        scheme,
-		IsOpenShift:   t.OpenShift,
-		EventRecorder: record.NewFakeRecorder(1024),
-		RESTMapper:    test.NewTESTRESTMapper(),
-		Log:           logger,
-		ReconcilerTLS: test.NewTestReconcilerTLS(&t.TestReconcilerConfig),
-		InsightsProxy: insightsURL,
+		Client:                 test.NewClientWithTimestamp(test.NewTestClient(client, t.TestResources)),
+		Scheme:                 scheme,
+		IsOpenShift:            t.OpenShift,
+		EventRecorder:          record.NewFakeRecorder(1024),
+		RESTMapper:             test.NewTESTRESTMapper(),
+		Log:                    logger,
+		ReconcilerTLS:          test.NewTestReconcilerTLS(&t.TestReconcilerConfig),
+		InsightsProxy:          insightsURL,
+		IsCertManagerInstalled: !t.CertManagerMissing,
+		NewControllerBuilder:   test.NewControllerBuilder(&t.TestReconcilerConfig),
 	}
 }
 
@@ -424,13 +432,9 @@ func (c *controllerTest) commonTests() {
 				err := t.Client.Get(context.Background(), types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, binding)
 				Expect(err).ToNot(HaveOccurred())
 
-				// Labels should be merged
-				expectedLabels := map[string]string{
-					"test":                           "label",
-					"operator.cryostat.io/name":      cr.Name,
-					"operator.cryostat.io/namespace": cr.InstallNamespace,
-				}
-				Expect(binding.Labels).To(Equal(expectedLabels))
+				// Labels are merged with existing ones
+				metav1.SetMetaDataLabel(&expected.ObjectMeta, "test", "label")
+				Expect(binding.Labels).To(Equal(expected.Labels))
 				Expect(binding.Annotations).To(Equal(oldBinding.Annotations))
 
 				// Subjects and RoleRef should be fully replaced
@@ -1809,40 +1813,21 @@ func (c *controllerTest) commonTests() {
 							t.expectNoCryostat()
 						})
 					})
-					Context("with cert-manager enabled", func() {
-						JustBeforeEach(func() {
-							err := t.Client.Delete(context.Background(), t.NewRoleBinding(targetNamespaces[0]))
-							Expect(err).ToNot(HaveOccurred())
-							t.reconcileDeletedCryostat()
-						})
-						It("should delete CA cert secrets from each namespace", func() {
-							t.checkCASecretsDeleted()
-						})
-						It("should delete agent cert secrets from each namespace", func() {
-							t.checkAgentCertSecretsDeleted()
-						})
-						It("should delete Cryostat", func() {
-							t.expectNoCryostat()
-						})
-					})
 				})
 			})
 
 			Context("with removed target namespaces", func() {
 				BeforeEach(func() {
-					t.TargetNamespaces = targetNamespaces
-					t.objs = append(t.objs, t.NewCryostat().Object)
-				})
-				JustBeforeEach(func() {
 					// Begin with RBAC set up for two namespaces,
 					// and remove the second namespace from the spec
 					t.TargetNamespaces = targetNamespaces[:1]
-					cr := t.getCryostatInstance()
-					cr.Spec.TargetNamespaces = t.TargetNamespaces
-					t.updateCryostatInstance(cr)
-
-					// Reconcile again
-					t.reconcileCryostatFully()
+					cr := t.NewCryostat()
+					*cr.TargetNamespaceStatus = targetNamespaces
+					t.objs = append(t.objs, cr.Object,
+						t.NewRoleBinding(targetNamespaces[0]),
+						t.NewRoleBinding(targetNamespaces[1]),
+						t.NewCACertSecret(targetNamespaces[0]),
+						t.NewCACertSecret(targetNamespaces[1]))
 				})
 				It("should create the expected main deployment", func() {
 					t.expectMainDeployment()
@@ -1856,29 +1841,11 @@ func (c *controllerTest) commonTests() {
 					Expect(err).ToNot(BeNil())
 					Expect(kerrors.IsNotFound(err)).To(BeTrue())
 				})
-				It("leave certficate secrets for the first namespace", func() {
+				It("leave CA Cert secret for the first namespace", func() {
 					t.expectCertificates()
 				})
-				It("should remove CA cert secret from the second namespace", func() {
+				It("should remove CA Cert secret from the second namespace", func() {
 					secret := t.NewCACertSecret(targetNamespaces[1])
-					err := t.Client.Get(context.Background(), types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}, secret)
-					Expect(err).ToNot(BeNil())
-					Expect(kerrors.IsNotFound(err)).To(BeTrue())
-				})
-				It("should remove agent certificate for the second namespace", func() {
-					cert := t.NewAgentCert(targetNamespaces[1])
-					err := t.Client.Get(context.Background(), types.NamespacedName{Name: cert.Name, Namespace: cert.Namespace}, cert)
-					Expect(err).ToNot(BeNil())
-					Expect(kerrors.IsNotFound(err)).To(BeTrue())
-				})
-				It("should remove agent cert secret for the second namespace", func() {
-					secret := t.NewAgentCertSecret(targetNamespaces[1])
-					err := t.Client.Get(context.Background(), types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}, secret)
-					Expect(err).ToNot(BeNil())
-					Expect(kerrors.IsNotFound(err)).To(BeTrue())
-				})
-				It("should remove agent cert secret copy from the second namespace", func() {
-					secret := t.NewAgentCertSecretCopy(targetNamespaces[1])
 					err := t.Client.Get(context.Background(), types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}, secret)
 					Expect(err).ToNot(BeNil())
 					Expect(kerrors.IsNotFound(err)).To(BeTrue())
@@ -2149,13 +2116,9 @@ func (c *controllerTest) commonTests() {
 				err := t.Client.Get(context.Background(), types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, binding)
 				Expect(err).ToNot(HaveOccurred())
 
-				// Labels should be merged
-				expectedLabels := map[string]string{
-					"test":                           "label",
-					"operator.cryostat.io/name":      cr.Name,
-					"operator.cryostat.io/namespace": cr.InstallNamespace,
-				}
-				Expect(binding.Labels).To(Equal(expectedLabels))
+				// Labels are merged with existing ones
+				metav1.SetMetaDataLabel(&expected.ObjectMeta, "test", "label")
+				Expect(binding.Labels).To(Equal(expected.Labels))
 				Expect(binding.Annotations).To(Equal(oldBinding.Annotations))
 
 				// Subjects and RoleRef should be fully replaced
@@ -2201,6 +2164,245 @@ func (c *controllerTest) commonTests() {
 			It("should have added the extra label and annotation to deployments and pods", func() {
 				t.expectMainDeploymentHasExtraMetadata()
 				t.expectReportsDeploymentHasExtraMetadata()
+			})
+		})
+	})
+
+	Describe("setting up with manager", func() {
+		BeforeEach(func() {
+			t = c.commonBeforeEach()
+			t.TargetNamespaces = []string{t.Namespace}
+		})
+
+		JustBeforeEach(func() {
+			c.commonJustBeforeEach(t)
+			// Create a default manager, not called
+			mgr, err := manager.New(cfg, manager.Options{})
+			Expect(err).ToNot(HaveOccurred())
+			t.controller.SetupWithManager(mgr)
+		})
+
+		JustAfterEach(func() {
+			c.commonJustAfterEach(t)
+		})
+
+		It("should watch Cryostat CRs", func() {
+			Expect(t.ControllerBuilder.ForCalls).To(HaveLen(1))
+			args := t.ControllerBuilder.ForCalls[0]
+			Expect(args.Object).To(BeAssignableToTypeOf(t.NewCryostat().Object))
+			Expect(args.Opts).To(BeEmpty())
+		})
+
+		It("should call Complete", func() {
+			Expect(t.ControllerBuilder.CompleteCalled).To(BeTrue())
+		})
+
+		Context("for owned resources", func() {
+			var ownsResources []ctrlclient.Object
+
+			BeforeEach(func() {
+				ownsResources = []ctrlclient.Object{
+					&appsv1.Deployment{},
+					&corev1.Service{},
+					&corev1.ConfigMap{},
+					&corev1.Secret{},
+					&corev1.PersistentVolumeClaim{},
+					&corev1.ServiceAccount{},
+					&rbacv1.Role{},
+					&rbacv1.RoleBinding{},
+					&netv1.Ingress{},
+				}
+			})
+
+			expectOwnedResources := func() {
+				It("should watch objects owned by Cryostat CRs", func() {
+					Expect(t.ControllerBuilder.OwnsCalls).To(HaveLen(len(ownsResources)))
+					resources := []ctrlclient.Object{}
+					for _, call := range t.ControllerBuilder.OwnsCalls {
+						resources = append(resources, call.Object)
+						Expect(call.Opts).To(BeEmpty())
+					}
+					Expect(resources).To(ConsistOf(ownsResources))
+				})
+			}
+
+			Context("cert-manager installed", func() {
+				BeforeEach(func() {
+					ownsResources = append(ownsResources, &certv1.Certificate{}, &certv1.Issuer{})
+				})
+				Context("on OpenShift", func() {
+					BeforeEach(func() {
+						ownsResources = append(ownsResources, &openshiftv1.Route{})
+					})
+					expectOwnedResources()
+				})
+				Context("on Kubernetes", func() {
+					BeforeEach(func() {
+						t.OpenShift = false
+					})
+					expectOwnedResources()
+				})
+			})
+
+			Context("cert-manager missing", func() {
+				BeforeEach(func() {
+					t.CertManagerMissing = true
+				})
+				Context("on OpenShift", func() {
+					BeforeEach(func() {
+						ownsResources = append(ownsResources, &openshiftv1.Route{})
+					})
+					expectOwnedResources()
+				})
+				Context("on Kubernetes", func() {
+					BeforeEach(func() {
+						t.OpenShift = false
+					})
+					expectOwnedResources()
+				})
+			})
+		})
+
+		Context("watches in target namespaces", func() {
+			var expectedResources []ctrlclient.Object
+
+			BeforeEach(func() {
+				expectedResources = []ctrlclient.Object{
+					&rbacv1.RoleBinding{},
+					&corev1.Secret{},
+				}
+			})
+
+			It("should watch specified resources", func() {
+				Expect(t.ControllerBuilder.WatchesCalls).To(HaveLen(len(expectedResources)))
+				resources := []ctrlclient.Object{}
+				for _, watch := range t.ControllerBuilder.WatchesCalls {
+					resources = append(resources, watch.Object)
+				}
+				Expect(resources).To(ConsistOf(expectedResources))
+			})
+
+			Context("filtering by labels", func() {
+				var pred predicate.Predicate
+				var obj ctrlclient.Object
+
+				JustBeforeEach(func() {
+					Expect(t.ControllerBuilder.WatchesCalls).To(HaveLen(len(expectedResources)))
+					Expect(t.ControllerBuilder.Predicates).To(HaveLen(len(expectedResources)))
+					for _, watch := range t.ControllerBuilder.WatchesCalls {
+						Expect(watch.Opts).To(HaveLen(1))
+						Expect(watch.Opts[0]).To(BeAssignableToTypeOf(builder.Predicates{}))
+					}
+					pred = t.ControllerBuilder.Predicates[0]
+				})
+
+				Context("with both labels present", func() {
+					BeforeEach(func() {
+						obj = t.NewAgentCertSecretCopy("foo")
+					})
+
+					It("should accept", func() {
+						t.expectPredicateToAccept(pred, obj)
+					})
+				})
+
+				Context("with name label missing", func() {
+					BeforeEach(func() {
+						obj = t.NewAgentCertSecretCopy("foo")
+						delete(obj.GetLabels(), "operator.cryostat.io/name")
+					})
+
+					It("should reject", func() {
+						t.expectPredicateToReject(pred, obj)
+					})
+				})
+
+				Context("with namespace label missing", func() {
+					BeforeEach(func() {
+						obj = t.NewAgentCertSecretCopy("foo")
+						delete(obj.GetLabels(), "operator.cryostat.io/namespace")
+					})
+
+					It("should reject", func() {
+						t.expectPredicateToReject(pred, obj)
+					})
+				})
+
+				Context("both labels missing", func() {
+					BeforeEach(func() {
+						obj = t.NewAgentCertSecret("foo")
+						delete(obj.GetLabels(), "operator.cryostat.io/name")
+					})
+
+					It("should reject", func() {
+						t.expectPredicateToReject(pred, obj)
+					})
+				})
+			})
+
+			Context("handling events", func() {
+				var handlerFunc handler.MapFunc
+				var obj ctrlclient.Object
+
+				JustBeforeEach(func() {
+					Expect(t.ControllerBuilder.WatchesCalls).To(HaveLen(len(expectedResources)))
+					Expect(t.ControllerBuilder.MapFuncs).To(HaveLen(len(expectedResources)))
+					for i, watch := range t.ControllerBuilder.WatchesCalls {
+						Expect(watch.EventHandler).ToNot(BeNil())
+						// Check that the handler uses the expected underlying type
+						mapFunc := t.ControllerBuilder.MapFuncs[i]
+						expectedHandler := handler.EnqueueRequestsFromMapFunc(mapFunc)
+						Expect(watch.EventHandler).To(BeAssignableToTypeOf(expectedHandler))
+					}
+					handlerFunc = t.ControllerBuilder.MapFuncs[0]
+				})
+
+				Context("with both labels present", func() {
+					BeforeEach(func() {
+						obj = t.NewAgentCertSecretCopy("foo")
+					})
+
+					It("should accept", func() {
+						result := handlerFunc(context.Background(), obj)
+						Expect(result).To(ConsistOf(newReconcileRequest(t.Namespace, t.Name)))
+					})
+				})
+
+				Context("with name label missing", func() {
+					BeforeEach(func() {
+						obj = t.NewAgentCertSecretCopy("foo")
+						delete(obj.GetLabels(), "operator.cryostat.io/name")
+					})
+
+					It("should reject", func() {
+						result := handlerFunc(context.Background(), obj)
+						Expect(result).To(BeEmpty())
+					})
+				})
+
+				Context("with namespace label missing", func() {
+					BeforeEach(func() {
+						obj = t.NewAgentCertSecretCopy("foo")
+						delete(obj.GetLabels(), "operator.cryostat.io/namespace")
+					})
+
+					It("should reject", func() {
+						result := handlerFunc(context.Background(), obj)
+						Expect(result).To(BeEmpty())
+					})
+				})
+
+				Context("both labels missing", func() {
+					BeforeEach(func() {
+						obj = t.NewAgentCertSecret("foo")
+						delete(obj.GetLabels(), "operator.cryostat.io/name")
+					})
+
+					It("should reject", func() {
+						result := handlerFunc(context.Background(), obj)
+						Expect(result).To(BeEmpty())
+					})
+				})
 			})
 		})
 	})
@@ -2328,36 +2530,6 @@ func (t *cryostatTestInput) expectCertificates() {
 			Expect(secret.Type).To(Equal(expectedSecret.Type))
 		}
 	}
-
-	// Check agent certificates and secrets
-	for _, ns := range t.TargetNamespaces {
-		// Check certificate object
-		expectedCert := t.NewAgentCert(ns)
-		cert := &certv1.Certificate{}
-		err := t.Client.Get(context.Background(), types.NamespacedName{Name: expectedCert.Name, Namespace: expectedCert.Namespace}, cert)
-		Expect(err).ToNot(HaveOccurred())
-		t.checkMetadata(cert, expectedCert)
-		Expect(cert.Spec).To(Equal(expectedCert.Spec))
-
-		// Check certificate secret is created and owned by CR
-		expectedSecret := t.NewAgentCertSecret(ns)
-		secret := &corev1.Secret{}
-		err = t.Client.Get(context.Background(), types.NamespacedName{Name: expectedSecret.Name, Namespace: expectedSecret.Namespace}, secret)
-		Expect(err).ToNot(HaveOccurred())
-		t.checkMetadata(secret, expectedSecret)
-		Expect(secret.Data).To(Equal(expectedSecret.Data))
-
-		if ns != t.Namespace {
-			// Ensure secret is copied into the target namespace
-			expectedSecret = t.NewAgentCertSecretCopy(ns)
-			secret = &corev1.Secret{}
-			err = t.Client.Get(context.Background(), types.NamespacedName{Name: expectedSecret.Name, Namespace: expectedSecret.Namespace}, secret)
-			Expect(err).ToNot(HaveOccurred())
-			t.checkMetadataNoOwner(secret, expectedSecret)
-			Expect(secret.GetOwnerReferences()).To(BeEmpty())
-			Expect(secret.Data).To(Equal(expectedSecret.Data))
-		}
-	}
 }
 
 func (t *cryostatTestInput) expectRBAC() {
@@ -2406,24 +2578,6 @@ func (t *cryostatTestInput) checkRoleBindingsDeleted() {
 		expected := t.NewRoleBinding(ns)
 		binding := &rbacv1.RoleBinding{}
 		err := t.Client.Get(context.Background(), types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, binding)
-		Expect(kerrors.IsNotFound(err)).To(BeTrue())
-	}
-}
-
-func (t *cryostatTestInput) checkCASecretsDeleted() {
-	for _, ns := range t.TargetNamespaces {
-		expected := t.NewCACertSecret(ns)
-		secret := &corev1.Secret{}
-		err := t.Client.Get(context.Background(), types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, secret)
-		Expect(kerrors.IsNotFound(err)).To(BeTrue())
-	}
-}
-
-func (t *cryostatTestInput) checkAgentCertSecretsDeleted() {
-	for _, ns := range t.TargetNamespaces {
-		expected := t.NewAgentCertSecretCopy(ns)
-		secret := &corev1.Secret{}
-		err := t.Client.Get(context.Background(), types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, secret)
 		Expect(kerrors.IsNotFound(err)).To(BeTrue())
 	}
 }
@@ -3068,9 +3222,14 @@ func (t *cryostatTestInput) reconcile() (reconcile.Result, error) {
 }
 
 func (t *cryostatTestInput) reconcileWithName(name string) (reconcile.Result, error) {
-	nsName := types.NamespacedName{Name: name, Namespace: t.Namespace}
-	req := reconcile.Request{NamespacedName: nsName}
+	req := newReconcileRequest(t.Namespace, name)
 	return t.controller.Reconcile(context.Background(), req)
+}
+
+func newReconcileRequest(namespace string, name string) reconcile.Request {
+	return reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: namespace, Name: name},
+	}
 }
 
 func (t *cryostatTestInput) expectConsoleLink() {
@@ -3084,4 +3243,20 @@ func (t *cryostatTestInput) expectConsoleLink() {
 func (t *cryostatTestInput) expectTargetNamespaces() {
 	cr := t.getCryostatInstance()
 	Expect(*cr.TargetNamespaceStatus).To(ConsistOf(t.TargetNamespaces))
+}
+
+func (t *cryostatTestInput) expectPredicateToAccept(pred predicate.Predicate, obj ctrlclient.Object) {
+	t.expectPredicate(pred, obj, BeTrue())
+}
+
+func (t *cryostatTestInput) expectPredicateToReject(pred predicate.Predicate, obj ctrlclient.Object) {
+	t.expectPredicate(pred, obj, BeFalse())
+}
+
+func (t *cryostatTestInput) expectPredicate(pred predicate.Predicate, obj ctrlclient.Object,
+	matcher gomegatypes.GomegaMatcher) {
+	Expect(pred.Create(t.NewCreateEvent(obj))).To(matcher)
+	Expect(pred.Update(t.NewUpdateEvent(obj))).To(matcher)
+	Expect(pred.Delete(t.NewDeleteEvent(obj))).To(matcher)
+	Expect(pred.Generic(t.NewGenericEvent(obj))).To(matcher)
 }

--- a/internal/controllers/reconciler_test.go
+++ b/internal/controllers/reconciler_test.go
@@ -424,8 +424,13 @@ func (c *controllerTest) commonTests() {
 				err := t.Client.Get(context.Background(), types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, binding)
 				Expect(err).ToNot(HaveOccurred())
 
-				// Labels are unaffected
-				Expect(binding.Labels).To(Equal(oldBinding.Labels))
+				// Labels should be merged
+				expectedLabels := map[string]string{
+					"test":                           "label",
+					"operator.cryostat.io/name":      cr.Name,
+					"operator.cryostat.io/namespace": cr.InstallNamespace,
+				}
+				Expect(binding.Labels).To(Equal(expectedLabels))
 				Expect(binding.Annotations).To(Equal(oldBinding.Annotations))
 
 				// Subjects and RoleRef should be fully replaced
@@ -2144,8 +2149,13 @@ func (c *controllerTest) commonTests() {
 				err := t.Client.Get(context.Background(), types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, binding)
 				Expect(err).ToNot(HaveOccurred())
 
-				// Labels are unaffected
-				Expect(binding.Labels).To(Equal(oldBinding.Labels))
+				// Labels should be merged
+				expectedLabels := map[string]string{
+					"test":                           "label",
+					"operator.cryostat.io/name":      cr.Name,
+					"operator.cryostat.io/namespace": cr.InstallNamespace,
+				}
+				Expect(binding.Labels).To(Equal(expectedLabels))
 				Expect(binding.Annotations).To(Equal(oldBinding.Annotations))
 
 				// Subjects and RoleRef should be fully replaced

--- a/internal/main.go
+++ b/internal/main.go
@@ -229,6 +229,7 @@ func newReconcilerConfig(mgr ctrl.Manager, logName string, eventRecorderName str
 		EventRecorder:          mgr.GetEventRecorderFor(eventRecorderName),
 		RESTMapper:             mgr.GetRESTMapper(),
 		InsightsProxy:          insightsURL,
+		NewControllerBuilder:   common.NewControllerBuilder,
 		ReconcilerTLS: common.NewReconcilerTLS(&common.ReconcilerTLSConfig{
 			Client: mgr.GetClient(),
 		}),

--- a/internal/test/builder.go
+++ b/internal/test/builder.go
@@ -1,0 +1,105 @@
+// Copyright The Cryostat Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/cryostatio/cryostat-operator/internal/controllers/common"
+)
+
+// TestCtrlBuilder is a fake ControllerBuilder to aid testing of
+// controller watches
+type TestCtrlBuilder struct {
+	ForCalls       []ForArgs
+	OwnsCalls      []OwnsArgs
+	WatchesCalls   []WatchesArgs
+	MapFuncs       []handler.MapFunc
+	Predicates     []predicate.Predicate
+	CompleteCalled bool
+}
+
+// ForArgs contain arguments used for a call to For
+type ForArgs struct {
+	Object client.Object
+	Opts   []builder.ForOption
+}
+
+// OwnsArgs contain arguments used for a call to Owns
+type OwnsArgs struct {
+	Object client.Object
+	Opts   []builder.OwnsOption
+}
+
+// WatchesArgs contain arguments used for a call to Watches
+type WatchesArgs struct {
+	Object       client.Object
+	EventHandler handler.EventHandler
+	Opts         []builder.WatchesOption
+}
+
+var _ common.ControllerBuilder = (*TestCtrlBuilder)(nil)
+
+func NewControllerBuilder(config *TestReconcilerConfig) func(ctrl.Manager) common.ControllerBuilder {
+	return func(ctrl.Manager) common.ControllerBuilder {
+		return config.ControllerBuilder
+	}
+}
+
+func (b *TestCtrlBuilder) For(object client.Object, opts ...builder.ForOption) common.ControllerBuilder {
+	b.ForCalls = append(b.ForCalls, ForArgs{
+		Object: object,
+		Opts:   opts,
+	})
+	return b
+}
+
+func (b *TestCtrlBuilder) Owns(object client.Object, opts ...builder.OwnsOption) common.ControllerBuilder {
+	b.OwnsCalls = append(b.OwnsCalls, OwnsArgs{
+		Object: object,
+		Opts:   opts,
+	})
+	return b
+}
+
+func (b *TestCtrlBuilder) Watches(object client.Object, eventHandler handler.EventHandler,
+	opts ...builder.WatchesOption) common.ControllerBuilder {
+	b.WatchesCalls = append(b.WatchesCalls, WatchesArgs{
+		Object:       object,
+		EventHandler: eventHandler,
+		Opts:         opts,
+	})
+	return b
+}
+
+func (b *TestCtrlBuilder) Complete(r reconcile.Reconciler) error {
+	b.CompleteCalled = true
+	return nil
+}
+
+func (b *TestCtrlBuilder) EnqueueRequestsFromMapFunc(fn handler.MapFunc) handler.EventHandler {
+	b.MapFuncs = append(b.MapFuncs, fn)
+	return handler.EnqueueRequestsFromMapFunc(fn)
+}
+
+func (b *TestCtrlBuilder) WithPredicates(predicates ...predicate.Predicate) builder.Predicates {
+	b.Predicates = append(b.Predicates, predicates...)
+	return builder.WithPredicates(predicates...)
+}

--- a/internal/test/reconciler.go
+++ b/internal/test/reconciler.go
@@ -36,6 +36,8 @@ type TestReconcilerConfig struct {
 	EnvGrafanaImageTag             *string
 	EnvReportsImageTag             *string
 	GeneratedPasswords             []string
+	ControllerBuilder              *TestCtrlBuilder
+	CertManagerMissing             bool
 }
 
 func NewTestReconcilerTLS(config *TestReconcilerConfig) common.ReconcilerTLS {

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -844,6 +844,10 @@ func (r *TestResources) NewCACertSecret(ns string) *corev1.Secret {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      r.getClusterUniqueNameForCA(),
 			Namespace: ns,
+			Labels: map[string]string{
+				"operator.cryostat.io/name":      r.Name,
+				"operator.cryostat.io/namespace": r.Namespace,
+			},
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
@@ -868,6 +872,10 @@ func (r *TestResources) NewAgentCertSecret(ns string) *corev1.Secret {
 
 func (r *TestResources) NewAgentCertSecretCopy(ns string) *corev1.Secret {
 	secret := r.NewAgentCertSecret(ns)
+	secret.Labels = map[string]string{
+		"operator.cryostat.io/name":      r.Name,
+		"operator.cryostat.io/namespace": r.Namespace,
+	}
 	secret.Namespace = ns
 	return secret
 }
@@ -2707,6 +2715,10 @@ func (r *TestResources) NewRoleBinding(ns string) *rbacv1.RoleBinding {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      r.getClusterUniqueName(),
 			Namespace: ns,
+			Labels: map[string]string{
+				"operator.cryostat.io/name":      r.Name,
+				"operator.cryostat.io/namespace": r.Namespace,
+			},
 		},
 		Subjects: []rbacv1.Subject{
 			{

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -41,6 +41,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
 type TestResources struct {
@@ -3112,4 +3114,29 @@ func (r *TestResources) getClusterUniqueNameForAgent(namespace string) string {
 
 func (r *TestResources) GetAgentCertPrefix() string {
 	return "cryostat-agent-"
+}
+
+func (r *TestResources) NewCreateEvent(obj ctrlclient.Object) event.CreateEvent {
+	return event.CreateEvent{
+		Object: obj,
+	}
+}
+
+func (r *TestResources) NewUpdateEvent(obj ctrlclient.Object) event.UpdateEvent {
+	return event.UpdateEvent{
+		ObjectOld: obj,
+		ObjectNew: obj,
+	}
+}
+
+func (r *TestResources) NewDeleteEvent(obj ctrlclient.Object) event.DeleteEvent {
+	return event.DeleteEvent{
+		Object: obj,
+	}
+}
+
+func (r *TestResources) NewGenericEvent(obj ctrlclient.Object) event.GenericEvent {
+	return event.GenericEvent{
+		Object: obj,
+	}
 }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #941 

## Description of the change:
* Adds labels to role bindings and secrets created by the operator in target namespaces. These labels identify the name and namespace of the CR responsible for them
* Adds a custom controller watch that filters role bindings and secrets by those labels, and enqueues the identified CR
* Adds a testable wrapper around the controller builder, with a fake implementation for tests.
* Adds tests for each controller watch in the `SetupWithManager` method.

## Motivation for the change:
* Allows the operator to watch and respond to deletion of those target namespace objects, or the namespace itself. In the case where the object was deleted, the controller will recreate the deleted object. In the case that the target namespace was deleted, the controller will requeue with an error until either the namespace is recreated, or it is removed from the CR spec.
* Improves test coverage for controller watches, which has been missing.

## How to manually test:
1. Create a multi-namespace Cryostat CR
   a. Delete a role binding and/or secret within the target namespace.
   b. Observe the operator recreating the deleted object.
2. Delete the entire target namespace
   a. The operator should fail to reconcile the CR
   b. Recreate the namespace
   c. The operator should successfully reconcile, and recreate the missing objects
3. Delete the entire target namespace again
   a. The operator should fail to reconcile the CR
   b. Remove the deleted namespace from the CR's spec
   c. The operator should successfully reconcile
