### PR TITLE
test(samples): add liveness/readiness probes to sample apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -450,7 +450,7 @@ undeploy_sample_app_agent_injected: ## Undeploy sample app with Cryostat Agent d
 .PHONY: sample_app_agent_injected
 sample_app_agent_injected: undeploy_sample_app_agent_injected ## Deploy sample app with Cryostat Agent deployed by Operator injection.
 	$(CLUSTER_CLIENT) apply $(SAMPLE_APP_FLAGS) -f config/samples/sample-app-agent-injected.yaml
-	$(CLUSTER_CLIENT) patch --type=merge -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"cryostat.io/namespace\":\"${DEPLOY_NAMESPACE}\"}}}}}" deployment/quarkus-cryostat-agent
+	$(CLUSTER_CLIENT) patch --type=merge -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"cryostat.io/namespace\":\"${DEPLOY_NAMESPACE}\"}}}}}" deployment/quarkus-cryostat-agent-injected
 
 .PHONY: cert_manager
 cert_manager: remove_cert_manager ## Install cert manager.

--- a/config/samples/sample-app-agent-injected.yaml
+++ b/config/samples/sample-app-agent-injected.yaml
@@ -3,17 +3,17 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: quarkus-cryostat-agent
-  name: quarkus-cryostat-agent
+    app: quarkus-cryostat-agent-injected
+  name: quarkus-cryostat-agent-injected
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: quarkus-cryostat-agent
+      app: quarkus-cryostat-agent-injected
   template:
     metadata:
       labels:
-        app: quarkus-cryostat-agent
+        app: quarkus-cryostat-agent-injected
         cryostat.io/name: cryostat-sample
         cryostat.io/namespace: cryostat-operator-system
     spec:
@@ -26,14 +26,25 @@ spec:
             -Dio.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel=debug
         image: quay.io/redhat-java-monitoring/quarkus-cryostat-agent:latest
         imagePullPolicy: Always
-        name: quarkus-cryostat-agent
+        name: quarkus-cryostat-agent-injected
         ports:
         - containerPort: 10010
           protocol: TCP
+          name: app-http
         resources:
           limits:
             cpu: 500m
             memory: 256Mi
+        livenessProbe:
+          httpGet:
+            path: /hello-resteasy
+            port: app-http
+          initialDelaySeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /hello-resteasy
+            port: app-http
+          initialDelaySeconds: 3
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -47,11 +58,11 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: quarkus-cryostat-agent
-  name: quarkus-cryostat-agent
+    app: quarkus-cryostat-agent-injected
+  name: quarkus-cryostat-agent-injected
 spec:
   selector:
-    app: quarkus-cryostat-agent
+    app: quarkus-cryostat-agent-injected
   ports:
   - name: app-http
     port: 10010

--- a/config/samples/sample-app.yaml
+++ b/config/samples/sample-app.yaml
@@ -22,8 +22,10 @@ spec:
           ports:
           - containerPort: 10010
             protocol: TCP
+            name: app-http
           - containerPort: 9097
             protocol: TCP
+            name: jfr-jmx
           resources:
             requests:
               cpu: 200m
@@ -36,6 +38,16 @@ spec:
             capabilities:
               drop:
               - ALL
+          livenessProbe:
+            httpGet:
+              path: /hello-resteasy
+              port: app-http
+            initialDelaySeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /hello-resteasy
+              port: app-http
+            initialDelaySeconds: 3
       restartPolicy: Always
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to https://github.com/cryostatio/cryostat-agent/issues/634

## Description of the change:
Adds liveness and readiness probes to two of the sample app definitions. These are the two that represent the common cases - an Agent-less application that is discovered by Endpoints (EndpointSlice) and uses JMX, and an autoconfig-injected Agent.

## Motivation for the change:
Make these two sample app cases more representative of real production workloads which should be expected to use liveness and readiness probes.

## How to manually test:
1. Deploy Operator, create CR, etc. as usual
2. `make sample_app` and `make sample_app_agent_injected` as usual, ensuring that discovery for both works as usual and that Kubernetes reports both as alive and ready to accept traffic. Check the injected Agent's logs in the application Pod and observe that initially, the Agent fails to resolve its own callback URL (hostname), but once the pod probes succeed then the Agent becomes able to resolve itself and proceeds with Cryostat registration.
