### PR TITLE
test(scorecard): verify database and storage deployment availability

### DIFF
--- a/internal/test/scorecard/common_utils.go
+++ b/internal/test/scorecard/common_utils.go
@@ -360,6 +360,21 @@ func (r *TestResources) createAndWaitTillCryostatAvailable(cr *operatorv1beta2.C
 	// Poll the deployment until it becomes available or we timeout
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
+
+	// The database component should be available
+	err = r.waitForDeploymentAvailability(ctx, r.Name+"-database", r.Namespace)
+	if err != nil {
+		r.logError(fmt.Sprintf("Cryostat database deployment did not become available: %s", err.Error()))
+		return nil, err
+	}
+
+	// The storage component should be available
+	err = r.waitForDeploymentAvailability(ctx, r.Name+"-storage", r.Namespace)
+	if err != nil {
+		r.logError(fmt.Sprintf("Cryostat storage deployment did not become available: %s", err.Error()))
+		return nil, err
+	}
+
 	err = r.waitForDeploymentAvailability(ctx, r.Name, r.Namespace)
 	if err != nil {
 		r.logError(fmt.Sprintf("Cryostat main deployment did not become available: %s", err.Error()))


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Follow-up: #814 

## Description of the change:

As of v4.0 (i.e. after #814), the main deployment is split into main, database and storage. Thus, scorecard test needs to adapt to wait for the database and storage deployment availability before proceeding further in tests.

The fix is included in commit: https://github.com/cryostatio/cryostat-operator/commit/0cf7dba526b5168e9d6a64c9818a5d6357e6ef5b. I added some clean-up a separate one.



## Motivation for the change:

See https://github.com/cryostatio/cryostat-operator/pull/1101#issuecomment-2839479502