### PR TITLE
feat(deploy): apply default resource limits

### DIFF
--- a/api/v1beta2/cryostat_types.go
+++ b/api/v1beta2/cryostat_types.go
@@ -74,7 +74,9 @@ type CryostatSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Target Connection Cache Options"
 	TargetConnectionCacheOptions *TargetConnectionCacheOptions `json:"targetConnectionCacheOptions,omitempty"`
-	// Resource requirements for the Cryostat deployment.
+	// Resource requirements for the Cryostat deployment. Default resource requests will be added to each
+	// container unless specified. Default resource limits will be added to each container if neither
+	// resource requests or limits are specified.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	Resources *ResourceConfigList `json:"resources,omitempty"`
@@ -285,6 +287,8 @@ type ReportConfiguration struct {
 	Replicas int32 `json:"replicas,omitempty"`
 	// The resources allocated to each sidecar replica.
 	// A replica with more resources can handle larger input recordings and will process them faster.
+	// Default resource requests will be added to the container unless specified.
+	// Default resource limits will be added to each container if neither resource requests or limits are specified.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
@@ -771,6 +775,8 @@ type AgentOptions struct {
 	AllowInsecure bool `json:"allowInsecure,omitempty"`
 	// The resources allocated to the init container used to inject the Cryostat agent,
 	// when using the operator's agent auto-configuration feature.
+	// Default resource requests will be added to the init container unless specified.
+	// Default resource limits will be added to the init container if neither resource requests or limits are specified.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -24,7 +24,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:4.1.0-dev
-    createdAt: "2025-08-26T20:58:33Z"
+    createdAt: "2025-09-22T20:35:39Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {
@@ -102,7 +102,7 @@ spec:
             path: agentOptions.disableHostnameVerification
             x-descriptors:
               - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-          - description: The resources allocated to the init container used to inject the Cryostat agent, when using the operator's agent auto-configuration feature.
+          - description: The resources allocated to the init container used to inject the Cryostat agent, when using the operator's agent auto-configuration feature. Default resource requests will be added to the init container unless specified. Default resource limits will be added to the init container if neither resource requests or limits are specified.
             displayName: Resources
             path: agentOptions.resources
             x-descriptors:
@@ -272,7 +272,7 @@ spec:
             path: reportOptions.replicas
             x-descriptors:
               - urn:alm:descriptor:com.tectonic.ui:podCount
-          - description: The resources allocated to each sidecar replica. A replica with more resources can handle larger input recordings and will process them faster.
+          - description: The resources allocated to each sidecar replica. A replica with more resources can handle larger input recordings and will process them faster. Default resource requests will be added to the container unless specified. Default resource limits will be added to each container if neither resource requests or limits are specified.
             displayName: Resources
             path: reportOptions.resources
             x-descriptors:
@@ -322,7 +322,7 @@ spec:
             path: reportOptions.subProcessMaxHeapSize
             x-descriptors:
               - urn:alm:descriptor:com.tectonic.ui:number
-          - description: Resource requirements for the Cryostat deployment.
+          - description: Resource requirements for the Cryostat deployment. Default resource requests will be added to each container unless specified. Default resource limits will be added to each container if neither resource requests or limits are specified.
             displayName: Resources
             path: resources
           - description: Resource requirements for the agent proxy container.

--- a/bundle/manifests/operator.cryostat.io_cryostats.yaml
+++ b/bundle/manifests/operator.cryostat.io_cryostats.yaml
@@ -5406,6 +5406,8 @@ spec:
                     description: |-
                       The resources allocated to the init container used to inject the Cryostat agent,
                       when using the operator's agent auto-configuration feature.
+                      Default resource requests will be added to the init container unless specified.
+                      Default resource limits will be added to the init container if neither resource requests or limits are specified.
                     properties:
                       claims:
                         description: |-
@@ -6010,6 +6012,8 @@ spec:
                     description: |-
                       The resources allocated to each sidecar replica.
                       A replica with more resources can handle larger input recordings and will process them faster.
+                      Default resource requests will be added to the container unless specified.
+                      Default resource limits will be added to each container if neither resource requests or limits are specified.
                     properties:
                       claims:
                         description: |-
@@ -7452,7 +7456,10 @@ spec:
                     type: integer
                 type: object
               resources:
-                description: Resource requirements for the Cryostat deployment.
+                description: |-
+                  Resource requirements for the Cryostat deployment. Default resource requests will be added to each
+                  container unless specified. Default resource limits will be added to each container if neither
+                  resource requests or limits are specified.
                 properties:
                   agentProxyResources:
                     description: Resource requirements for the agent proxy container.

--- a/config/crd/bases/operator.cryostat.io_cryostats.yaml
+++ b/config/crd/bases/operator.cryostat.io_cryostats.yaml
@@ -5393,6 +5393,8 @@ spec:
                     description: |-
                       The resources allocated to the init container used to inject the Cryostat agent,
                       when using the operator's agent auto-configuration feature.
+                      Default resource requests will be added to the init container unless specified.
+                      Default resource limits will be added to the init container if neither resource requests or limits are specified.
                     properties:
                       claims:
                         description: |-
@@ -5997,6 +5999,8 @@ spec:
                     description: |-
                       The resources allocated to each sidecar replica.
                       A replica with more resources can handle larger input recordings and will process them faster.
+                      Default resource requests will be added to the container unless specified.
+                      Default resource limits will be added to each container if neither resource requests or limits are specified.
                     properties:
                       claims:
                         description: |-
@@ -7439,7 +7443,10 @@ spec:
                     type: integer
                 type: object
               resources:
-                description: Resource requirements for the Cryostat deployment.
+                description: |-
+                  Resource requirements for the Cryostat deployment. Default resource requests will be added to each
+                  container unless specified. Default resource limits will be added to each container if neither
+                  resource requests or limits are specified.
                 properties:
                   agentProxyResources:
                     description: Resource requirements for the agent proxy container.

--- a/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
@@ -94,6 +94,9 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: The resources allocated to the init container used to inject
           the Cryostat agent, when using the operator's agent auto-configuration feature.
+          Default resource requests will be added to the init container unless specified.
+          Default resource limits will be added to the init container if neither resource
+          requests or limits are specified.
         displayName: Resources
         path: agentOptions.resources
         x-descriptors:
@@ -311,7 +314,9 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:podCount
       - description: The resources allocated to each sidecar replica. A replica with
           more resources can handle larger input recordings and will process them
-          faster.
+          faster. Default resource requests will be added to the container unless
+          specified. Default resource limits will be added to each container if neither
+          resource requests or limits are specified.
         displayName: Resources
         path: reportOptions.resources
         x-descriptors:
@@ -367,7 +372,10 @@ spec:
         path: reportOptions.subProcessMaxHeapSize
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - description: Resource requirements for the Cryostat deployment.
+      - description: Resource requirements for the Cryostat deployment. Default resource
+          requests will be added to each container unless specified. Default resource
+          limits will be added to each container if neither resource requests or limits
+          are specified.
         displayName: Resources
         path: resources
       - description: Resource requirements for the agent proxy container.

--- a/docs/config.md
+++ b/docs/config.md
@@ -152,33 +152,36 @@ spec:
     subProcessMaxHeapSize: 200
 ```
 
-If the sidecar's resource requests are not specified, they are set with the following defaults:
+If the sidecar's resource requests/limits are not specified, they are set with the following defaults:
 
-| Request | Quantity |
-|---------|----------|
-| Reports Container CPU | 500m |
-| Reports Container Memory | 512Mi |
+| Resource | Requests | Limits |
+|---------|----------|--------|
+| Reports Container CPU | 500m | 1000m |
+| Reports Container Memory | 512Mi | 1Gi |
 
 
 ### Resource Requirements
-By default, the operator deploys Cryostat with pre-configured resource requests:
+By default, the operator deploys Cryostat with pre-configured resource requests/limits:
 
-| Request | Quantity |
-|---------|----------|
-| Auth Proxy container CPU | 25m |
-| Auth Proxy container Memory | 64Mi |
-| Cryostat container CPU | 500m |
-| Cryostat container Memory | 384Mi |
-| JFR Data Source container CPU | 200m |
-| JFR Data Source container Memory | 200Mi |
-| Grafana container CPU | 25m |
-| Grafana container Memory | 80Mi |
-| Database container CPU | 25m |
-| Database container Memory | 64Mi |
-| Storage container CPU | 50m |
-| Storage container Memory | 256Mi |
+| Resource | Requests | Limits |
+|---------|----------|--------|
+| Agent Proxy container CPU | 25m | 50m |
+| Agent Proxy container Memory | 64Mi | 200Mi |
+| Auth Proxy container CPU | 25m | 50m |
+| Auth Proxy container Memory | 64Mi | 128Mi |
+| Cryostat container CPU | 500m | 1000m |
+| Cryostat container Memory | 384Mi | 1Gi |
+| JFR Data Source container CPU | 200m | 400m |
+| JFR Data Source container Memory | 200Mi | 500Mi |
+| Grafana container CPU | 25m | 50m |
+| Grafana container Memory | 80Mi | 200Mi |
+| Database container CPU | 25m | 50m |
+| Database container Memory | 64Mi | 200Mi |
+| Storage container CPU | 50m | 100m |
+| Storage container Memory | 256Mi | 512Mi |
 
 Using the Cryostat custom resource, you can define resources requests and/or limits for each of the containers in Cryostat's main pod:
+- the `agent-proxy` container running the nginx reverse proxy, which allows agents to communicate with Cryostat.
 - the `auth-proxy` container running the oauth2-proxy, which performs authorization checks, and is placed in front of the operand containers.
 - the `core` container running the Cryostat backend and web application. If setting a memory limit for this container, we recommend at least 768MiB.
 - the `datasource` container running JFR Data Source, which converts recordings into a Grafana-compatible format.
@@ -192,6 +195,13 @@ metadata:
   name: cryostat-sample
 spec:
   resources:
+    agentProxyResources:
+      requests:
+        cpu: 800m
+        memory: 256Mi
+      limits:
+        cpu: 1000m
+        memory: 512Mi
     authProxyResources:
       requests:
         cpu: 800m
@@ -233,7 +243,7 @@ spec:
         memory: 512Mi
       limits:
         cpu: 1000m
-        memory: 768 Mi
+        memory: 768Mi
 ```
 This example sets CPU and memory requests and limits for each container, but you may choose to define any combination of requests and limits that suits your use case.
 

--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -77,20 +77,36 @@ type TLSConfig struct {
 const (
 	defaultAuthProxyCpuRequest        string = "25m"
 	defaultAuthProxyMemoryRequest     string = "64Mi"
+	defaultAuthProxyCpuLimit          string = "50m"
+	defaultAuthProxyMemoryLimit       string = "128Mi"
 	defaultCoreCpuRequest             string = "500m"
 	defaultCoreMemoryRequest          string = "384Mi"
+	defaultCoreCpuLimit               string = "1000m"
+	defaultCoreMemoryLimit            string = "1Gi"
 	defaultJfrDatasourceCpuRequest    string = "200m"
 	defaultJfrDatasourceMemoryRequest string = "200Mi"
+	defaultJfrDatasourceCpuLimit      string = "400m"
+	defaultJfrDatasourceMemoryLimit   string = "500Mi"
 	defaultGrafanaCpuRequest          string = "25m"
 	defaultGrafanaMemoryRequest       string = "80Mi"
+	defaultGrafanaCpuLimit            string = "50m"
+	defaultGrafanaMemoryLimit         string = "200Mi"
 	defaultDatabaseCpuRequest         string = "25m"
 	defaultDatabaseMemoryRequest      string = "64Mi"
+	defaultDatabaseCpuLimit           string = "50m"
+	defaultDatabaseMemoryLimit        string = "200Mi"
 	defaultStorageCpuRequest          string = "50m"
 	defaultStorageMemoryRequest       string = "256Mi"
+	defaultStorageCpuLimit            string = "100m"
+	defaultStorageMemoryLimit         string = "512Mi"
 	defaultReportCpuRequest           string = "500m"
 	defaultReportMemoryRequest        string = "512Mi"
+	defaultReportCpuLimit             string = "1000m"
+	defaultReportMemoryLimit          string = "1Gi"
 	defaultAgentProxyCpuRequest       string = "25m"
 	defaultAgentProxyMemoryRequest    string = "64Mi"
+	defaultAgentProxyCpuLimit         string = "50m"
+	defaultAgentProxyMemoryLimit      string = "200Mi"
 	OAuth2ConfigFileName              string = "alpha_config.json"
 	OAuth2ConfigFilePath              string = "/etc/oauth2_proxy/alpha_config"
 	DatabaseName                      string = "cryostat"
@@ -825,7 +841,8 @@ func NewReportContainerResource(cr *model.CryostatInstance) *corev1.ResourceRequ
 	if cr.Spec.ReportOptions != nil {
 		resources = cr.Spec.ReportOptions.Resources.DeepCopy()
 	}
-	common.PopulateResourceRequest(resources, defaultReportCpuRequest, defaultReportMemoryRequest)
+	common.PopulateResourceRequest(resources, defaultReportCpuRequest, defaultReportMemoryRequest,
+		defaultReportCpuLimit, defaultReportMemoryLimit)
 	return resources
 }
 
@@ -1054,7 +1071,8 @@ func NewAuthProxyContainerResource(cr *model.CryostatInstance) *corev1.ResourceR
 	if cr.Spec.Resources != nil {
 		resources = cr.Spec.Resources.AuthProxyResources.DeepCopy()
 	}
-	common.PopulateResourceRequest(resources, defaultAuthProxyCpuRequest, defaultAuthProxyMemoryRequest)
+	common.PopulateResourceRequest(resources, defaultAuthProxyCpuRequest, defaultAuthProxyMemoryRequest,
+		defaultAuthProxyCpuLimit, defaultAuthProxyMemoryLimit)
 	return resources
 }
 
@@ -1326,7 +1344,8 @@ func NewCoreContainerResource(cr *model.CryostatInstance) *corev1.ResourceRequir
 	if cr.Spec.Resources != nil {
 		resources = cr.Spec.Resources.CoreResources.DeepCopy()
 	}
-	common.PopulateResourceRequest(resources, defaultCoreCpuRequest, defaultCoreMemoryRequest)
+	common.PopulateResourceRequest(resources, defaultCoreCpuRequest, defaultCoreMemoryRequest,
+		defaultCoreCpuLimit, defaultCoreMemoryLimit)
 	return resources
 }
 
@@ -1697,7 +1716,8 @@ func NewGrafanaContainerResource(cr *model.CryostatInstance) *corev1.ResourceReq
 	if cr.Spec.Resources != nil {
 		resources = cr.Spec.Resources.GrafanaResources.DeepCopy()
 	}
-	common.PopulateResourceRequest(resources, defaultGrafanaCpuRequest, defaultGrafanaMemoryRequest)
+	common.PopulateResourceRequest(resources, defaultGrafanaCpuRequest, defaultGrafanaMemoryRequest,
+		defaultGrafanaCpuLimit, defaultGrafanaMemoryLimit)
 	return resources
 }
 
