### PR TITLE
feat(agent): add object selector for pod webhook

### DIFF
--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -30,7 +30,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:4.0.0-dev
-    createdAt: "2025-01-14T22:32:19Z"
+    createdAt: "2025-01-16T19:04:11Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {
@@ -1234,6 +1234,12 @@ spec:
       deploymentName: cryostat-operator-controller
       failurePolicy: Ignore
       generateName: mpod.cryostat.io
+      objectSelector:
+        matchExpressions:
+          - key: cryostat.io/name
+            operator: Exists
+          - key: cryostat.io/namespace
+            operator: Exists
       rules:
         - apiGroups:
             - ""

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -35,6 +35,7 @@ patchesStrategicMerge:
 - image_pull_patch.yaml
 - manager_webhook_patch.yaml
 - webhookcainjection_patch.yaml
+- webhook_object_selector_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/config/default/webhook_object_selector_patch.yaml
+++ b/config/default/webhook_object_selector_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- name: mpod.cryostat.io
+  objectSelector:
+    matchExpressions:
+      - key: cryostat.io/name
+        operator: Exists
+      - key: cryostat.io/namespace
+        operator: Exists

--- a/internal/webhooks/agent/pod_defaulter.go
+++ b/internal/webhooks/agent/pod_defaulter.go
@@ -62,9 +62,10 @@ func (r *podMutator) Default(ctx context.Context, obj runtime.Object) error {
 		return fmt.Errorf("expected a Pod, but received a %T", obj)
 	}
 
-	// TODO do this with objectSelector: https://github.com/kubernetes-sigs/controller-tools/issues/553
-	// Check for required labels and return early if missing
+	// Check for required labels and return early if missing.
+	// This should not happen because such pods are filtered out by Kubernetes server-side due to our object selector.
 	if !metav1.HasLabel(pod.ObjectMeta, constants.AgentLabelCryostatName) || !metav1.HasLabel(pod.ObjectMeta, constants.AgentLabelCryostatNamespace) {
+		r.log.Info("pod is missing required labels")
 		return nil
 	}
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #993 

## Description of the change:
* Patches the MutatingWebhookConfiguration with an object selector that causes the pod webhook to only be invoked if it contains the required `cryostat.io/name` and `cryostat.io/namespace` labels

## Motivation for the change:
* Increases performance by using Kubernetes to perform server-side filtering so our webhook isn't invoked upon every pod creation event in the cluster

## How to manually test:
1. Deploy PR and create a default CR
2. `make sample_app`, there should be no log messages from `pod-webhook`. If the filtering didn't work, we would see the new "pod is missing required labels" log message.
3. `make sample_app_agent_injected`. You should see a `pod-webhook` log message like "configured Cryostat agent for pod" and the sample app should be properly instrumented
