### PR TITLE
fix(agent): pass log level as part of javaagent arg

### DIFF
--- a/internal/webhooks/agent/pod_defaulter.go
+++ b/internal/webhooks/agent/pod_defaulter.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
-	"strings"
 	"time"
 
 	operatorv1beta2 "github.com/cryostatio/cryostat-operator/api/v1beta2"
@@ -50,7 +49,7 @@ var _ admission.CustomDefaulter = &podMutator{}
 
 const (
 	agentArg                    = "-javaagent:/tmp/cryostat-agent/cryostat-agent-shaded.jar"
-	agentLogLevelProp           = "-Dio.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel"
+	agentLogLevelProp           = "io.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel"
 	podNameEnvVar               = "CRYOSTAT_AGENT_POD_NAME"
 	podIPEnvVar                 = "CRYOSTAT_AGENT_POD_IP"
 	agentMaxSizeBytes           = "50Mi"
@@ -517,11 +516,7 @@ func extendJavaOptsVar(envs []corev1.EnvVar, javaOptsVar string, logLevel string
 		return nil, err
 	}
 
-	agentArgLine :=
-		strings.Join([]string{
-			agentArg,
-			fmt.Sprintf("%s=%s", agentLogLevelProp, logLevel),
-		}, " ")
+	agentArgLine := fmt.Sprintf("%s=%s=%s", agentArg, agentLogLevelProp, logLevel)
 	if existing != nil {
 		existing.Value += " " + agentArgLine
 	} else {

--- a/internal/webhooks/agent/test/resources.go
+++ b/internal/webhooks/agent/test/resources.go
@@ -535,7 +535,7 @@ func (r *AgentWebhookTestResources) newMutatedContainer(original *corev1.Contain
 			},
 			{
 				Name:  options.javaOptionsName,
-				Value: options.javaOptionsValue + fmt.Sprintf("-javaagent:/tmp/cryostat-agent/cryostat-agent-shaded.jar -Dio.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel=%s", options.logLevel),
+				Value: options.javaOptionsValue + fmt.Sprintf("-javaagent:/tmp/cryostat-agent/cryostat-agent-shaded.jar=io.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel=%s", options.logLevel),
 			},
 		}...),
 		Ports: []corev1.ContainerPort{


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #1119 

## Description of the change:
* Pass the log level system property with the `javaagent` argument

## Motivation for the change:
* Allows Wildfly to work with agent auto-configuration again

## How to manually test:
1. Deploy a Wildfly [sample app](https://github.com/cryostatio/test-applications/tree/main/wildfly/28)
2. Set agent auto-configuration labels along with `cryostat.io/java-options-var: MODULE_OPTS`
3. Wildfly should start with the Cryostat agent (log level is not yet fully respected)
