### PR TITLE
test(agent): fix failing pull policy test on release

### DIFF
--- a/internal/webhooks/agent/pod_defaulter_test.go
+++ b/internal/webhooks/agent/pod_defaulter_test.go
@@ -107,7 +107,6 @@ var _ = Describe("PodDefaulter", func() {
 					Expect(container.Env).To(Equal(expected.Env))
 					Expect(container.EnvFrom).To(Equal(expected.EnvFrom))
 					Expect(container.Image).To(HavePrefix(expected.Image[:strings.Index(expected.Image, ":")]))
-					Expect(container.ImagePullPolicy).To(Equal(expected.ImagePullPolicy))
 					Expect(container.VolumeMounts).To(Equal(expected.VolumeMounts))
 					Expect(container.SecurityContext).To(Equal(expected.SecurityContext))
 					Expect(container.Ports).To(Equal(expected.Ports))
@@ -277,6 +276,16 @@ var _ = Describe("PodDefaulter", func() {
 					})
 
 					ExpectPod()
+
+					It("should use Always pull policy", func() {
+						actual := t.getPod(expectedPod)
+						expectedInitContainers := expectedPod.Spec.InitContainers
+						Expect(actual.Spec.InitContainers).To(HaveLen(len(expectedInitContainers)))
+						for idx := range expectedInitContainers {
+							container := actual.Spec.InitContainers[idx]
+							Expect(container.ImagePullPolicy).To(Equal(corev1.PullAlways))
+						}
+					})
 				})
 
 				Context("for release", func() {
@@ -286,6 +295,16 @@ var _ = Describe("PodDefaulter", func() {
 					})
 
 					ExpectPod()
+
+					It("should use IfNotPresent pull policy", func() {
+						actual := t.getPod(expectedPod)
+						expectedInitContainers := expectedPod.Spec.InitContainers
+						Expect(actual.Spec.InitContainers).To(HaveLen(len(expectedInitContainers)))
+						for idx := range expectedInitContainers {
+							container := actual.Spec.InitContainers[idx]
+							Expect(container.ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
+						}
+					})
 				})
 			})
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to: #1081 

## Description of the change:
* Test image pull policy only for stubbed image tags

## Motivation for the change:
* Fixes the test failure when running on a release tag

## How to manually test:
1. `make test-envtest`
