### PR TITLE
feat(agent): add label for Java options variable name

### DIFF
--- a/internal/controllers/constants/constants.go
+++ b/internal/controllers/constants/constants.go
@@ -65,6 +65,7 @@ const (
 	AgentLabelCallbackPort      = agentLabelPrefix + "callback-port"
 	AgentLabelContainer         = agentLabelPrefix + "container"
 	AgentLabelReadOnly          = agentLabelPrefix + "read-only"
+	AgentLabelJavaOptionsVar    = agentLabelPrefix + "java-options-var"
 
 	CryostatCATLSCommonName     = "cryostat-ca-cert-manager"
 	CryostatTLSCommonName       = "cryostat"

--- a/internal/webhooks/agent/pod_defaulter_test.go
+++ b/internal/webhooks/agent/pod_defaulter_test.go
@@ -409,6 +409,16 @@ var _ = Describe("PodDefaulter", func() {
 					ExpectPod()
 				})
 			})
+
+			Context("with a custom java options var label", func() {
+				BeforeEach(func() {
+					t.objs = append(t.objs, t.NewCryostat().Object)
+					originalPod = t.NewPodJavaOptsVar()
+					expectedPod = t.NewMutatedPodJavaOptsVarLabel()
+				})
+
+				ExpectPod()
+			})
 		})
 
 		Context("with a missing Cryostat CR", func() {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #1001 

## Description of the change:
* Adds a `cryostat.io/java-options-var` label whose value is used instead of `JAVA_TOOL_OPTIONS` to inject the Cryostat agent

## Motivation for the change:
* Allows more flexibility to users where `JAVA_TOOL_OPTIONS` may not work for their application

## How to manually test:
1. Deploy PR and create default CR
2. `kubectl create deploy wildfly --image=quay.io/wildfly/wildfly:latest-jdk17 --port=8080`
3. Edit the wildfly pod template to add the following labels:
    ```yaml
    cryostat.io/name: cryostat-sample
    cryostat.io/namespace: cryostat-operator-system
    cryostat.io/java-options-var: MODULE_OPTS
    ```
4. The wildfly pod is created with `MODULE_OPTS` used to inject the agent
5. The agent should run and register properly with Cryostat