### PR TITLE
test(sampleapp): configure Cryostat Agent sample app to use k8s serviceaccount token auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -415,7 +415,6 @@ sample_app_agent: undeploy_sample_app_agent ## Deploy sample app with Cryostat A
 		fi; \
 	fi; \
 	$(CLUSTER_CLIENT) apply $(SAMPLE_APP_FLAGS) -f config/samples/sample-app-agent.yaml; \
-	$(CLUSTER_CLIENT) set env $(SAMPLE_APP_FLAGS) deployment/quarkus-cryostat-agent CRYOSTAT_AGENT_AUTHORIZATION="Bearer $(AUTH_TOKEN)"
 
 .PHONY: undeploy_sample_app_agent_proxy
 undeploy_sample_app_agent_proxy: ## Undeploy sample app with Cryostat Agent configured for TLS client auth on nginx proxy.

--- a/config/samples/sample-app-agent.yaml
+++ b/config/samples/sample-app-agent.yaml
@@ -15,10 +15,11 @@ spec:
       labels:
         app: quarkus-cryostat-agent
     spec:
+      serviceAccountName: quarkus-cryostat-agent-serviceaccount
       containers:
       - env:
         - name: CRYOSTAT_AGENT_APP_NAME
-          value: agent-test
+          value: quarkus-cryostat-agent
         - name: NAMESPACE
           valueFrom:
             fieldRef:
@@ -28,6 +29,8 @@ spec:
           value: "true"
         - name: CRYOSTAT_AGENT_BASEURI
           value: https://cryostat-sample.$(NAMESPACE).svc:4180
+        - name: CRYOSTAT_AGENT_AUTHORIZATION_TYPE
+          value: kubernetes
         - name: POD_IP
           valueFrom:
             fieldRef:
@@ -35,12 +38,11 @@ spec:
               fieldPath: status.podIP
         - name: CRYOSTAT_AGENT_CALLBACK
           value: http://$(POD_IP):9977
-        - name: CRYOSTAT_AGENT_AUTHORIZATION
-          value: Bearer abcd1234
         - name: JAVA_OPTS_APPEND
           value: |-
             -Dquarkus.http.host=0.0.0.0
             -Djava.util.logging.manager=org.jboss.logmanager.LogManager
+            -Dio.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel=info
             -Dcom.sun.management.jmxremote.port=9097
             -Dcom.sun.management.jmxremote.ssl=false
             -Dcom.sun.management.jmxremote.authenticate=false
@@ -102,3 +104,32 @@ spec:
     port: 10010
     protocol: TCP
     targetPort: 10010
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: quarkus-cryostat-agent-serviceaccount
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: quarkus-cryostat-agent-role
+rules:
+- apiGroups:
+  - ""
+  verbs:
+  - create
+  resources:
+  - pods/exec
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: quarkus-cryostat-agent-role-binding
+subjects:
+- kind: ServiceAccount
+  name: quarkus-cryostat-agent-serviceaccount
+roleRef:
+  kind: Role
+  name: quarkus-cryostat-agent-role
+  apiGroup: rbac.authorization.k8s.io

--- a/config/samples/sample-app-agent.yaml
+++ b/config/samples/sample-app-agent.yaml
@@ -29,8 +29,6 @@ spec:
           value: "true"
         - name: CRYOSTAT_AGENT_BASEURI
           value: https://cryostat-sample.$(NAMESPACE).svc:4180
-        - name: CRYOSTAT_AGENT_AUTHORIZATION_TYPE
-          value: kubernetes
         - name: POD_IP
           valueFrom:
             fieldRef:

--- a/config/samples/sample-app-agent.yaml
+++ b/config/samples/sample-app-agent.yaml
@@ -19,7 +19,10 @@ spec:
       containers:
       - env:
         - name: CRYOSTAT_AGENT_APP_NAME
-          value: quarkus-cryostat-agent
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
         - name: NAMESPACE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

See https://github.com/cryostatio/cryostat-operator/pull/928
See https://github.com/cryostatio/cryostat-agent/pull/383

## Description of the change:
Reconfigures the `make sample_app_agent` to use the automatic Kubernetes serviceaccount token detection for authentication/authorization to the auth proxy. This will automatically in OpenShift. In other Kubernetes environments the user will need to patch the resulting Deployment to add `CRYOSTAT_AGENT_AUTHORIZATION` or `CRYOSTAT_AGENT_AUTHORIZATION_TYPE`+`CRYOSTAT_AGENT_AUTHORIZATION_VALUE` environment variables to match any `oauth2-proxy` `Basic` authentication that may be optionally configured.

## Motivation for the change:
Exercises the latest best practice of using injected serviceaccount tokens managed by cluster RBAC, rather than using hardcoded long-lived tokens as part of the Deployment spec.

This probably still isn't exactly the *best* practice, as this grants the Role to the whole workload application and not only its Agent, so it's adding extra privileges to the workload that are not strictly required. It is useful and convenient as an example for testing and development, to demonstrate how the serviceaccount token system works with the Agent and the auth proxy, and it's better than giving the Agent an admin user token via environment variable which was commonly done for testing before.

The even more ideal situation is to configure the Agent with TLS client certificates properly and have it talk to the new TLS gateway proxy. I think that would be a good setup to exercise as a new sample app configuration at some point.

## How to manually test:
1. Get an OpenShift cluster
2. Install Operator
3. Create a Cryostat CR named `cryostat-sample`, ex `make create_cryostat_cr`
4. `make sample_app_agent`
5. Open Cryostat UI and ensure that the sample application appears on the Topology view. This may take a bit of time but should be relatively short.

![Screenshot 2024-12-13 at 15-49-18 quarkus-cryostat-agent-7f778c5bb4-9g8n8 · Pod · Environment · Red Hat OpenShift Service on AWS](https://github.com/user-attachments/assets/dfefaf2d-eca3-44c4-b3fc-48248be48a18)

![Screenshot 2024-12-13 at 15-49-09 Topology](https://github.com/user-attachments/assets/f3c6e7e9-97f2-460e-95dc-db6fe48489c6)
