### PR TITLE
build(insights): add Kustomize patch to adjust pull policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -375,6 +375,7 @@ manifests: controller-gen ## Generate manifests e.g. CRD, RBAC, etc.
 	envsubst < hack/image_pull_patch.yaml.in > config/default/image_pull_patch.yaml
 	envsubst < hack/plugin_image_pull_patch.yaml.in > config/openshift/plugin_image_pull_patch.yaml
 	envsubst < hack/insights_patch.yaml.in > config/overlays/insights/insights_patch.yaml
+	envsubst < hack/insights_image_pull_patch.yaml.in > config/insights/insights_image_pull_patch.yaml
 
 .PHONY: fmt
 fmt: add-license ## Run go fmt against code.

--- a/config/insights/insights_image_pull_patch.yaml
+++ b/config/insights/insights_image_pull_patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: insights
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: insights
+        imagePullPolicy: "Always"

--- a/config/insights/kustomization.yaml
+++ b/config/insights/kustomization.yaml
@@ -23,6 +23,9 @@ resources:
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
 
+patchesStrategicMerge:
+- insights_image_pull_patch.yaml
+
 replacements:
 - source:
     fieldPath: metadata.name

--- a/hack/insights_image_pull_patch.yaml.in
+++ b/hack/insights_image_pull_patch.yaml.in
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: insights
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: insights
+        imagePullPolicy: "${PULL_POLICY}"


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #691 

## Description of the change:
* Adds a Kustomize patch to control pull policy in the same way we do for the operator controller and console plugin

## Motivation for the change:
* Makes pull policy consistent across images

## How to manually test:
1. `make bundle`