@@ -1767,7 +1787,8 @@ func NewStorageContainerResource(cr *model.CryostatInstance) *corev1.ResourceReq
 	if cr.Spec.Resources != nil {
 		resources = cr.Spec.Resources.ObjectStorageResources.DeepCopy()
 	}
-	common.PopulateResourceRequest(resources, defaultStorageCpuRequest, defaultStorageMemoryRequest)
+	common.PopulateResourceRequest(resources, defaultStorageCpuRequest, defaultStorageMemoryRequest,
+		defaultStorageCpuLimit, defaultStorageMemoryLimit)
 	return resources
 }
 
@@ -1892,7 +1913,8 @@ func NewDatabaseContainerResource(cr *model.CryostatInstance) *corev1.ResourceRe
 	if cr.Spec.Resources != nil {
 		resources = cr.Spec.Resources.DatabaseResources.DeepCopy()
 	}
-	common.PopulateResourceRequest(resources, defaultDatabaseCpuRequest, defaultDatabaseMemoryRequest)
+	common.PopulateResourceRequest(resources, defaultDatabaseCpuRequest, defaultDatabaseMemoryRequest,
+		defaultDatabaseCpuLimit, defaultDatabaseMemoryLimit)
 	return resources
 }
 
@@ -2012,7 +2034,8 @@ func NewJfrDatasourceContainerResource(cr *model.CryostatInstance) *corev1.Resou
 	if cr.Spec.Resources != nil {
 		resources = cr.Spec.Resources.DataSourceResources.DeepCopy()
 	}
