### PR TITLE
fix(cert): avoid owner ref conflicts with cert-manager

### DIFF
--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -24,7 +24,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:4.2.0-dev
-    createdAt: "2025-10-28T23:50:44Z"
+    createdAt: "2025-10-30T18:47:04Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {
@@ -1162,6 +1162,12 @@ spec:
                 - list
                 - update
                 - watch
+            - apiGroups:
+                - cert-manager.io
+              resources:
+                - certificates/finalizers
+              verbs:
+                - update
             - apiGroups:
                 - config.openshift.io
               resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -81,6 +81,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates/finalizers
+  verbs:
+  - update
+- apiGroups:
   - config.openshift.io
   resources:
   - apiservers

--- a/internal/controllers/cryostat_controller.go
+++ b/internal/controllers/cryostat_controller.go
@@ -62,6 +62,7 @@ func NewCryostatReconciler(config *ReconcilerConfig) (*CryostatReconciler, error
 // +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=*
 // +kubebuilder:rbac:namespace=system,groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create
 // +kubebuilder:rbac:groups=cert-manager.io,resources=issuers;certificates,verbs=create;get;list;update;watch;delete
+// +kubebuilder:rbac:groups=cert-manager.io,resources=certificates/finalizers,verbs=update
 // +kubebuilder:rbac:groups=console.openshift.io,resources=consolelinks,verbs=get;create;list;update;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses;networkpolicies,verbs=*
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #1140 

## Description of the change:
* If the certificate secret is already owned by the certificate, do nothing
* If the secret is owned by the CR, change the controller reference to the certificate
* Fix some secrets where the owner reference was not being set in the first place
* Add UUID generation to the fake client in order for `metav1.IsControlledBy` to work
* Add tests

## Motivation for the change:
* Prevents the operator from breaking when the cert-manager `--enable-certificate-owner-ref` parameter is set

## How to manually test:
1. `kubectl edit -n cert-manager cert-manager`, add `--enable-certificate-owner-ref=true` to the container's command line args
2. Build and deploy PR
3. Create a default CR, the operator should successfully reconcile
