### PR TITLE
ci(bundle): build plain-k8s and OCP bundle modes

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -67,22 +67,28 @@ jobs:
 
   build-bundle:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        bundle_mode: ['k8s', 'ocp']
     steps:
     - uses: actions/checkout@v4
     - name: Build bundle image
-      run: IMAGE_NAMESPACE=${{ env.CI_REGISTRY }} make bundle-build
+      run: IMAGE_NAMESPACE=${{ env.CI_REGISTRY }} BUNDLE_MODE=${{ matrix.bundle_mode }} make bundle-build
     - name: Tag image
       id: tag-image
       run: |
         IMG_TAG="$(make --eval='print-img-ver: ; @echo $(IMAGE_VERSION)' print-img-ver)"
-        if [ "$GITHUB_REF" == "refs/heads/main" ]; then
-          podman tag \
-          ${{ env.CI_BUNDLE_IMG }}:$IMG_TAG \
-          ${{ env.CI_BUNDLE_IMG }}:latest
-          echo "tags=$IMG_TAG latest" >> $GITHUB_OUTPUT
-        else
-          echo "tags=$IMG_TAG" >> $GITHUB_OUTPUT
+        TAGS+=("${IMG_TAG}-${{ matrix.bundle_mode }}")
+        if [ "${GITHUB_REF}" == "refs/heads/main" ] ; then
+          if [ "${{ matrix.bundle_mode }}" == "k8s" ]; then
+            TAGS+=("${IMG_TAG}" "latest")
+          fi
+          TAGS+=("latest-${{ matrix.bundle_mode }}")
         fi
+        for tag in "${TAGS[@]}"; do
+          podman tag "${{ env.CI_BUNDLE_IMG }}:${IMG_TAG}" "${{ env.CI_BUNDLE_IMG }}:${tag}"
+        done
+        echo "tags=${TAGS[@]}" >> $GITHUB_OUTPUT
     - name: Push to quay.io
       id: push-to-quay
       uses: redhat-actions/push-to-registry@v2

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -11,8 +11,6 @@ on:
       - v[0-9]+
       - v[0-9]+.[0-9]+
       - cryostat-v[0-9]+.[0-9]+
-      # TODO remove once merged into main
-      - cryostat3
 
 env:
   CI_USER: cryostat+bot

--- a/.github/workflows/test-ci-push.yml
+++ b/.github/workflows/test-ci-push.yml
@@ -11,8 +11,6 @@ on:
       - v[0-9]+
       - v[0-9]+.[0-9]+
       - cryostat-v[0-9]+.[0-9]+
-      # TODO remove once merged into main
-      - cryostat3
 
 jobs:
   check-before-test:


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to #687
Related to #1023

Sample runs:

`k8s`: https://github.com/andrewazores/cryostat-operator/actions/runs/12991924912/job/36230608257
```
Run redhat-actions/push-to-registry@v2
Creating temporary Podman image storage for pulling from Docker daemon
Storage driver is not 'overlay', so not overriding storage configuration
Combining image name "cryostat-operator-bundle" and registry "quay.io/andrewazores" to form registry path "quay.io/andrewazores/cryostat-operator-bundle"
🔍 Checking if the given image is manifest or not.
/usr/bin/podman version
/usr/bin/podman manifest exists cryostat-operator-bundle:4.0.0-dev-k8s
/usr/bin/podman manifest exists cryostat-operator-bundle:4.0.0-dev
/usr/bin/podman manifest exists cryostat-operator-bundle:latest
/usr/bin/podman manifest exists cryostat-operator-bundle:latest-k8s
🔍 Checking if "cryostat-operator-bundle:4.0.0-dev-k8s, cryostat-operator-bundle:4.0.0-dev, cryostat-operator-bundle:latest, cryostat-operator-bundle:latest-k8s" present in the local Podman image storage
/usr/bin/podman image exists cryostat-operator-bundle:4.0.0-dev-k8s
/usr/bin/podman image exists cryostat-operator-bundle:4.0.0-dev
/usr/bin/podman image exists cryostat-operator-bundle:latest
/usr/bin/podman image exists cryostat-operator-bundle:latest-k8s
Tags "cryostat-operator-bundle:4.0.0-dev-k8s, cryostat-operator-bundle:4.0.0-dev, cryostat-operator-bundle:latest, cryostat-operator-bundle:latest-k8s" found in Podman image storage
🔍 Checking if "cryostat-operator-bundle:4.0.0-dev-k8s, cryostat-operator-bundle:4.0.0-dev, cryostat-operator-bundle:latest, cryostat-operator-bundle:latest-k8s" present in the local Docker image storage
/usr/bin/podman --root /tmp/podman-from-docker-8IQTYL pull docker-daemon:cryostat-operator-bundle:4.0.0-dev-k8s
/usr/bin/podman --root /tmp/podman-from-docker-8IQTYL pull docker-daemon:cryostat-operator-bundle:4.0.0-dev
/usr/bin/podman --root /tmp/podman-from-docker-8IQTYL pull docker-daemon:cryostat-operator-bundle:latest
/usr/bin/podman --root /tmp/podman-from-docker-8IQTYL pull docker-daemon:cryostat-operator-bundle:latest-k8s
Tag "cryostat-operator-bundle:4.0.0-dev-k8s" was found in the Podman image storage, but not in the Docker image storage. The image(s) will be pushed from Podman image storage.
⏳ Pushing "cryostat-operator-bundle:4.0.0-dev-k8s, cryostat-operator-bundle:4.0.0-dev, cryostat-operator-bundle:latest, cryostat-operator-bundle:latest-k8s" to "quay.io/andrewazores/cryostat-operator-bundle:4.0.0-dev-k8s, quay.io/andrewazores/cryostat-operator-bundle:4.0.0-dev, quay.io/andrewazores/cryostat-operator-bundle:latest, quay.io/andrewazores/cryostat-operator-bundle:latest-k8s" respectively as "andrewazores+github_ci"
/usr/bin/podman push --quiet --digestfile cryostat-operator-bundle-4.0.0-dev-k8s_digest.txt cryostat-operator-bundle:4.0.0-dev-k8s quay.io/andrewazores/cryostat-operator-bundle:4.0.0-dev-k8s --tls-verify=true --creds=andrewazores+github_ci:***
✅ Successfully pushed "cryostat-operator-bundle:4.0.0-dev-k8s" to "quay.io/andrewazores/cryostat-operator-bundle:4.0.0-dev-k8s"
sha256:42e547a8148a8444f6f86afc4c994d5eada34b652415cbc4a4f1374c71b4be0a
/usr/bin/podman push --quiet --digestfile cryostat-operator-bundle-4.0.0-dev-k8s_digest.txt cryostat-operator-bundle:4.0.0-dev quay.io/andrewazores/cryostat-operator-bundle:4.0.0-dev --tls-verify=true --creds=andrewazores+github_ci:***
✅ Successfully pushed "cryostat-operator-bundle:4.0.0-dev" to "quay.io/andrewazores/cryostat-operator-bundle:4.0.0-dev"
sha256:42e547a8148a8444f6f86afc4c994d5eada34b652415cbc4a4f1374c71b4be0a
/usr/bin/podman push --quiet --digestfile cryostat-operator-bundle-4.0.0-dev-k8s_digest.txt cryostat-operator-bundle:latest quay.io/andrewazores/cryostat-operator-bundle:latest --tls-verify=true --creds=andrewazores+github_ci:***
✅ Successfully pushed "cryostat-operator-bundle:latest" to "quay.io/andrewazores/cryostat-operator-bundle:latest"
sha256:42e547a8148a8444f6f86afc4c994d5eada34b652415cbc4a4f1374c71b4be0a
/usr/bin/podman push --quiet --digestfile cryostat-operator-bundle-4.0.0-dev-k8s_digest.txt cryostat-operator-bundle:latest-k8s quay.io/andrewazores/cryostat-operator-bundle:latest-k8s --tls-verify=true --creds=andrewazores+github_ci:***
✅ Successfully pushed "cryostat-operator-bundle:latest-k8s" to "quay.io/andrewazores/cryostat-operator-bundle:latest-k8s"
sha256:42e547a8148a8444f6f86afc4c994d5eada34b652415cbc4a4f1374c71b4be0a
Removing temporary Podman image storage for pulling from Docker daemon
/usr/bin/podman --root /tmp/podman-from-docker-8IQTYL rmi -a -f
(node:2181) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
```

