### PR TITLE
fix(diagnostics): Add heap dumps upload path to nginx allowed paths config

### DIFF
--- a/internal/controllers/configmaps.go
+++ b/internal/controllers/configmaps.go
@@ -194,6 +194,7 @@ http {
 	tcp_nopush          on;
 	keepalive_timeout   65;
 	types_hash_max_size 4096;
+	client_max_body_size 0;
 
 	include             /etc/nginx/mime.types;
 	default_type        application/octet-stream;

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -4971,6 +4971,7 @@ http {
 	tcp_nopush          on;
 	keepalive_timeout   65;
 	types_hash_max_size 4096;
+	client_max_body_size 0;
 
 	include             /etc/nginx/mime.types;
 	default_type        application/octet-stream;
@@ -5090,6 +5091,7 @@ http {
 	tcp_nopush          on;
 	keepalive_timeout   65;
 	types_hash_max_size 4096;
+	client_max_body_size 0;
 
 	include             /etc/nginx/mime.types;
 	default_type        application/octet-stream;


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: [#1172](https://github.com/cryostatio/cryostat-operator/issues/1172)

## Description of the change:
- Adds the /api/beta/diagnostics/heapdump/upload endpoint to the allowed path prefixes for the agent proxy nginx config allowing the agent to push to it.
- Configures the nginx proxy to remove the client_max_body_size, the default it's set to is 1 mb which is way too small for a heap dump and I'm surprised we haven't hit it before with recordings since they can get fairly large too. Any request body exceeding that size gets back a 413.

## To manually test:
- Pull and build this PR
- make cert_manager
- make generate manifests manager oci-build bundle bundle-build
- podman image prune -f ; podman push $IMAGE_NAMESPACE/cryostat-operator:4.1.0-dev ; podman push $IMAGE_NAMESPACE/cryostat-operator-bundle:4.1.0-dev
- make deploy_bundle BUNDLE_IMG=$IMAGE_NAMESPACE/cryostat-operator-bundle:4.1.0-dev
- make sample_app_agent_proxy
- Trigger a heap dump on the agent-test target, make sure that it gets uploaded
- Check the agent proxy container logs to make sure nothing unexpected happened, similarly check the agent-test container logs