### PR TITLE
build(agent): add agent init image to related images

### DIFF
--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -24,7 +24,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:4.0.0-dev
-    createdAt: "2025-02-04T23:03:44Z"
+    createdAt: "2025-02-04T23:08:18Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {
@@ -1146,6 +1146,8 @@ spec:
                         value: quay.io/cryostat/cryostat-db:latest
                       - name: RELATED_IMAGE_AGENT_PROXY
                         value: registry.access.redhat.com/ubi9/nginx-124:latest
+                      - name: RELATED_IMAGE_AGENT_INIT
+                        value: quay.io/cryostat/cryostat-agent-init:latest
                       - name: WATCH_NAMESPACE
                         valueFrom:
                           fieldRef:
@@ -1313,6 +1315,8 @@ spec:
       name: database
     - image: registry.access.redhat.com/ubi9/nginx-124:latest
       name: agent-proxy
+    - image: quay.io/cryostat/cryostat-agent-init:latest
+      name: agent-init
   version: 4.0.0-dev
   webhookdefinitions:
     - admissionReviewVersions:

--- a/config/default/image_tag_patch.yaml
+++ b/config/default/image_tag_patch.yaml
@@ -27,3 +27,5 @@ spec:
           value: "quay.io/cryostat/cryostat-db:latest"
         - name: RELATED_IMAGE_AGENT_PROXY
           value: "registry.access.redhat.com/ubi9/nginx-124:latest"
+        - name: RELATED_IMAGE_AGENT_INIT
+          value: "quay.io/cryostat/cryostat-agent-init:latest"

--- a/hack/image_tag_patch.yaml.in
+++ b/hack/image_tag_patch.yaml.in
@@ -27,3 +27,5 @@ spec:
           value: "${DATABASE_IMG}"
         - name: RELATED_IMAGE_AGENT_PROXY
           value: "${AGENT_PROXY_IMG}"
+        - name: RELATED_IMAGE_AGENT_INIT
+          value: "${AGENT_INIT_IMG}"


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #970
Depends on: #1041

## Description of the change:
* This was a piece missed in #991 that adds the configurable agent init image to the list of related images in the CSV.

## Motivation for the change:
* Needed for [disconnected](https://docs.openshift.com/container-platform/4.17/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-restricted-network_osdk-generating-csvs) installation of the operator

## How to manually test:
1. Build/deploy
2. CSV should have the expected relatedImages entry and corresponding environment variable in the deployment
