### PR TITLE
fix(insights): correct environment variable order in overlay

### DIFF
--- a/config/overlays/insights/insights_manager_patch.yaml
+++ b/config/overlays/insights/insights_manager_patch.yaml
@@ -1,0 +1,11 @@
+# Modifies operator deployment to use Insights integration
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: INSIGHTS_ENABLED
+    value: "true"
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: INSIGHTS_URL
+    value: "http://insights-proxy.$(OPERATOR_NAMESPACE).svc.cluster.local:8080"

--- a/config/overlays/insights/insights_patch.yaml
+++ b/config/overlays/insights/insights_patch.yaml
@@ -16,19 +16,3 @@ spec:
           value: "console.redhat.com"
         - name: USER_AGENT_PREFIX
           value: "cryostat-operator/4.1.0-dev"
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: controller
-  namespace: system
-spec:
-  template:
-    spec:
-      containers:
-      - name: manager
-        env:
-        - name: INSIGHTS_ENABLED
-          value: "true"
-        - name: INSIGHTS_URL
-          value: "http://insights-proxy.$(OPERATOR_NAMESPACE).svc.cluster.local:8080"

--- a/config/overlays/insights/kustomization.yaml
+++ b/config/overlays/insights/kustomization.yaml
@@ -4,3 +4,12 @@ resources:
 
 patchesStrategicMerge:
 - insights_patch.yaml
+
+patchesJson6902:
+- path: insights_manager_patch.yaml
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: controller
+    namespace: system

--- a/hack/insights_patch.yaml.in
+++ b/hack/insights_patch.yaml.in
@@ -16,19 +16,3 @@ spec:
           value: "${INSIGHTS_BACKEND}"
         - name: USER_AGENT_PREFIX
           value: "cryostat-operator/${OPERATOR_VERSION}"
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: controller
-  namespace: system
-spec:
-  template:
-    spec:
-      containers:
-      - name: manager
-        env:
-        - name: INSIGHTS_ENABLED
-          value: "true"
-        - name: INSIGHTS_URL
-          value: "http://insights-proxy.$(OPERATOR_NAMESPACE).svc.cluster.local:8080"


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #1072 

## Description of the change:
* Adds a new JSON patch to append the Insights variables to the end of the environment variable array

## Motivation for the change:
* Allows the optional Insights integration to work again

## How to manually test:
1. `make bundle ENABLE_INSIGHTS=true`
2. Verify that the `OPERATOR_NAMESPACE` variable is defined before `INSIGHTS_URL`
