### PR TITLE
feat(storage): enable at-rest encryption on storage container

### DIFF
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -1331,6 +1331,10 @@ func NewStorageContainer(cr *model.CryostatInstance, imageTag string, tls *TLSCo
 			Name:  "IP_BIND",
 			Value: "0.0.0.0",
 		},
+		{
+			Name:  "REST_ENCRYPTION_ENABLE",
+			Value: "1",
+		},
 	}
 
 	mounts := []corev1.VolumeMount{

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -1633,6 +1633,10 @@ func (r *TestResources) NewStorageEnvironmentVariables() []corev1.EnvVar {
 			Value: "0.0.0.0",
 		},
 		{
+			Name:  "REST_ENCRYPTION_ENABLE",
+			Value: "1",
+		},
+		{
 			Name: "CRYOSTAT_SECRET_KEY",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

See https://github.com/cryostatio/cryostat/pull/690

## Description of the change:
Enables the `cryostat-storage` flag to turn on SeaweedFS at-rest data encryption.

## Motivation for the change:
Improves data security and integrity by ensuring that at-rest files are encrypted. This is not a full solution because Seaweed stores the encryption/decryption key in the file metadata (so that the file can be decrypted later), and in our usage the metadata is stored on the same persistent volume as the encrypted file. So, any attack vectors where the attacker has direct access to the PV bypassing authn/authz checks or the S3 API will still allow the attacker to compromise the data.

## How to manually test:
1. Build and deploy Operator with this PR
2. Create a Cryostat CR
3. Check the corresponding Cryostat Deployment or Pod definition and look for the env. var. `REST_ENCRYPTION_ENABLE=1`
4. Check the `cryostat-storage` container logs within the Pod and look for:

```
+ '[' 1 = 1 ']'
+ FLAGS+=("-filer.encryptVolumeData")
+ exec weed -logtostderr=true server -dir=/data -volume.max=40 -volume.fileSizeLimitMB=4096 -master.volumeSizeLimitMB=251 -master.volumePreallocate=false -filer.allowedOrigins=0.0.0.0 -filer.exposeDirectoryData=false -filer.disableDirListing -webdav=false -filer.encryptVolumeData -s3 -s3.config=/tmp/tmp.SJp8GVR95B
```

`-filer.encryptVolumeData` should be passed as an argument to the `exec weed` invocation.