### PR TITLE
feat(diagnostics): add diagnostics buckets to storage setup

### DIFF
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -1807,7 +1807,7 @@ func NewStorageContainer(cr *model.CryostatInstance, imageTag string, tls *TLSCo
 	envs := []corev1.EnvVar{
 		{
 			Name:  "CRYOSTAT_BUCKETS",
-			Value: "archivedrecordings,archivedreports,eventtemplates,probes",
+			Value: "archivedrecordings,archivedreports,eventtemplates,probes,threaddumps,heapdumps",
 		},
 		{
 			Name:  "CRYOSTAT_ACCESS_KEY",

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -2900,7 +2900,7 @@ func (r *TestResources) NewStorageEnvironmentVariables() []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{
 			Name:  "CRYOSTAT_BUCKETS",
-			Value: "archivedrecordings,archivedreports,eventtemplates,probes",
+			Value: "archivedrecordings,archivedreports,eventtemplates,probes,threaddumps,heapdumps",
 		},
 		{
 			Name:  "CRYOSTAT_ACCESS_KEY",


### PR DESCRIPTION
Fixes: [#1150](https://github.com/cryostatio/cryostat-operator/issues/1150)

## Description of the change:
Adds the diagnostics buckets (threaddumps, heapdumps) to the CRYOSTAT_BUCKETS environment variable for the storage container.

## How to manually test:
1. Pull and build this PR, spin up a crc cluster or other test environment and create a sample app with the cryostat agent (heap dumps require an agent connection)
2. make cert_manager
3. make generate manifests manager oci-build bundle bundle-build
4. make deploy_bundle BUNDLE_IMG=quay.io/jmatsuok/cryostat-operator-bundle:4.1.0-snapshot
5. wait for the operator to install then create a cryostat CR
6. Check the environment variables for the cryostat-storage pod, make sure CRYOSTAT_BUCKETS includes the thread and heap dumps buckets
7. Test the diagnostics functionality, make sure thread and heap dumps work as expected and can be downloaded.
