### PR TITLE
fix(plugin): check OpenShift version compatibility

### DIFF
--- a/internal/console/console_suite_test.go
+++ b/internal/console/console_suite_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	configv1 "github.com/openshift/api/config/v1"
 	consolev1 "github.com/openshift/api/console/v1"
 	openshiftoperatorv1 "github.com/openshift/api/operator/v1"
 
@@ -71,6 +72,7 @@ var _ = BeforeSuite(func() {
 
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
+			filepath.Join(append(openshiftPrefix, "config", "v1", "zz_generated.crd-manifests", "0000_00_cluster-version-operator_01_clusterversions-Default.crd.yaml")...),
 			filepath.Join(append(openshiftPrefix, "console", "v1", "zz_generated.crd-manifests", "90_consoleplugins.crd.yaml")...),
 			filepath.Join(append(openshiftPrefix, "operator", "v1", "zz_generated.crd-manifests", "0000_50_console_01_consoles.crd.yaml")...),
 		},
@@ -86,6 +88,7 @@ var _ = BeforeSuite(func() {
 	k8sScheme = runtime.NewScheme()
 	sb := runtime.NewSchemeBuilder(
 		scheme.AddToScheme,
+		configv1.AddToScheme,
 		consolev1.AddToScheme,
 		openshiftoperatorv1.AddToScheme,
 	)

--- a/internal/console/plugin_test.go
+++ b/internal/console/plugin_test.go
@@ -221,6 +221,19 @@ var _ = Describe("Plugin", func() {
 				})
 				expectNoChanges()
 			})
+			Context("that is too new", func() {
+				BeforeEach(func() {
+					t.objs = append(t.objs, t.NewClusterVersionNew())
+				})
+				JustBeforeEach(func() {
+					t.updateClusterVersionStatus(t.NewClusterVersionNew())
+					startError = installer.Start(context.Background())
+				})
+				It("should not return an error", func() {
+					Expect(startError).ToNot(HaveOccurred())
+				})
+				expectNoChanges()
+			})
 			Context("that is too malformed", func() {
 				BeforeEach(func() {
 					t.objs = append(t.objs, t.NewClusterVersionBad())

--- a/internal/console/test/resources.go
+++ b/internal/console/test/resources.go
@@ -194,6 +194,10 @@ func (r *PluginTestResources) NewClusterVersionOld() *configv1.ClusterVersion {
 	return r.newClusterVersion("4.12.0-foo+bar")
 }
 
+func (r *PluginTestResources) NewClusterVersionNew() *configv1.ClusterVersion {
+	return r.newClusterVersion("100.0.0-foo+bar")
+}
+
 func (r *PluginTestResources) NewClusterVersionBad() *configv1.ClusterVersion {
 	return r.newClusterVersion("")
 }

--- a/internal/console/test/resources.go
+++ b/internal/console/test/resources.go
@@ -16,6 +16,7 @@ package test
 
 import (
 	"github.com/cryostatio/cryostat-operator/internal/test"
+	configv1 "github.com/openshift/api/config/v1"
 	consolev1 "github.com/openshift/api/console/v1"
 	openshiftoperatorv1 "github.com/openshift/api/operator/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -183,4 +184,32 @@ func (r *PluginTestResources) NewOperatorDeploymentMissingLabels() *appsv1.Deplo
 	deploy := r.NewOperatorDeployment()
 	delete(deploy.Labels, "olm.owner")
 	return deploy
+}
+
+func (r *PluginTestResources) NewClusterVersion() *configv1.ClusterVersion {
+	return r.newClusterVersion("4.17.0-foo+bar")
+}
+
+func (r *PluginTestResources) NewClusterVersionOld() *configv1.ClusterVersion {
+	return r.newClusterVersion("4.12.0-foo+bar")
+}
+
+func (r *PluginTestResources) NewClusterVersionBad() *configv1.ClusterVersion {
+	return r.newClusterVersion("")
+}
+
+func (r *PluginTestResources) newClusterVersion(version string) *configv1.ClusterVersion {
+	return &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: configv1.ClusterVersionSpec{
+			ClusterID: "00000000-0000-0000-0000-000000000000",
+		},
+		Status: configv1.ClusterVersionStatus{
+			Desired: configv1.Release{
+				Version: version,
+			},
+		},
+	}
 }

--- a/internal/console/test/resources.go
+++ b/internal/console/test/resources.go
@@ -201,7 +201,7 @@ func (r *PluginTestResources) NewClusterVersionBad() *configv1.ClusterVersion {
 func (r *PluginTestResources) newClusterVersion(version string) *configv1.ClusterVersion {
 	return &configv1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "cluster",
+			Name: "version",
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: "00000000-0000-0000-0000-000000000000",

--- a/internal/controllers/constants/constants.go
+++ b/internal/controllers/constants/constants.go
@@ -80,5 +80,5 @@ const (
 	ConsoleServicePort        int32 = 9443
 	ConsoleProxyName                = "cryostat-plugin-proxy"
 	ConsoleCRName                   = "cluster"
-	ClusterVersionName              = "cluster"
+	ClusterVersionName              = "version"
 )

--- a/internal/controllers/constants/constants.go
+++ b/internal/controllers/constants/constants.go
@@ -80,4 +80,5 @@ const (
 	ConsoleServicePort        int32 = 9443
 	ConsoleProxyName                = "cryostat-plugin-proxy"
 	ConsoleCRName                   = "cluster"
+	ClusterVersionName              = "cluster"
 )


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #1030 

## Description of the change:
* Use the ClusterVersion API to find the cluster's OpenShift version
* Log a message instead of installing the ConsolePlugin and modifying the Console CR

## Motivation for the change:
* This prevents installing a broken plugin on older versions of OpenShift

## How to manually test:
1. Generate a bundle image from this PR `make bundle BUNDLE_MODE=ocp ...`
2. Try it on an OpenShift >= 4.15 cluster, it should install the plugin and it should function
3. Try it on an OpenShift < 4.15 cluster, it should not install the plugin and instead log a message:
    `OpenShift version 4.12.0 is older than the minimum required (4.15.0) for the Console Plugin. Plugin installation will be skipped.`
