### PR TITLE
fix(storage): disable checksum validation when deploying managed storage

### DIFF
--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -1467,6 +1467,13 @@ func NewCoreContainer(cr *model.CryostatInstance, specs *ServiceSpecs, imageTag 
 	if DeployManagedStorage(cr) {
 		// default environment variable settings for managed/provisioned cryostat-storage instance
 		envs = append(envs, []corev1.EnvVar{
+			// FIXME since Quarkus 3.20 / S3 SDK 2.30.36 leaving this enabled results in junk 'chunk-signature' data
+			// being inserted to PutObjectRequests when the object storage instance is SeaweedFS/cryostat-storage
+			// See https://github.com/cryostatio/cryostat/issues/948
+			{
+				Name:  "QUARKUS_S3_CHECKSUM_VALIDATION",
+				Value: "false",
+			},
 			{
 				Name:  "QUARKUS_S3_ENDPOINT_OVERRIDE",
 				Value: specs.StorageURL.String(),

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -2703,6 +2703,10 @@ func (r *TestResources) NewCoreEnvironmentVariables(reportsUrl string, ingress b
 			Value: "cryostat",
 		},
 		{
+			Name:  "QUARKUS_S3_CHECKSUM_VALIDATION",
+			Value: "false",
+		},
+		{
 			Name:  "QUARKUS_S3_ENDPOINT_OVERRIDE",
 			Value: fmt.Sprintf("%s://%s-storage.%s.svc.cluster.local:%d", storageProtocol, r.Name, r.Namespace, storagePort),
 		},


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to https://github.com/cryostatio/cryostat/issues/948
Depends on https://github.com/cryostatio/cryostat/pull/1016

## Description of the change:
*This change adds allows the users to provide...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Insert steps here...*
2. *...*
