### PR TITLE
fix(csv): revert change to minKubeVersion

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=cryostat-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.31.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.33.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -24,7 +24,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Developer Tools
     containerImage: quay.io/cryostat/cryostat-operator:4.1.1-dev
-    createdAt: "2025-11-27T21:54:14Z"
+    createdAt: "2025-12-17T16:19:26Z"
     description: JVM monitoring and profiling tool
     operatorframework.io/initialization-resource: |-
       {
@@ -40,7 +40,7 @@ metadata:
           }
         }
       }
-    operators.operatorframework.io/builder: operator-sdk-v1.31.0
+    operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: github.com/cryostatio/cryostat-operator
     support: Cryostat Community
@@ -1442,7 +1442,7 @@ spec:
     - email: cryostat-development@googlegroups.com
       name: The Cryostat Authors
   maturity: stable
-  minKubeVersion: 1.29.0
+  minKubeVersion: 1.25.0
   provider:
     name: The Cryostat Community
   relatedImages:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: cryostat-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.31.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.33.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
@@ -1300,7 +1300,7 @@ spec:
   - email: cryostat-development@googlegroups.com
     name: The Cryostat Authors
   maturity: stable
-  minKubeVersion: 1.29.0
+  minKubeVersion: 1.25.0
   provider:
     name: The Cryostat Community
   version: 0.0.0

--- a/config/overlays/insights/insights_patch.yaml
+++ b/config/overlays/insights/insights_patch.yaml
@@ -11,7 +11,7 @@ spec:
       - name: insights
         env:
         - name: RELATED_IMAGE_INSIGHTS_PROXY
-          value: "registry.redhat.io/3scale-amp2/apicast-gateway-rhel8:3scale2.15"
+          value: "registry.redhat.io/3scale-amp2/apicast-gateway-rhel8:3scale2.16"
         - name: INSIGHTS_BACKEND_DOMAIN
           value: "console.redhat.com"
         - name: USER_AGENT_PREFIX


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to: https://github.com/cryostatio/cryostat-operator/pull/1207

## Description of the change:
* Reverts change to minKubeVersion in CSV

## Motivation for the change:
* Restores support for older Kubernetes versions
* Hopefully fixes our Scorecard CI tests