-	common.PopulateResourceRequest(resources, defaultJfrDatasourceCpuRequest, defaultJfrDatasourceMemoryRequest)
+	common.PopulateResourceRequest(resources, defaultJfrDatasourceCpuRequest, defaultJfrDatasourceMemoryRequest,
+		defaultJfrDatasourceCpuLimit, defaultJfrDatasourceMemoryLimit)
 	return resources
 }
 
@@ -2132,7 +2155,8 @@ func newAgentProxyContainerResource(cr *model.CryostatInstance) *corev1.Resource
 	if cr.Spec.Resources != nil {
 		resources = cr.Spec.Resources.AgentProxyResources.DeepCopy()
 	}
-	common.PopulateResourceRequest(resources, defaultAgentProxyCpuRequest, defaultAgentProxyMemoryRequest)
+	common.PopulateResourceRequest(resources, defaultAgentProxyCpuRequest, defaultAgentProxyMemoryRequest,
+		defaultAgentProxyCpuLimit, defaultAgentProxyMemoryLimit)
 	return resources
 }
 

--- a/internal/controllers/reconciler_test.go
+++ b/internal/controllers/reconciler_test.go
@@ -1811,6 +1811,14 @@ func (c *controllerTest) commonTests() {
 					t.expectMainDeployment()
 				})
 			})
