### PR TITLE
fix(rbac): remove unused permissions from ClusterRole

### DIFF
--- a/bundle/manifests/cryostat-operator-cryostat_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/cryostat-operator-cryostat_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -16,13 +16,5 @@ rules:
   - authorization.k8s.io
   resources:
   - subjectaccessreviews
-  - selfsubjectaccessreviews
   verbs:
   - create
-- apiGroups:
-  - oauth.openshift.io
-  resources:
-  - oauthaccesstokens
-  verbs:
-  - list
-  - delete

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -24,7 +24,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:4.0.0-dev
-    createdAt: "2025-01-28T00:29:47Z"
+    createdAt: "2025-01-31T15:55:35Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {
@@ -997,12 +997,6 @@ spec:
             - apiGroups:
                 - authorization.k8s.io
               resources:
-                - selfsubjectaccessreviews
-              verbs:
-                - create
-            - apiGroups:
-                - authorization.k8s.io
-              resources:
                 - subjectaccessreviews
               verbs:
                 - create
@@ -1052,13 +1046,6 @@ spec:
                 - networkpolicies
               verbs:
                 - '*'
-            - apiGroups:
-                - oauth.openshift.io
-              resources:
-                - oauthaccesstokens
-              verbs:
-                - delete
-                - list
             - apiGroups:
                 - operator.cryostat.io
               resources:

--- a/config/rbac/cryostat_role.yaml
+++ b/config/rbac/cryostat_role.yaml
@@ -15,13 +15,5 @@ rules:
   - authorization.k8s.io
   resources:
   - subjectaccessreviews
-  - selfsubjectaccessreviews
   verbs:
   - create
-- apiGroups:
-  - oauth.openshift.io
-  resources:
-  - oauthaccesstokens
-  verbs:
-  - list
-  - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -66,12 +66,6 @@ rules:
 - apiGroups:
   - authorization.k8s.io
   resources:
-  - selfsubjectaccessreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
   - subjectaccessreviews
   verbs:
   - create
@@ -121,13 +115,6 @@ rules:
   - networkpolicies
   verbs:
   - '*'
-- apiGroups:
-  - oauth.openshift.io
-  resources:
-  - oauthaccesstokens
-  verbs:
-  - delete
-  - list
 - apiGroups:
   - operator.cryostat.io
   resources:

--- a/internal/controllers/cryostat_controller.go
+++ b/internal/controllers/cryostat_controller.go
@@ -54,9 +54,7 @@ func NewCryostatReconciler(config *ReconcilerConfig) (*CryostatReconciler, error
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=create;get;list;update;watch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create;get;list;update;watch;delete
 // +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
-// +kubebuilder:rbac:groups=authorization.k8s.io,resources=selfsubjectaccessreviews,verbs=create
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
-// +kubebuilder:rbac:groups=oauth.openshift.io,resources=oauthaccesstokens,verbs=list;delete
 // +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;update;watch
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes;routes/custom-host,verbs=*
 // +kubebuilder:rbac:groups=apps.openshift.io,resources=deploymentconfigs,verbs=get


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to: #951 

## Description of the change:
* Removes `oauthaccesstokens` and `selfsubjectaccessreviews` from the operator's cluster role and also from the cluster role bound to Cryostat service accounts. 

## Motivation for the change:
* These permissions were needed before we migrated to using the OpenShift OAuth Proxy sidecar. It's good security practice to remove unneeded permissions.

## How to manually test:
1. Deploy PR
2. Inspect the `cryostat-operator-cryostat` ClusterRole and verify the permissions are removed.