`ocp`: https://github.com/andrewazores/cryostat-operator/actions/runs/12991924912/job/36230608655
```
Run redhat-actions/push-to-registry@v2
Creating temporary Podman image storage for pulling from Docker daemon
Storage driver is not 'overlay', so not overriding storage configuration
Combining image name "cryostat-operator-bundle" and registry "quay.io/andrewazores" to form registry path "quay.io/andrewazores/cryostat-operator-bundle"
🔍 Checking if the given image is manifest or not.
/usr/bin/podman version
/usr/bin/podman manifest exists cryostat-operator-bundle:4.0.0-dev-ocp
/usr/bin/podman manifest exists cryostat-operator-bundle:latest-ocp
🔍 Checking if "cryostat-operator-bundle:4.0.0-dev-ocp, cryostat-operator-bundle:latest-ocp" present in the local Podman image storage
/usr/bin/podman image exists cryostat-operator-bundle:4.0.0-dev-ocp
/usr/bin/podman image exists cryostat-operator-bundle:latest-ocp
Tags "cryostat-operator-bundle:4.0.0-dev-ocp, cryostat-operator-bundle:latest-ocp" found in Podman image storage
🔍 Checking if "cryostat-operator-bundle:4.0.0-dev-ocp, cryostat-operator-bundle:latest-ocp" present in the local Docker image storage
/usr/bin/podman --root /tmp/podman-from-docker-RbS6Q2 pull docker-daemon:cryostat-operator-bundle:4.0.0-dev-ocp
/usr/bin/podman --root /tmp/podman-from-docker-RbS6Q2 pull docker-daemon:cryostat-operator-bundle:latest-ocp
Tag "cryostat-operator-bundle:4.0.0-dev-ocp" was found in the Podman image storage, but not in the Docker image storage. The image(s) will be pushed from Podman image storage.
⏳ Pushing "cryostat-operator-bundle:4.0.0-dev-ocp, cryostat-operator-bundle:latest-ocp" to "quay.io/andrewazores/cryostat-operator-bundle:4.0.0-dev-ocp, quay.io/andrewazores/cryostat-operator-bundle:latest-ocp" respectively as "andrewazores+github_ci"
/usr/bin/podman push --quiet --digestfile cryostat-operator-bundle-4.0.0-dev-ocp_digest.txt cryostat-operator-bundle:4.0.0-dev-ocp quay.io/andrewazores/cryostat-operator-bundle:4.0.0-dev-ocp --tls-verify=true --creds=andrewazores+github_ci:***
✅ Successfully pushed "cryostat-operator-bundle:4.0.0-dev-ocp" to "quay.io/andrewazores/cryostat-operator-bundle:4.0.0-dev-ocp"
sha256:5b75c8f806fa84b617a3f371745a329dc88aab4a1e5c89fae537e6e52d19c1c5
/usr/bin/podman push --quiet --digestfile cryostat-operator-bundle-4.0.0-dev-ocp_digest.txt cryostat-operator-bundle:latest-ocp quay.io/andrewazores/cryostat-operator-bundle:latest-ocp --tls-verify=true --creds=andrewazores+github_ci:***
✅ Successfully pushed "cryostat-operator-bundle:latest-ocp" to "quay.io/andrewazores/cryostat-operator-bundle:latest-ocp"
sha256:5b75c8f806fa84b617a3f371745a329dc88aab4a1e5c89fae537e6e52d19c1c5
Removing temporary Podman image storage for pulling from Docker daemon
/usr/bin/podman --root /tmp/podman-from-docker-RbS6Q2 rmi -a -f
(node:2166) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
```

![image](https://github.com/user-attachments/assets/d08413b7-d2af-44ef-bb0c-5e9cfb99d1f5)
