### PR TITLE
feat(agent): add toggle to allow insecure connections

### DIFF
--- a/api/v1beta2/cryostat_types.go
+++ b/api/v1beta2/cryostat_types.go
@@ -744,6 +744,10 @@ type AgentOptions struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Disable Hostname Verification",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	DisableHostnameVerification bool `json:"disableHostnameVerification,omitempty"`
+	// Allow insecure (non-TLS) HTTP connections to Cryostat Agents.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Allow Insecure Connections",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	AllowInsecure bool `json:"allowInsecure,omitempty"`
 	// The resources allocated to the init container used to inject the Cryostat agent,
 	// when using the operator's agent auto-configuration feature.
 	// +optional

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -24,7 +24,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:4.1.0-dev
-    createdAt: "2025-02-26T21:20:08Z"
+    createdAt: "2025-03-13T17:39:42Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {
@@ -92,6 +92,11 @@ spec:
           - description: Options to control how the operator configures Cryostat Agents to communicate with this Cryostat instance.
             displayName: Agent Options
             path: agentOptions
+          - description: Allow insecure (non-TLS) HTTP connections to Cryostat Agents.
+            displayName: Allow Insecure Connections
+            path: agentOptions.allowInsecure
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
           - description: Disables hostname verification when Cryostat connects to Agents over TLS. Consider enabling this if the Cryostat Agent fails to determine the hostname of your pod.
             displayName: Disable Hostname Verification
             path: agentOptions.disableHostnameVerification

--- a/bundle/manifests/operator.cryostat.io_cryostats.yaml
+++ b/bundle/manifests/operator.cryostat.io_cryostats.yaml
@@ -5393,6 +5393,10 @@ spec:
                   Options to control how the operator configures Cryostat Agents
                   to communicate with this Cryostat instance.
                 properties:
+                  allowInsecure:
+                    description: Allow insecure (non-TLS) HTTP connections to Cryostat
+                      Agents.
+                    type: boolean
                   disableHostnameVerification:
                     description: |-
                       Disables hostname verification when Cryostat connects to Agents over TLS.

--- a/config/crd/bases/operator.cryostat.io_cryostats.yaml
+++ b/config/crd/bases/operator.cryostat.io_cryostats.yaml
@@ -5380,6 +5380,10 @@ spec:
                   Options to control how the operator configures Cryostat Agents
                   to communicate with this Cryostat instance.
                 properties:
+                  allowInsecure:
+                    description: Allow insecure (non-TLS) HTTP connections to Cryostat
+                      Agents.
+                    type: boolean
                   disableHostnameVerification:
                     description: |-
                       Disables hostname verification when Cryostat connects to Agents over TLS.

--- a/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
@@ -80,6 +80,11 @@ spec:
           to communicate with this Cryostat instance.
         displayName: Agent Options
         path: agentOptions
+      - description: Allow insecure (non-TLS) HTTP connections to Cryostat Agents.
+        displayName: Allow Insecure Connections
+        path: agentOptions.allowInsecure
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Disables hostname verification when Cryostat connects to Agents
           over TLS. Consider enabling this if the Cryostat Agent fails to determine
           the hostname of your pod.

--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -1496,14 +1496,24 @@ func NewCoreContainer(cr *model.CryostatInstance, specs *ServiceSpecs, imageTag 
 	}
 	envs = append(envs, grafanaVars...)
 