+			Context("with no limits", func() {
+				BeforeEach(func() {
+					t.objs = append(t.objs, t.NewCryostatWithResourcesNoLimit().Object)
+				})
+				It("should create expected deployment", func() {
+					t.expectMainDeployment()
+				})
+			})
 		})
 		Context("with network options", func() {
 			JustBeforeEach(func() {

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -811,6 +811,55 @@ func (r *TestResources) NewCryostatWithLowResourceLimit() *model.CryostatInstanc
 	return cr
 }
 
+func (r *TestResources) NewCryostatWithResourcesNoLimit() *model.CryostatInstance {
+	cr := r.NewCryostat()
+	cr.Spec.Resources = &operatorv1beta2.ResourceConfigList{
+		CoreResources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("250m"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+		},
+		GrafanaResources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("128m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+		},
+		DataSourceResources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("300m"),
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
+			},
+		},
+		ObjectStorageResources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("300m"),
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+		},
+		DatabaseResources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+		},
+		AuthProxyResources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("40m"),
+				corev1.ResourceMemory: resource.MustParse("100Mi"),
+			},
+		},
+		AgentProxyResources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("30m"),
+				corev1.ResourceMemory: resource.MustParse("80Mi"),
+			},
+		},
+	}
+	return cr
+}
+
 func (r *TestResources) NewCryostatWithBuiltInDiscoveryDisabled() *model.CryostatInstance {
 	cr := r.NewCryostat()
 	cr.Spec.TargetDiscoveryOptions = &operatorv1beta2.TargetDiscoveryOptions{
@@ -4606,15 +4655,14 @@ func (r *TestResources) NewCoreContainerResource(cr *model.CryostatInstance) *co
 			corev1.ResourceCPU:    resource.MustParse("500m"),
 			corev1.ResourceMemory: resource.MustParse("384Mi"),
 		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1000m"),
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
+		},
 	}
 
