### PR TITLE
feat(agent): add label for read-only agent

### DIFF
--- a/internal/controllers/constants/constants.go
+++ b/internal/controllers/constants/constants.go
@@ -63,6 +63,7 @@ const (
 	AgentLabelCryostatNamespace = agentLabelPrefix + "namespace"
 	AgentLabelCallbackPort      = agentLabelPrefix + "callback-port"
 	AgentLabelContainer         = agentLabelPrefix + "container"
+	AgentLabelReadOnly          = agentLabelPrefix + "read-only"
 
 	CryostatCATLSCommonName     = "cryostat-ca-cert-manager"
 	CryostatTLSCommonName       = "cryostat"

--- a/internal/webhooks/agent/pod_defaulter_test.go
+++ b/internal/webhooks/agent/pod_defaulter_test.go
@@ -386,6 +386,29 @@ var _ = Describe("PodDefaulter", func() {
 					ExpectPod()
 				})
 			})
+
+			Context("with a custom read-only label", func() {
+				Context("that is valid", func() {
+					BeforeEach(func() {
+						t.objs = append(t.objs, t.NewCryostat().Object)
+						originalPod = t.NewPodReadOnlyLabel()
+						expectedPod = t.NewMutatedPodReadOnlyLabel()
+					})
+
+					ExpectPod()
+				})
+
+				Context("that is non-boolean", func() {
+					BeforeEach(func() {
+						t.objs = append(t.objs, t.NewCryostat().Object)
+						originalPod = t.NewPodReadOnlyLabelInvalid()
+						// Should fail
+						expectedPod = originalPod
+					})
+
+					ExpectPod()
+				})
+			})
 		})
 
 		Context("with a missing Cryostat CR", func() {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #996 

## Description of the change:
* Adds `cryostat.io/read-only` label to allow users to make the injected agent read-only. 

## Motivation for the change:
* Gives users more control over security of their injected agents

## How to manually test:
1. Deploy this PR and create default CR
2. `make sample_app_injected`, should inject with write access turned on
3. Edit deployment with `cryostat.io/read-only: true`, should inject with write access turned off