-	if cr.Spec.AgentOptions != nil && cr.Spec.AgentOptions.DisableHostnameVerification {
-		envs = append(envs,
-			corev1.EnvVar{
-				// TODO This should eventually be replaced by an agent-specific toggle.
-				// See: https://github.com/cryostatio/cryostat/issues/778
-				Name:  "QUARKUS_REST_CLIENT_VERIFY_HOST",
-				Value: "false",
-			})
+	if cr.Spec.AgentOptions != nil {
+		if cr.Spec.AgentOptions.DisableHostnameVerification {
+			envs = append(envs,
+				corev1.EnvVar{
+					// TODO This should eventually be replaced by an agent-specific toggle.
+					// See: https://github.com/cryostatio/cryostat/issues/778
+					Name:  "QUARKUS_REST_CLIENT_VERIFY_HOST",
+					Value: "false",
+				})
+		}
+		if cr.Spec.AgentOptions.AllowInsecure {
+			envs = append(envs,
+				corev1.EnvVar{
+					Name:  "CRYOSTAT_AGENT_TLS_REQUIRED",
+					Value: "false",
+				},
+			)
+		}
 	}
 
 	// Mount the templates specified in Cryostat CR under /opt/cryostat.d/templates.d

--- a/internal/controllers/reconciler_test.go
+++ b/internal/controllers/reconciler_test.go
@@ -1886,7 +1886,7 @@ func (c *controllerTest) commonTests() {
 			Context("with insecure connections allowed", func() {
 				BeforeEach(func() {
 					t.objs = append(t.objs, t.NewCryostatWithAgentInsecureAllowed().Object)
-					t.DisableAgentHostnameVerify = true
+					t.AllowAgentInsecure = true
 				})
 				JustBeforeEach(func() {
 					t.reconcileCryostatFully()

--- a/internal/controllers/reconciler_test.go
+++ b/internal/controllers/reconciler_test.go
@@ -1883,6 +1883,18 @@ func (c *controllerTest) commonTests() {
 					t.expectMainDeployment()
 				})
 			})
+			Context("with insecure connections allowed", func() {
+				BeforeEach(func() {
+					t.objs = append(t.objs, t.NewCryostatWithAgentInsecureAllowed().Object)
+					t.DisableAgentHostnameVerify = true
+				})
+				JustBeforeEach(func() {
+					t.reconcileCryostatFully()
+				})
+				It("should configure deployment appropriately", func() {
+					t.expectMainDeployment()
+				})
+			})
 		})
 		Context("with an existing Cryostat CR", func() {
 			var otherInput *cryostatTestInput

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -56,6 +56,7 @@ type TestResources struct {
 	TargetNamespaces           []string
 	InsightsURL                string
 	DisableAgentHostnameVerify bool
+	AllowAgentInsecure         bool
 }
 
 func NewTestScheme() *runtime.Scheme {
@@ -997,6 +998,14 @@ func (r *TestResources) NewCryostatWithAgentHostnameVerifyDisabled() *model.Cryo
 	cr := r.NewCryostat()
 	cr.Spec.AgentOptions = &operatorv1beta2.AgentOptions{
 		DisableHostnameVerification: true,
+	}
+	return cr
+}
+
+func (r *TestResources) NewCryostatWithAgentInsecureAllowed() *model.CryostatInstance {
+	cr := r.NewCryostat()
+	cr.Spec.AgentOptions = &operatorv1beta2.AgentOptions{
+		AllowInsecure: true,
 	}
 	return cr
 }
@@ -2445,6 +2454,14 @@ func (r *TestResources) NewCoreEnvironmentVariables(reportsUrl string, ingress b
 		envs = append(envs,
 			corev1.EnvVar{
 				Name:  "QUARKUS_REST_CLIENT_VERIFY_HOST",
+				Value: "false",
+			})
+	}
+
+	if r.AllowAgentInsecure {
+		envs = append(envs,
+			corev1.EnvVar{
+				Name:  "CRYOSTAT_AGENT_TLS_REQUIRED",
 				Value: "false",
 			})
 	}


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

See #1011

## Description of the change:
Adds a simple toggle to set `cryostat.agent.tls.required=false`.

## Motivation for the change:
For manual (non-autoconfig) Agent setups, in testing or prototyping scenarios, it can be difficult or complicated to set up TLS fully. This toggle can be used to allow insecure HTTP Agent callback URLs again, since 4.0 enforces this requirement by default whereas prior Cryostat versions did not. This would also be required for agent autoconfiguration to work if cert-manager integration is disabled, though I haven't specifically tested that scenario yet and more might need to be done.

## How to manually test:
1. *Insert steps here...*
2. *...*