-	if cr.Spec.Resources != nil && cr.Spec.Resources.CoreResources.Requests != nil {
-		resources.Requests = cr.Spec.Resources.CoreResources.Requests
-	}
-
-	if cr.Spec.Resources != nil && cr.Spec.Resources.CoreResources.Limits != nil {
-		resources.Limits = cr.Spec.Resources.CoreResources.Limits
-		checkWithLimit(resources.Requests, resources.Limits)
+	if cr.Spec.Resources != nil {
+		applyResourceCustomization(cr.Spec.Resources.CoreResources, resources)
 	}
 
 	return resources
@@ -4626,15 +4674,14 @@ func (r *TestResources) NewDatasourceContainerResource(cr *model.CryostatInstanc
 			corev1.ResourceCPU:    resource.MustParse("200m"),
 			corev1.ResourceMemory: resource.MustParse("200Mi"),
 		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("400m"),
+			corev1.ResourceMemory: resource.MustParse("500Mi"),
+		},
 	}
 
-	if cr.Spec.Resources != nil && cr.Spec.Resources.DataSourceResources.Requests != nil {
-		resources.Requests = cr.Spec.Resources.DataSourceResources.Requests
-	}
-
-	if cr.Spec.Resources != nil && cr.Spec.Resources.DataSourceResources.Limits != nil {
-		resources.Limits = cr.Spec.Resources.DataSourceResources.Limits
-		checkWithLimit(resources.Requests, resources.Limits)
+	if cr.Spec.Resources != nil {
+		applyResourceCustomization(cr.Spec.Resources.DataSourceResources, resources)
 	}
 
 	return resources
@@ -4646,15 +4693,14 @@ func (r *TestResources) NewGrafanaContainerResource(cr *model.CryostatInstance) 
 			corev1.ResourceCPU:    resource.MustParse("25m"),
 			corev1.ResourceMemory: resource.MustParse("80Mi"),
 		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("200Mi"),
+		},
 	}
 
