### PR TITLE
feat(agent): autoconfig passes publish context and fillStrategy

### DIFF
--- a/internal/controllers/configmaps.go
+++ b/internal/controllers/configmaps.go
@@ -301,6 +301,7 @@ func (r *Reconciler) reconcileAgentProxyConfig(ctx context.Context, cr *model.Cr
 		CryostatPort:  constants.CryostatHTTPContainerPort,
 		AllowedPathPrefixes: []string{
 			"/api/v4/discovery",
+			"/api/v4.2/discovery",
 			"/api/v4/credentials",
 			"/api/beta/recordings",
 			"/api/beta/diagnostics/heapdump/upload",

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -5224,6 +5224,14 @@ http {
 			proxy_pass http://127.0.0.1:8181$request_uri;
 		}
 
+		location /api/v4.2/discovery/ {
+			proxy_pass http://127.0.0.1:8181$request_uri;
+		}
+
+		location = /api/v4.2/discovery {
+			proxy_pass http://127.0.0.1:8181$request_uri;
+		}
+
 		location /api/v4/credentials/ {
 			proxy_pass http://127.0.0.1:8181$request_uri;
 		}
@@ -5314,6 +5322,14 @@ http {
 		}
 
 		location = /api/v4/discovery {
+			proxy_pass http://127.0.0.1:8181$request_uri;
+		}
+
+		location /api/v4.2/discovery/ {
+			proxy_pass http://127.0.0.1:8181$request_uri;
+		}
+
+		location = /api/v4.2/discovery {
 			proxy_pass http://127.0.0.1:8181$request_uri;
 		}
 

--- a/internal/webhooks/agent/pod_defaulter.go
+++ b/internal/webhooks/agent/pod_defaulter.go
@@ -239,6 +239,22 @@ func (r *podMutator) Default(ctx context.Context, obj runtime.Object) error {
 			Name:  "CRYOSTAT_AGENT_WEBSERVER_PORT",
 			Value: strconv.Itoa(int(*port)),
 		},
+		corev1.EnvVar{
+			Name:  "CRYOSTAT_AGENT_PUBLISH_FILL_STRATEGY",
+			Value: "KUBERNETES",
+		},
+		corev1.EnvVar{
+			Name:  "CRYOSTAT_AGENT_PUBLISH_CONTEXT_NAMESPACE",
+			Value: pod.Namespace,
+		},
+		corev1.EnvVar{
+			Name:  "CRYOSTAT_AGENT_PUBLISH_CONTEXT_NODETYPE",
+			Value: "Pod",
+		},
+		corev1.EnvVar{
+			Name:  "CRYOSTAT_AGENT_PUBLISH_CONTEXT_NAME",
+			Value: fmt.Sprintf("$(%s)", podNameEnvVar),
+		},
 	)
 
 	if len(harvesterTemplate) > 0 {

--- a/internal/webhooks/agent/test/resources.go
+++ b/internal/webhooks/agent/test/resources.go
@@ -579,6 +579,22 @@ func (r *AgentWebhookTestResources) newMutatedContainer(original *corev1.Contain
 				Value: strconv.Itoa(int(options.callbackPort)),
 			},
 			{
+				Name:  "CRYOSTAT_AGENT_PUBLISH_FILL_STRATEGY",
+				Value: "KUBERNETES",
+			},
+			{
+				Name:  "CRYOSTAT_AGENT_PUBLISH_CONTEXT_NAMESPACE",
+				Value: options.namespace,
+			},
+			{
+				Name:  "CRYOSTAT_AGENT_PUBLISH_CONTEXT_NODETYPE",
+				Value: "Pod",
+			},
+			{
+				Name:  "CRYOSTAT_AGENT_PUBLISH_CONTEXT_NAME",
+				Value: "$(CRYOSTAT_AGENT_POD_NAME)",
+			},
+			{
 				Name:  options.javaOptionsName,
 				Value: options.javaOptionsValue + fmt.Sprintf("-javaagent:"+constants.AgentJarPath+"=io.cryostat.agent.shaded.org.slf4j.simpleLogger.defaultLogLevel=%s", options.logLevel),
 			},


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #1068
Closes #1218
See #1218
Depends on https://github.com/cryostatio/cryostat-agent/pull/785
Depends on https://github.com/cryostatio/cryostat/pull/1258

## Description of the change:
Adds additional capability to the Agent autoconfiguration webhook to populate the cryostatio/cryostat-agent#785 cryostatio/cryostat#1258 fill strategy and contextual map. The values are obvious: the fill strategy is `KUBERNETES`, the nodeType is `Pod`, and the name and namespace are those of the Pod being autoconfigured.

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
See #1218, steps are similar:

```
$ export OPERATOR_IMG=quay.io/andrewazores/cryostat-operator:4.2.0-k8s-ergo-36
$ export CORE_IMG=quay.io/andrewazores/cryostat:4.2.0-k8s-ergo-23
$ export AGENT_INIT_IMG=quay.io/andrewazores/cryostat-agent-init:0.7.0-publish-context-4
```