### PR TITLE
feat(deploy): add secret/config map hash to pod templates

### DIFF
--- a/internal/controllers/configmaps.go
+++ b/internal/controllers/configmaps.go
@@ -136,7 +136,7 @@ func (r *Reconciler) reconcileOAuth2ProxyConfig(ctx context.Context, cr *model.C
 	if r.IsOpenShift {
 		return r.deleteConfigMap(ctx, cm)
 	} else {
-		json, err := json.Marshal(cfg)
+		json, err := json.MarshalIndent(cfg, "", "  ")
 		if err != nil {
 			return err
 		}

--- a/internal/controllers/reconciler.go
+++ b/internal/controllers/reconciler.go
@@ -593,6 +593,12 @@ func (r *Reconciler) updateConditionsFromDeployment(ctx context.Context, cr *mod
 var errSelectorModified error = errors.New("deployment selector has been modified")
 
 func (r *Reconciler) createOrUpdateDeployment(ctx context.Context, deploy *appsv1.Deployment, owner metav1.Object) error {
+	// Annotate the deployment with hashes for any referenced secrets/config maps
+	err := common.AnnotateWithObjRefHashes(ctx, r.Client, deploy.Namespace, &deploy.Spec.Template)
+	if err != nil {
+		return err
+	}
+	// Make a copy of the new desired deployment
 	deployCopy := deploy.DeepCopy()
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, deploy, func() error {
 		// Merge any required labels and annotations


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #119 

## Description of the change:
1. For each operand pod, collect all secrets and config maps used in volumes and environment variables
2. In alphanumeric order, marshal each secret/config map's key-value pairs as JSON, and concatenate the results
3. Hash the concatenated JSON. For secrets, use SHA256. For config maps, use FNV-1, which is faster for non-sensitive data.
4. Add the hashes as annotations to the appropriate pod template.

Other changes:
* Format/indent the OAuth2 proxy config map for readability
* Indentation changes for configmap/secret data in test files. Since we're hashing these, indentation matters for the resulting hashes.
* Modified the test client to move each secret's `StringData` field to `Data` upon write. This mirrors what's done by a real API server.

## Motivation for the change:
* Cryostat setups don't stop working when certificates are renewed by cert-manager.

## How to manually test:
1. Build and deploy PR with a default CR
2. Download `cmutil`: https://github.com/cert-manager/cmctl/releases/tag/v2.2.0
3. Manually renew a certificate: `/path/to/cmctl renew cryostat-sample`
4. Verify that a new Cryostat pod has been rolled out. The same approach can be used for database/storage/reports pods.