### PR TITLE
feat(fips): detect FIPS clusters and use TLSv1.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY internal/main.go internal/main.go
 COPY api/ api/
 COPY internal/controllers/ internal/controllers/
 COPY internal/console/ internal/console/
+COPY internal/fips/ internal/fips/
 COPY internal/webhooks/ internal/webhooks/
 
 # Build

--- a/internal/controllers/reconciler.go
+++ b/internal/controllers/reconciler.go
@@ -63,6 +63,7 @@ type ReconcilerConfig struct {
 	EventRecorder          record.EventRecorder
 	RESTMapper             meta.RESTMapper
 	InsightsProxy          *url.URL // Only defined if Insights is enabled
+	FIPSEnabled            bool
 	NewControllerBuilder   func(ctrl.Manager) common.ControllerBuilder
 	common.ReconcilerTLS
 	common.OSUtils

--- a/internal/fips/fips.go
+++ b/internal/fips/fips.go
@@ -1,0 +1,45 @@
+// Copyright The Cryostat Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fips
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var fipsInstallConfigRegex = regexp.MustCompile(`(?m)^\s*fips:\s*true\s*$`)
+
+func IsFIPS(reader client.Reader) (bool, error) {
+	cm := &corev1.ConfigMap{}
+
+	// Query cluster-config-v1 config map for FIPS mode
+	// https://access.redhat.com/solutions/6525331
+	err := reader.Get(context.Background(), types.NamespacedName{Name: "cluster-config-v1", Namespace: "kube-system"}, cm)
+	if err != nil {
+		return false, err
+	}
+
+	config, pres := cm.Data["install-config"]
+	if !pres {
+		return false, fmt.Errorf("%s config map has no \"install-config\" key", cm.Name)
+	}
+
+	return fipsInstallConfigRegex.MatchString(config), nil
+}

--- a/internal/fips/fips_suite_test.go
+++ b/internal/fips/fips_suite_test.go
@@ -1,0 +1,91 @@
+// Copyright The Cryostat Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fips_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	//+kubebuilder:scaffold:imports
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var ctx context.Context
+var cancel context.CancelFunc
+var k8sScheme *runtime.Scheme
+var logger logr.Logger
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Console Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logger = zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true))
+	logf.SetLogger(logger)
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
+	}
+
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sScheme = runtime.NewScheme()
+	sb := runtime.NewSchemeBuilder(
+		scheme.AddToScheme,
+	)
+	err = sb.AddToScheme(k8sScheme)
+	Expect(err).ToNot(HaveOccurred())
+
+	// +kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: k8sScheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/internal/fips/fips_test.go
+++ b/internal/fips/fips_test.go
@@ -1,0 +1,122 @@
+// Copyright The Cryostat Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fips_test
+
+import (
+	"strconv"
+
+	"github.com/cryostatio/cryostat-operator/internal/fips"
+	fipstests "github.com/cryostatio/cryostat-operator/internal/fips/test"
+	"github.com/cryostatio/cryostat-operator/internal/test"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+type fipsTestInput struct {
+	client ctrlclient.Client
+	objs   []ctrlclient.Object
+	*fipstests.FIPSTestResources
+}
+
+var _ = Describe("FIPS", func() {
+	var t *fipsTestInput
+	count := 0
+
+	namespaceWithSuffix := func(name string) string {
+		return name + "-fips-" + strconv.Itoa(count)
+	}
+
+	BeforeEach(func() {
+		ns := namespaceWithSuffix("test")
+		t = &fipsTestInput{
+			FIPSTestResources: &fipstests.FIPSTestResources{
+				TestResources: &test.TestResources{
+					Name:             "cryostat",
+					Namespace:        ns,
+					TargetNamespaces: []string{ns},
+					TLS:              true,
+				},
+			},
+		}
+		t.objs = []ctrlclient.Object{
+			t.NewNamespace(),
+		}
+	})
+
+	JustBeforeEach(func() {
+		logger := zap.New()
+		logf.SetLogger(logger)
+
+		t.client = k8sClient
+		for _, obj := range t.objs {
+			err := t.client.Create(ctx, obj)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+
+	JustAfterEach(func() {
+		for _, obj := range t.objs {
+			err := ctrlclient.IgnoreNotFound(t.client.Delete(ctx, obj))
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+
+	AfterEach(func() {
+		count++
+	})
+
+	Context("detecting FIPS mode", func() {
+		Context("on FIPS cluster", func() {
+			BeforeEach(func() {
+				t.objs = append(t.objs, t.NewClusterConfigFIPS())
+			})
+			It("should return true", func() {
+				result, err := fips.IsFIPS(k8sClient)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(BeTrue())
+			})
+		})
+		Context("on non-FIPS cluster", func() {
+			BeforeEach(func() {
+				t.objs = append(t.objs, t.NewClusterConfigNoFIPS())
+			})
+			It("should return false", func() {
+				result, err := fips.IsFIPS(k8sClient)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+		})
+		Context("with missing config map", func() {
+			It("should return an error", func() {
+				_, err := fips.IsFIPS(k8sClient)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		Context("with missing install-config", func() {
+			BeforeEach(func() {
+				t.objs = append(t.objs, t.NewClusterConfigBad())
+			})
+			It("should return an error", func() {
+				_, err := fips.IsFIPS(k8sClient)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+})

--- a/internal/fips/test/resources.go
+++ b/internal/fips/test/resources.go
@@ -1,0 +1,93 @@
+// Copyright The Cryostat Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"fmt"
+
+	"github.com/cryostatio/cryostat-operator/internal/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type FIPSTestResources struct {
+	*test.TestResources
+}
+
+const installConfig = `additionalTrustBundlePolicy: Proxyonly
+apiVersion: v1
+baseDomain: cluster.example.com
+compute:
+- architecture: amd64
+  hyperthreading: Enabled
+  name: worker
+  platform: {}
+  replicas: 3
+controlPlane:
+  architecture: amd64
+  hyperthreading: Enabled
+  name: master
+  platform: {}
+  replicas: 3
+%smetadata:
+  creationTimestamp: null
+  name: cluster
+networking:
+  clusterNetwork:
+  - cidr: 0.0.0.0/32
+    hostPrefix: 32
+  machineNetwork:
+  - cidr: 0.0.0.0/32
+  networkType: OVNKubernetes
+  serviceNetwork:
+  - 0.0.0.0/32
+platform: {}
+publish: External
+pullSecret: ""
+sshKey: |
+  ssh-rsa foo`
+
+func (r *FIPSTestResources) NewClusterConfigFIPS() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-config-v1",
+			Namespace: "kube-system",
+		},
+		Data: map[string]string{
+			"install-config": fmt.Sprintf(installConfig, "fips: true\n"),
+		},
+	}
+}
+
+func (r *FIPSTestResources) NewClusterConfigNoFIPS() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-config-v1",
+			Namespace: "kube-system",
+		},
+		Data: map[string]string{
+			"install-config": fmt.Sprintf(installConfig, ""),
+		},
+	}
+}
+
+func (r *FIPSTestResources) NewClusterConfigBad() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-config-v1",
+			Namespace: "kube-system",
+		},
+	}
+}

--- a/internal/webhooks/agent/pod_defaulter.go
+++ b/internal/webhooks/agent/pod_defaulter.go
@@ -312,6 +312,20 @@ func (r *podMutator) Default(ctx context.Context, obj runtime.Object) error {
 			})
 	}
 
+	if r.config.FIPSEnabled {
+		// Force usage for TLSv1.3 for FIPS compatibility
+		container.Env = append(container.Env,
+			corev1.EnvVar{
+				Name:  "CRYOSTAT_AGENT_WEBCLIENT_TLS_VERSION",
+				Value: "TLSv1.3",
+			},
+			corev1.EnvVar{
+				Name:  "CRYOSTAT_AGENT_WEBSERVER_TLS_VERSION",
+				Value: "TLSv1.3",
+			},
+		)
+	}
+
 	// Inject agent using JAVA_TOOL_OPTIONS or specified variable, appending to any existing value
 	extended, err := extendJavaOptsVar(container.Env, getJavaOptionsVar(pod.Labels), getLogLevel(pod.Labels))
 	if err != nil {

--- a/internal/webhooks/agent/pod_defaulter_test.go
+++ b/internal/webhooks/agent/pod_defaulter_test.go
@@ -529,6 +529,23 @@ var _ = Describe("PodDefaulter", func() {
 					ExpectPod()
 				})
 			})
+
+			Context("on a FIPS cluster", func() {
+				BeforeEach(func() {
+					agentWebhookConfig.FIPSEnabled = true
+					t.IsFIPS = true
+
+					t.objs = append(t.objs, t.NewCryostat().Object)
+					originalPod = t.NewPod()
+					expectedPod = t.NewMutatedPod()
+				})
+
+				AfterEach(func() {
+					agentWebhookConfig.FIPSEnabled = false
+				})
+
+				ExpectPod()
+			})
 		})
 
 		Context("with a missing Cryostat CR", func() {

--- a/internal/webhooks/agent/pod_webhook.go
+++ b/internal/webhooks/agent/pod_webhook.go
@@ -40,6 +40,7 @@ type AgentWebhook interface {
 
 type AgentWebhookConfig struct {
 	InitImageTag *string
+	FIPSEnabled  bool
 	common.OSUtils
 }
 

--- a/internal/webhooks/agent/test/resources.go
+++ b/internal/webhooks/agent/test/resources.go
@@ -28,6 +28,7 @@ import (
 )
 
 type AgentWebhookTestResources struct {
+	IsFIPS bool
 	*test.TestResources
 }
 
@@ -629,6 +630,20 @@ func (r *AgentWebhookTestResources) newMutatedContainer(original *corev1.Contain
 				Value: "false",
 			},
 		)
+	}
+
+	if r.IsFIPS {
+		fipsEnvs := []corev1.EnvVar{
+			{
+				Name:  "CRYOSTAT_AGENT_WEBCLIENT_TLS_VERSION",
+				Value: "TLSv1.3",
+			},
+			{
+				Name:  "CRYOSTAT_AGENT_WEBSERVER_TLS_VERSION",
+				Value: "TLSv1.3",
+			},
+		}
+		container.Env = append(container.Env, fipsEnvs...)
 	}
 
 	var callbackEnvs []corev1.EnvVar


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to: #1153 

## Description of the change:
* Detects if running on a FIPS-enabled OpenShift cluster
* If so, force agent auto-configuration to use TLSv1.3

## Motivation for the change:
* This resolves an issue on FIPS clusters where the agents can't communicate with Cryostat

## How to manually test:
1. Provision a FIPS cluster
2. Build and deploy this PR, create a default Cryostat
3. Deploy auto-config sample app