-	if cr.Spec.Resources != nil && cr.Spec.Resources.GrafanaResources.Requests != nil {
-		resources.Requests = cr.Spec.Resources.GrafanaResources.Requests
-	}
-
-	if cr.Spec.Resources != nil && cr.Spec.Resources.GrafanaResources.Limits != nil {
-		resources.Limits = cr.Spec.Resources.GrafanaResources.Limits
-		checkWithLimit(resources.Requests, resources.Limits)
+	if cr.Spec.Resources != nil {
+		applyResourceCustomization(cr.Spec.Resources.GrafanaResources, resources)
 	}
 
 	return resources
@@ -4666,15 +4712,14 @@ func (r *TestResources) NewStorageContainerResource(cr *model.CryostatInstance) 
 			corev1.ResourceCPU:    resource.MustParse("50m"),
 			corev1.ResourceMemory: resource.MustParse("256Mi"),
 		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
 	}
 
-	if cr.Spec.Resources != nil && cr.Spec.Resources.ObjectStorageResources.Requests != nil {
-		resources.Requests = cr.Spec.Resources.ObjectStorageResources.Requests
-	}
-
-	if cr.Spec.Resources != nil && cr.Spec.Resources.ObjectStorageResources.Limits != nil {
-		resources.Limits = cr.Spec.Resources.ObjectStorageResources.Limits
-		checkWithLimit(resources.Requests, resources.Limits)
+	if cr.Spec.Resources != nil {
+		applyResourceCustomization(cr.Spec.Resources.CoreResources, resources)
 	}
 
 	return resources
@@ -4686,15 +4731,14 @@ func (r *TestResources) NewDatabaseContainerResource(cr *model.CryostatInstance)
 			corev1.ResourceCPU:    resource.MustParse("25m"),
 			corev1.ResourceMemory: resource.MustParse("64Mi"),
 		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("200Mi"),
+		},
 	}
 
