### PR TITLE
fix(agent): don't require TLS when cert-manager is disabled

### DIFF
--- a/internal/webhooks/agent/pod_defaulter.go
+++ b/internal/webhooks/agent/pod_defaulter.go
@@ -301,7 +301,15 @@ func (r *podMutator) Default(ctx context.Context, obj runtime.Object) error {
 				Value: "cryostat",
 			},
 		)
+	} else {
+		// Allow the agent to connect to non-HTTPS Cryostat server
+		container.Env = append(container.Env,
+			corev1.EnvVar{
+				Name:  "CRYOSTAT_AGENT_WEBCLIENT_TLS_REQUIRED",
+				Value: "false",
+			})
 	}
+
 	// Inject agent using JAVA_TOOL_OPTIONS or specified variable, appending to any existing value
 	extended, err := extendJavaOptsVar(container.Env, getJavaOptionsVar(pod.Labels))
 	if err != nil {

--- a/internal/webhooks/agent/test/resources.go
+++ b/internal/webhooks/agent/test/resources.go
@@ -606,6 +606,13 @@ func (r *AgentWebhookTestResources) newMutatedContainer(original *corev1.Contain
 				MountPath: "/var/run/secrets/io.cryostat/cryostat-agent",
 				ReadOnly:  true,
 			})
+	} else {
+		container.Env = append(container.Env,
+			corev1.EnvVar{
+				Name:  "CRYOSTAT_AGENT_WEBCLIENT_TLS_REQUIRED",
+				Value: "false",
+			},
+		)
 	}
 
 	var callbackEnvs []corev1.EnvVar


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to: #1076

## Description of the change:
* Sets `CRYOSTAT_AGENT_WEBCLIENT_TLS_REQUIRED` to false when cert-manager is disabled

## Motivation for the change:
* Allows users to connect agents to Cryostat instances where cert-manager integration is disabled

