### PR TITLE
feat(agent): add label to control which container is mutated

### DIFF
--- a/config/samples/sample-app-agent-injected.yaml
+++ b/config/samples/sample-app-agent-injected.yaml
@@ -17,7 +17,6 @@ spec:
         cryostat.io/name: cryostat-sample
         cryostat.io/namespace: cryostat-operator-system
     spec:
-      serviceAccountName: quarkus-cryostat-agent-serviceaccount
       containers:
       - env:
         - name: JAVA_OPTS_APPEND
@@ -54,40 +53,7 @@ spec:
   selector:
     app: quarkus-cryostat-agent
   ports:
-  - name: agent-http
-    port: 9977
-    protocol: TCP
-    targetPort: 9977
   - name: app-http
     port: 10010
     protocol: TCP
     targetPort: 10010
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: quarkus-cryostat-agent-serviceaccount
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: quarkus-cryostat-agent-role
-rules:
-- apiGroups:
-  - ""
-  verbs:
-  - create
-  resources:
-  - pods/exec
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: quarkus-cryostat-agent-role-binding
-subjects:
-- kind: ServiceAccount
-  name: quarkus-cryostat-agent-serviceaccount
-roleRef:
-  kind: Role
-  name: quarkus-cryostat-agent-role
-  apiGroup: rbac.authorization.k8s.io

--- a/internal/controllers/constants/constants.go
+++ b/internal/controllers/constants/constants.go
@@ -62,6 +62,7 @@ const (
 	AgentLabelCryostatName      = agentLabelPrefix + "name"
 	AgentLabelCryostatNamespace = agentLabelPrefix + "namespace"
 	AgentLabelCallbackPort      = agentLabelPrefix + "callback-port"
+	AgentLabelContainer         = agentLabelPrefix + "container"
 
 	CryostatCATLSCommonName     = "cryostat-ca-cert-manager"
 	CryostatTLSCommonName       = "cryostat"

--- a/internal/webhooks/agent/pod_defaulter_test.go
+++ b/internal/webhooks/agent/pod_defaulter_test.go
@@ -123,27 +123,30 @@ var _ = Describe("PodDefaulter", func() {
 
 			It("should add volume mounts(s)", func() {
 				actual := t.getPod(expectedPod)
-				expected := expectedPod.Spec.Containers[0]
-				Expect(actual.Spec.Containers).To(HaveLen(1))
-				container := actual.Spec.Containers[0]
-				Expect(container.VolumeMounts).To(ConsistOf(expected.VolumeMounts))
+				Expect(actual.Spec.Containers).To(HaveLen(len(expectedPod.Spec.Containers)))
+				for i, expected := range expectedPod.Spec.Containers {
+					container := actual.Spec.Containers[i]
+					Expect(container.VolumeMounts).To(ConsistOf(expected.VolumeMounts))
+				}
 			})
 
 			It("should add environment variables", func() {
 				actual := t.getPod(expectedPod)
-				expected := expectedPod.Spec.Containers[0]
-				Expect(actual.Spec.Containers).To(HaveLen(1))
-				container := actual.Spec.Containers[0]
-				Expect(container.Env).To(ConsistOf(expected.Env))
-				Expect(container.EnvFrom).To(ConsistOf(expected.EnvFrom))
+				Expect(actual.Spec.Containers).To(HaveLen(len(expectedPod.Spec.Containers)))
+				for i, expected := range expectedPod.Spec.Containers {
+					container := actual.Spec.Containers[i]
+					Expect(container.Env).To(ConsistOf(expected.Env))
+					Expect(container.EnvFrom).To(ConsistOf(expected.EnvFrom))
+				}
 			})
 
 			It("should add ports(s)", func() {
 				actual := t.getPod(expectedPod)
-				expected := expectedPod.Spec.Containers[0]
-				Expect(actual.Spec.Containers).To(HaveLen(1))
-				container := actual.Spec.Containers[0]
-				Expect(container.Ports).To(ConsistOf(expected.Ports))
+				Expect(actual.Spec.Containers).To(HaveLen(len(expectedPod.Spec.Containers)))
+				for i, expected := range expectedPod.Spec.Containers {
+					container := actual.Spec.Containers[i]
+					Expect(container.Ports).To(ConsistOf(expected.Ports))
+				}
 			})
 		}
 
@@ -349,6 +352,39 @@ var _ = Describe("PodDefaulter", func() {
 				})
 
 				ExpectPod()
+			})
+
+			Context("with multiple containers", func() {
+				BeforeEach(func() {
+					t.objs = append(t.objs, t.NewCryostat().Object)
+					originalPod = t.NewPodMultiContainer()
+					expectedPod = t.NewMutatedPodMultiContainer()
+				})
+
+				ExpectPod()
+			})
+
+			Context("with a custom container label", func() {
+				Context("for a container that exists", func() {
+					BeforeEach(func() {
+						t.objs = append(t.objs, t.NewCryostat().Object)
+						originalPod = t.NewPodContainerLabel()
+						expectedPod = t.NewMutatedPodContainerLabel()
+					})
+
+					ExpectPod()
+				})
+
+				Context("for a container that doesn't exist", func() {
+					BeforeEach(func() {
+						t.objs = append(t.objs, t.NewCryostat().Object)
+						originalPod = t.NewPodContainerBadLabel()
+						// Should fail
+						expectedPod = originalPod
+					})
+
+					ExpectPod()
+				})
 			})
 		})
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #994 

## Description of the change:
* Adds a `cryostat.io/container` label. If present on an auto-configured pod, the mutation webhook will look for the named container instead of defaulting to the first container.
* Removes RBAC and agent-related port from injected sample app. We want to make sure if works with default RBAC and no prior setup.

## Motivation for the change:
* Allows agent auto-configuration to work in multi-container pods

## How to manually test:
1. Deploy PR and create default CR
2. Create a modified sample app with an extra container such as:
    ```yaml
    ---
    apiVersion: apps/v1
    kind: Deployment
    metadata:
      labels:
        app: quarkus-cryostat-agent
      name: quarkus-cryostat-agent
    spec:
      replicas: 1
      selector:
        matchLabels:
          app: quarkus-cryostat-agent
      template:
        metadata:
          labels:
            app: quarkus-cryostat-agent
            cryostat.io/name: cryostat-sample
            cryostat.io/namespace: cryostat-operator-system
            cryostat.io/container: quarkus-cryostat-agent
        spec:
          containers:
          - name: sleeper
            image: registry.access.redhat.com/ubi9/ubi:latest
            command:
              - bash
              - '-c'
              - 'while true; do sleep 1; done'
          - env:
            - name: JAVA_OPTS_APPEND
              value: |-
                -Dquarkus.http.host=0.0.0.0
                -Djava.util.logging.manager=org.jboss.logmanager.LogManager
                -Dio.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel=debug
            image: quay.io/redhat-java-monitoring/quarkus-cryostat-agent:latest
            imagePullPolicy: Always
            name: quarkus-cryostat-agent
            ports:
            - containerPort: 10010
              protocol: TCP
            resources:
              limits:
                cpu: 500m
                memory: 256Mi
            securityContext:
              allowPrivilegeEscalation: false
              capabilities:
                drop:
                - ALL
          restartPolicy: Always
          securityContext:
            runAsNonRoot: true
    ```
3. Agent should be configured for the second container