-	if cr.Spec.Resources != nil && cr.Spec.Resources.DatabaseResources.Requests != nil {
-		resources.Requests = cr.Spec.Resources.DatabaseResources.Requests
-	}
-
-	if cr.Spec.Resources != nil && cr.Spec.Resources.DatabaseResources.Limits != nil {
-		resources.Limits = cr.Spec.Resources.DatabaseResources.Limits
-		checkWithLimit(resources.Requests, resources.Limits)
+	if cr.Spec.Resources != nil {
+		applyResourceCustomization(cr.Spec.Resources.DatabaseResources, resources)
 	}
 
 	return resources
@@ -4706,15 +4750,14 @@ func (r *TestResources) NewAuthProxyContainerResource(cr *model.CryostatInstance
 			corev1.ResourceCPU:    resource.MustParse("25m"),
 			corev1.ResourceMemory: resource.MustParse("64Mi"),
 		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+		},
 	}
 
-	if cr.Spec.Resources != nil && cr.Spec.Resources.AuthProxyResources.Requests != nil {
-		resources.Requests = cr.Spec.Resources.AuthProxyResources.Requests
-	}
-
-	if cr.Spec.Resources != nil && cr.Spec.Resources.AuthProxyResources.Limits != nil {
-		resources.Limits = cr.Spec.Resources.AuthProxyResources.Limits
-		checkWithLimit(resources.Requests, resources.Limits)
+	if cr.Spec.Resources != nil {
+		applyResourceCustomization(cr.Spec.Resources.AuthProxyResources, resources)
 	}
 
 	return resources
@@ -4726,15 +4769,14 @@ func (r *TestResources) NewAgentProxyContainerResource(cr *model.CryostatInstanc
 			corev1.ResourceCPU:    resource.MustParse("25m"),
 			corev1.ResourceMemory: resource.MustParse("64Mi"),
 		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("200Mi"),
+		},
 	}
 
-	if cr.Spec.Resources != nil && cr.Spec.Resources.AgentProxyResources.Requests != nil {
-		resources.Requests = cr.Spec.Resources.AgentProxyResources.Requests
-	}
-
-	if cr.Spec.Resources != nil && cr.Spec.Resources.AgentProxyResources.Limits != nil {
-		resources.Limits = cr.Spec.Resources.AgentProxyResources.Limits
-		checkWithLimit(resources.Requests, resources.Limits)
+	if cr.Spec.Resources != nil {
+		applyResourceCustomization(cr.Spec.Resources.AgentProxyResources, resources)
 	}
 
 	return resources
@@ -4746,21 +4788,28 @@ func (r *TestResources) NewReportContainerResource(cr *model.CryostatInstance) *
 			corev1.ResourceCPU:    resource.MustParse("500m"),
 			corev1.ResourceMemory: resource.MustParse("512Mi"),
 		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1000m"),
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
+		},
 	}
 
 	if cr.Spec.ReportOptions != nil {
-		reportOptions := cr.Spec.ReportOptions
-		if reportOptions.Resources.Requests != nil {
-			resources.Requests = reportOptions.Resources.Requests
-		}
-
-		if reportOptions.Resources.Limits != nil {
-			resources.Limits = reportOptions.Resources.Limits
-			checkWithLimit(resources.Requests, resources.Limits)
-		}
+		applyResourceCustomization(cr.Spec.ReportOptions.Resources, resources)
 	}
 
 	return resources
