### PR TITLE
fix(service): set appProtocol to https if TLS enabled

### DIFF
--- a/internal/controllers/constants/constants.go
+++ b/internal/controllers/constants/constants.go
@@ -38,6 +38,7 @@ const (
 	OperatorNamePrefix         string = "cryostat-operator-"
 	OperatorDeploymentName     string = "cryostat-operator-controller"
 	HttpPortName               string = "http"
+	HttpsPortName              string = "https"
 	// CAKey is the key for a CA certificate within a TLS secret
 	CAKey = certMeta.TLSCAKey
 	// ALL capability to drop for restricted pod security. See:

--- a/internal/controllers/services.go
+++ b/internal/controllers/services.go
@@ -47,7 +47,10 @@ func (r *Reconciler) reconcileCoreService(ctx context.Context, cr *model.Cryosta
 			"app":       cr.Name,
 			"component": "cryostat",
 		}
-		appProtocol := "http"
+		appProtocol := constants.HttpPortName
+		if tls != nil {
+			appProtocol = constants.HttpsPortName
+		}
 		svc.Spec.Ports = []corev1.ServicePort{
 			{
 				Name:        constants.HttpPortName,

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -1003,6 +1003,9 @@ func (r *TestResources) NewCryostatWithAgentHostnameVerifyDisabled() *model.Cryo
 
 func (r *TestResources) NewCryostatService() *corev1.Service {
 	appProtocol := "http"
+	if r.TLS {
+		appProtocol = "https"
+	}
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      r.Name,


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #1033
Related to cryostatio/cryostat-openshift-console-plugin#3

## Description of the change:
Sets the `appProtocol` of the Cryostat service port to `https` if TLS is enabled, otherwise leaves it as `http`.

## Motivation for the change:
This is used as a marker for other components to know whether the exposed service port is using HTTPS or HTTP. The console plugin backend uses the appProtocol first to determine whether it should send HTTPS or HTTP requests to the Cryostat instance. If it does not find an appProtocol on the port then it falls back to trying to use the port name. If it still cannot determine what the port is, then it bails out.

## How to manually test:
1. *Insert steps here...*
2. *...*
