### PR TITLE
fix(reports): correct reports service URL configuration key

### DIFF
--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -24,7 +24,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:4.1.0-dev
-    createdAt: "2025-03-13T17:39:42Z"
+    createdAt: "2025-04-25T12:49:59Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {

--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -1397,7 +1397,7 @@ func NewCoreContainer(cr *model.CryostatInstance, specs *ServiceSpecs, imageTag 
 	if specs.ReportsURL != nil {
 		reportsEnvs := []corev1.EnvVar{
 			{
-				Name:  "CRYOSTAT_SERVICES_REPORTS_URL",
+				Name:  "QUARKUS_REST_CLIENT_REPORTS_URL",
 				Value: specs.ReportsURL.String(),
 			},
 		}

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -2445,7 +2445,7 @@ func (r *TestResources) NewCoreEnvironmentVariables(reportsUrl string, ingress b
 	if reportsUrl != "" {
 		envs = append(envs,
 			corev1.EnvVar{
-				Name:  "CRYOSTAT_SERVICES_REPORTS_URL",
+				Name:  "QUARKUS_REST_CLIENT_REPORTS_URL",
 				Value: reportsUrl,
 			})
 	}


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #1100

## Description of the change:
Corrects the configuration key (environment variable name) that the Operator sets to inform Cryostat about the URL for the report generator sidecar service.

## Motivation for the change:
The key currently used is outdated and no longer used, so Cryostat ignores it and handles report generation on its own rather than shifting it onto the report generator instance(s). This means that report generator configuration is currently useless.

## How to manually test:
1. Check out and build PR
2. Deploy Operator, create Cryostat CR with `reportOptions: { replicas: 1 }`
3. `make sample_app` in a target namespace
4. Wait for everything to come up, then open the Cryostat UI and request a target analysis on the sample app, or request analysis of an archived recording.
5. Check the reports Pod logs and ensure that an HTTP access log line appears corresponding to a `POST` request to handle a report.
6. Currently, the requests will fail with an HTTP 502 due to https://github.com/cryostatio/cryostat/pull/856 . ~~Separate fix incoming. This one needs to be backported, that one will not.~~ Separate fix: https://github.com/cryostatio/cryostat-reports/pull/345