### PR TITLE
test(scorecard): adjust scorecard report generation expectation

### DIFF
--- a/internal/test/scorecard/clients.go
+++ b/internal/test/scorecard/clients.go
@@ -422,7 +422,7 @@ func (client *RecordingClient) Delete(ctx context.Context, target *Target, recor
 	return nil
 }
 
-func (client *RecordingClient) GenerateReport(ctx context.Context, target *Target, recording *Recording) (map[string]interface{}, error) {
+func (client *RecordingClient) RequestReportGeneration(ctx context.Context, target *Target, recording *Recording) (*string, error) {
 	if len(recording.ReportURL) < 1 {
 		return nil, fmt.Errorf("report URL is not available")
 	}
@@ -430,7 +430,6 @@ func (client *RecordingClient) GenerateReport(ctx context.Context, target *Targe
 	reportURL := client.Base.JoinPath(recording.ReportURL)
 
 	header := make(http.Header)
-	header.Add("Accept", "application/json")
 
 	resp, err := SendRequest(ctx, client.Client, http.MethodGet, reportURL.String(), nil, header)
 	if err != nil {
@@ -442,13 +441,12 @@ func (client *RecordingClient) GenerateReport(ctx context.Context, target *Targe
 		return nil, fmt.Errorf("API request failed with status code: %d, response body: %s, and headers:\n%s", resp.StatusCode, ReadError(resp), ReadHeader(resp))
 	}
 
-	report := make(map[string]interface{}, 0)
-	err = ReadJSON(resp, &report)
+	report, err := ReadString(resp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %s", err.Error())
 	}
 
-	return report, nil
+	return &report, nil
 }
 
 func (client *RecordingClient) ListArchives(ctx context.Context, target *Target) ([]Archive, error) {

--- a/internal/test/scorecard/tests.go
+++ b/internal/test/scorecard/tests.go
@@ -230,7 +230,7 @@ func CryostatRecordingTest(bundle *apimanifests.Bundle, namespace string, openSh
 	if err != nil {
 		return r.fail(fmt.Sprintf("failed to generate report for the recording: %s", err.Error()))
 	}
-	r.Log += fmt.Sprintf("report generation job ID for the recording %s: %+v\n", rec.Name, reportJobId)
+	r.Log += fmt.Sprintf("report generation job ID for the recording %s: %+v\n", rec.Name, *reportJobId)
 
 	// Stop the recording
 	err = apiClient.Recordings().Stop(context.Background(), target, rec.Id)

--- a/internal/test/scorecard/tests.go
+++ b/internal/test/scorecard/tests.go
@@ -226,11 +226,11 @@ func CryostatRecordingTest(bundle *apimanifests.Bundle, namespace string, openSh
 	}
 	r.Log += fmt.Sprintf("current list of archives: %+v\n", archives)
 
-	report, err := apiClient.Recordings().GenerateReport(context.Background(), target, rec)
+	reportJobId, err := apiClient.Recordings().RequestReportGeneration(context.Background(), target, rec)
 	if err != nil {
 		return r.fail(fmt.Sprintf("failed to generate report for the recording: %s", err.Error()))
 	}
-	r.Log += fmt.Sprintf("generated report for the recording %s: %+v\n", rec.Name, report)
+	r.Log += fmt.Sprintf("report generation job ID for the recording %s: %+v\n", rec.Name, reportJobId)
 
 	// Stop the recording
 	err = apiClient.Recordings().Stop(context.Background(), target, rec.Id)


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

See https://github.com/cryostatio/cryostat/pull/698
See #974

## Description of the change:
Adjusts the test to not expect a full report JSON response body, on request, but only a job ID string response.

Since https://github.com/cryostatio/cryostat/pull/698 the response is expected to be an async job ID on first request, then later the server will emit a websocket notification containing the same ID to notify clients that the request has been completed. Then when the client makes an identical request again, the report is ready and cached, so the server responds with it this second time around.

In the old system the server would always respond with the report response, even though this could sometimes take considerable time to complete. Because of this long delay, with the server writing no response bytes at all in the interim, clients (especially web browsers) could time out waiting while the server was still processing.

Ideally this scorecard test should be adjusted to account for the entire async job API cycle, but this would mean establishing a websocket connection to the server to listen for the async job ID. I think this is worth looking into but I will do it separately, and just get this minimal fix in ASAP to get CI passing again.

## Motivation for the change:
Get scorecards passing again.

## How to manually test:
1. *Insert steps here...*
2. *...*
