### PR TITLE
test(scorecard): long-running report generation websocket handling

### DIFF
--- a/internal/test/scorecard/tests.go
+++ b/internal/test/scorecard/tests.go
@@ -226,11 +226,11 @@ func CryostatRecordingTest(bundle *apimanifests.Bundle, namespace string, openSh
 	}
 	r.Log += fmt.Sprintf("current list of archives: %+v\n", archives)
 
-	reportJobId, err := apiClient.Recordings().RequestReportGeneration(context.Background(), target, rec)
+	report, err := apiClient.Recordings().GenerateReport(context.Background(), target, rec)
 	if err != nil {
 		return r.fail(fmt.Sprintf("failed to generate report for the recording: %s", err.Error()))
 	}
-	r.Log += fmt.Sprintf("report generation job ID for the recording %s: %+v\n", rec.Name, *reportJobId)
+	r.Log += fmt.Sprintf("generated report for the recording %s: %+v\n", rec.Name, report)
 
 	// Stop the recording
 	err = apiClient.Recordings().Stop(context.Background(), target, rec.Id)


### PR DESCRIPTION
- **Revert "test(scorecard): adjust scorecard report generation expectation (#985)"**
- **test(scorecard): long-running report generation websocket handling**

# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #986

## Description of the change:
*This change adds allows the users to provide...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Insert steps here...*
2. *...*