+}
+
+func applyResourceCustomization(resources corev1.ResourceRequirements, result *corev1.ResourceRequirements) {
+	if resources.Requests != nil {
+		result.Requests = resources.Requests
+	}
+
+	if resources.Requests != nil || resources.Limits != nil {
+		result.Limits = resources.Limits
+		checkWithLimit(result.Requests, result.Limits)
+	}
 }
 
 func checkWithLimit(requests, limits corev1.ResourceList) {

--- a/internal/webhooks/agent/pod_defaulter.go
+++ b/internal/webhooks/agent/pod_defaulter.go
@@ -55,6 +55,8 @@ const (
 	agentMaxSizeBytes           = "50Mi"
 	agentInitCpuRequest         = "10m"
 	agentInitMemoryRequest      = "32Mi"
+	agentInitCpuLimit           = "20m"
+	agentInitMemoryLimit        = "64Mi"
 	defaultLogLevel             = "off"
 	defaultJavaOptsVar          = "JAVA_TOOL_OPTIONS"
 	defaultHarvesterExitMaxAge  = int32(30000)
@@ -450,7 +452,8 @@ func getResourceRequirements(cr *model.CryostatInstance) *corev1.ResourceRequire
 	if cr.Spec.AgentOptions != nil {
 		resources = cr.Spec.AgentOptions.Resources.DeepCopy()
 	}
-	common.PopulateResourceRequest(resources, agentInitCpuRequest, agentInitMemoryRequest)
+	common.PopulateResourceRequest(resources, agentInitCpuRequest, agentInitMemoryRequest,
+		agentInitCpuLimit, agentInitMemoryLimit)
 	return resources
 }
 

--- a/internal/webhooks/agent/pod_defaulter_test.go
+++ b/internal/webhooks/agent/pod_defaulter_test.go
@@ -528,6 +528,16 @@ var _ = Describe("PodDefaulter", func() {
 
 					ExpectPod()
 				})
+
+				Context("with a no limit", func() {
+					BeforeEach(func() {
+						t.objs = append(t.objs, t.NewCryostatWithAgentInitResourcesNoLimit().Object)
+						originalPod = t.NewPod()
+						expectedPod = t.NewMutatedPodResourcesNoLimit()
+					})
+
+					ExpectPod()
+				})
 			})
 
 			Context("on a FIPS cluster", func() {

--- a/internal/webhooks/agent/test/resources.go
+++ b/internal/webhooks/agent/test/resources.go
@@ -281,6 +281,10 @@ func (r *AgentWebhookTestResources) setDefaultMutatedPodOptions(options *mutated
 				corev1.ResourceCPU:    resource.MustParse("10m"),
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
 			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("20m"),
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
+			},
 		}
 	}
 	options.scheme = "https"
@@ -407,6 +411,17 @@ func (r *AgentWebhookTestResources) NewMutatedPodResourcesLowLimit() *corev1.Pod
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("5m"),
 				corev1.ResourceMemory: resource.MustParse("16Mi"),
+			},
+		},
+	})
+}
+
+func (r *AgentWebhookTestResources) NewMutatedPodResourcesNoLimit() *corev1.Pod {
+	return r.newMutatedPod(&mutatedPodOptions{
+		resources: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("20m"),
+				corev1.ResourceMemory: resource.MustParse("40Mi"),
 			},
 		},
 	})
@@ -720,6 +735,19 @@ func (r *AgentWebhookTestResources) NewCryostatWithAgentInitLowResourceLimit() *
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("5m"),
 				corev1.ResourceMemory: resource.MustParse("16Mi"),
+			},
+		},
+	}
+	return cr
+}
+
+func (r *AgentWebhookTestResources) NewCryostatWithAgentInitResourcesNoLimit() *model.CryostatInstance {
+	cr := r.NewCryostat()
+	cr.Spec.AgentOptions = &operatorv1beta2.AgentOptions{
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("20m"),
+				corev1.ResourceMemory: resource.MustParse("40Mi"),
 			},
 		},
 	}


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #1155 

## Description of the change:
* Adds default resource limits (2-3x default requests) for each container managed by the operator
* Default resource limits won't be set if the user supplies either a resource request or limit for that container in the CR
* Updates the docs to reflect this change

## Motivation for the change:
* This prevents Cryostat from consuming excess resources and negatively affecting other workloads

## How to manually test:
1. Deploy and create default CR, observe new default limits
2. Customize CR and see changes applied
