### PR TITLE
feat: add enableAudit CR property for audit logging

### DIFF
--- a/api/v1beta2/cryostat_types.go
+++ b/api/v1beta2/cryostat_types.go
@@ -78,6 +78,12 @@ type CryostatSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	ReportOptions *ReportConfiguration `json:"reportOptions,omitempty"`
+	// Enable Cryostat audit logging.
+	// New Cryostat CRs default to true, but existing CRs created before this field was
+	// introduced remain unchanged until this property is explicitly set.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Audit Logging",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	EnableAudit *bool `json:"enableAudit,omitempty"`
 	// Options to customize the target connections cache for the Cryostat application.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Target Connection Cache Options"

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -329,6 +329,11 @@ func (in *CryostatSpec) DeepCopyInto(out *CryostatSpec) {
 		*out = new(ReportConfiguration)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.EnableAudit != nil {
+		in, out := &in.EnableAudit, &out.EnableAudit
+		*out = new(bool)
+		**out = **in
+	}
 	if in.TargetConnectionCacheOptions != nil {
 		in, out := &in.TargetConnectionCacheOptions, &out.TargetConnectionCacheOptions
 		*out = new(TargetConnectionCacheOptions)

--- a/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cryostat-operator.clusterserviceversion.yaml
@@ -11,6 +11,7 @@ metadata:
             "name": "cryostat-sample"
           },
           "spec": {
+            "enableAudit": true,
             "enableCertManager": true,
             "eventTemplates": [],
             "networkPolicies": {},
@@ -165,6 +166,11 @@ spec:
             path: declarativeCredentials[0].secretName
             x-descriptors:
               - urn:alm:descriptor:io.kubernetes:Secret
+          - description: 'Enable Cryostat audit logging. New Cryostat CRs default to true, but existing CRs created before this field was introduced remain unchanged until this property is explicitly set. Warning: enabling audit logging increases database storage usage over time.'
+            displayName: Enable Audit Logging
+            path: enableAudit
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
           - description: List of Flight Recorder Event Templates to preconfigure in Cryostat.
             displayName: Event Templates
             path: eventTemplates

--- a/bundle/manifests/operator.cryostat.io_cryostats.yaml
+++ b/bundle/manifests/operator.cryostat.io_cryostats.yaml
@@ -5696,6 +5696,12 @@ spec:
                   - secretName
                   type: object
                 type: array
+              enableAudit:
+                description: |-
+                  Enable Cryostat audit logging.
+                  New Cryostat CRs default to true, but existing CRs created before this field was
+                  introduced remain unchanged until this property is explicitly set.
+                type: boolean
               enableCertManager:
                 description: |-
                   Use cert-manager to secure in-cluster communication between Cryostat components.

--- a/config/crd/bases/operator.cryostat.io_cryostats.yaml
+++ b/config/crd/bases/operator.cryostat.io_cryostats.yaml
@@ -5683,6 +5683,12 @@ spec:
                   - secretName
                   type: object
                 type: array
+              enableAudit:
+                description: |-
+                  Enable Cryostat audit logging.
+                  New Cryostat CRs default to true, but existing CRs created before this field was
+                  introduced remain unchanged until this property is explicitly set.
+                type: boolean
               enableCertManager:
                 description: |-
                   Use cert-manager to secure in-cluster communication between Cryostat components.

--- a/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cryostat-operator.clusterserviceversion.yaml
@@ -179,6 +179,13 @@ spec:
         path: declarativeCredentials[0].secretName
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
+      - description: 'Enable Cryostat audit logging. New Cryostat CRs default to true,
+          but existing CRs created before this field was introduced remain unchanged
+          until this property is explicitly set.'
+        displayName: Enable Audit Logging
+        path: enableAudit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: List of Flight Recorder Event Templates to preconfigure in Cryostat.
         displayName: Event Templates
         path: eventTemplates

--- a/config/samples/operator_v1beta2_cryostat.yaml
+++ b/config/samples/operator_v1beta2_cryostat.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cryostat-sample
 spec:
   enableCertManager: true
+  enableAudit: true
   trustedCertSecrets: []
   eventTemplates: []
   reportOptions:

--- a/docs/config.md
+++ b/docs/config.md
@@ -300,6 +300,21 @@ spec:
     targetCacheTTL: 10
 ```
 
+### Audit Logging
+
+Cryostat can persist audit history in its database, which enables historical features such as looking back at information about targets after they have been lost. For newly created Cryostat CRs, the operator defaults `spec.enableAudit` to `true`. Existing Cryostat CRs that predate this field keep their previous behavior until you explicitly set the property.
+
+When audit logging is enabled, the Cryostat database will grow over time and may require additional storage.
+
+```yaml
+apiVersion: operator.cryostat.io/v1beta2
+kind: Cryostat
+metadata:
+  name: cryostat-sample
+spec:
+  enableAudit: false
+```
+
 ### Application Database
 
 Cryostat stores various pieces of information in a database. This can also include target application connection credentials, such as target applications' JMX credentials, which are stored in an encrypted database table. By default, the Operator will generate both a random database connection key and a random table encryption key and configure Cryostat and the database to use these. You may also specify these keys yourself by creating a Secret containing the keys `CONNECTION_KEY` and `ENCRYPTION_KEY`.

--- a/internal/controllers/common/resource_definitions/resource_definitions.go
+++ b/internal/controllers/common/resource_definitions/resource_definitions.go
@@ -1469,6 +1469,12 @@ func NewCoreContainer(cr *model.CryostatInstance, specs *ServiceSpecs, imageTag 
 			Value: "static",
 		},
 	}
+	if cr.Spec.EnableAudit != nil {
+		envs = append(envs, corev1.EnvVar{
+			Name:  "CRYOSTAT_AUDIT_ENABLED",
+			Value: strconv.FormatBool(*cr.Spec.EnableAudit),
+		})
+	}
 
 	if DeployManagedStorage(cr) {
 		// default environment variable settings for managed/provisioned cryostat-storage instance

--- a/internal/controllers/reconciler_test.go
+++ b/internal/controllers/reconciler_test.go
@@ -70,6 +70,7 @@ type cryostatTestInput struct {
 }
 
 func (c *controllerTest) commonBeforeEach() *cryostatTestInput {
+	auditEnabled := true
 	t := &cryostatTestInput{
 		TestReconcilerConfig: test.TestReconcilerConfig{
 			GeneratedPasswords: []string{"auth_cookie_secret", "connection_key", "encryption_key", "object_storage", "keystore"},
@@ -81,6 +82,7 @@ func (c *controllerTest) commonBeforeEach() *cryostatTestInput {
 			TLS:         true,
 			ExternalTLS: true,
 			OpenShift:   true,
+			EnableAudit: &auditEnabled,
 		},
 	}
 	t.objs = []ctrlclient.Object{
@@ -1954,6 +1956,30 @@ func (c *controllerTest) commonTests() {
 		Context("configuring environment variables with non-default spec values", func() {
 			JustBeforeEach(func() {
 				t.reconcileCryostatFully()
+			})
+			Context("containing EnableAudit=false", func() {
+				BeforeEach(func() {
+					auditDisabled := false
+					t.EnableAudit = &auditDisabled
+					t.objs = append(t.objs, t.NewCryostat().Object)
+				})
+				It("should disable audit logging", func() {
+					t.checkCoreHasEnvironmentVariables([]corev1.EnvVar{
+						{
+							Name:  "CRYOSTAT_AUDIT_ENABLED",
+							Value: "false",
+						},
+					})
+				})
+			})
+			Context("without EnableAudit configured", func() {
+				BeforeEach(func() {
+					t.EnableAudit = nil
+					t.objs = append(t.objs, t.NewCryostat().Object)
+				})
+				It("should leave audit logging unset", func() {
+					t.checkCoreDoesNotHaveEnvironmentVariable("CRYOSTAT_AUDIT_ENABLED")
+				})
 			})
 			Context("containing JmxCacheOptions", func() {
 				BeforeEach(func() {
@@ -4324,6 +4350,17 @@ func (t *cryostatTestInput) checkCoreHasEnvironmentVariables(expectedEnvVars []c
 	coreContainer := template.Spec.Containers[0]
 
 	Expect(coreContainer.Env).To(ContainElements(expectedEnvVars))
+}
+
+func (t *cryostatTestInput) checkCoreDoesNotHaveEnvironmentVariable(name string) {
+	deployment := &appsv1.Deployment{}
+	err := t.Client.Get(context.Background(), types.NamespacedName{Name: t.Name, Namespace: t.Namespace}, deployment)
+	Expect(err).ToNot(HaveOccurred())
+
+	coreContainer := deployment.Spec.Template.Spec.Containers[0]
+	for _, envVar := range coreContainer.Env {
+		Expect(envVar.Name).ToNot(Equal(name))
+	}
 }
 
 func (t *cryostatTestInput) getCryostatInstance() *model.CryostatInstance {

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -55,6 +55,7 @@ type TestResources struct {
 	OpenShift                  bool
 	ReportReplicas             int32
 	TargetNamespaces           []string
+	EnableAudit                *bool
 	InsightsURL                string
 	DisableAgentHostnameVerify bool
 	AllowAgentInsecure         bool
@@ -113,11 +114,15 @@ func (r *TestResources) newCryostatSpec() operatorv1beta2.CryostatSpec {
 			Replicas: r.ReportReplicas,
 		}
 	}
-	return operatorv1beta2.CryostatSpec{
+	spec := operatorv1beta2.CryostatSpec{
 		TargetNamespaces:  r.TargetNamespaces,
 		EnableCertManager: &certManager,
 		ReportOptions:     reportOptions,
 	}
+	if r.EnableAudit != nil {
+		spec.EnableAudit = r.EnableAudit
+	}
+	return spec
 }
 
 func (r *TestResources) ConvertNamespacedToModel(cr *operatorv1beta2.Cryostat) *model.CryostatInstance {
@@ -2750,6 +2755,14 @@ func (r *TestResources) NewCoreEnvironmentVariables(reportsUrl string, ingress b
 			Name:  "CRYOSTAT_TEMPLATE_PATH",
 			Value: "/opt/cryostat.d/templates.d",
 		},
+	}
+	if r.EnableAudit != nil {
+		envs = append(envs, corev1.EnvVar{
+			Name:  "CRYOSTAT_AUDIT_ENABLED",
+			Value: fmt.Sprintf("%t", *r.EnableAudit),
+		})
+	}
+	envs = append(envs, []corev1.EnvVar{
 		{
 			Name:  "CRYOSTAT_CONNECTIONS_MAX_OPEN",
 			Value: "-1",
@@ -2790,7 +2803,7 @@ func (r *TestResources) NewCoreEnvironmentVariables(reportsUrl string, ingress b
 			Name:  "STORAGE_PRESIGNED_DOWNLOADS_ENABLED",
 			Value: "false",
 		},
-	}
+	}...)
 	if r.TLS {
 		envs = append(envs,
 			corev1.EnvVar{

--- a/internal/webhooks/defaulter.go
+++ b/internal/webhooks/defaulter.go
@@ -42,5 +42,9 @@ func (r *cryostatDefaulter) Default(ctx context.Context, obj runtime.Object) err
 		r.log.Info("defaulting target namespaces", "name", cr.Name, "namespace", cr.Namespace)
 		cr.Spec.TargetNamespaces = []string{cr.Namespace}
 	}
+	if cr.Spec.EnableAudit == nil && cr.CreationTimestamp.IsZero() && cr.ResourceVersion == "" {
+		r.log.Info("defaulting audit logging", "name", cr.Name, "namespace", cr.Namespace)
+		cr.Spec.EnableAudit = &[]bool{true}[0]
+	}
 	return nil
 }

--- a/internal/webhooks/defaulter_test.go
+++ b/internal/webhooks/defaulter_test.go
@@ -107,11 +107,61 @@ var _ = Describe("CryostatDefaulter", func() {
 		})
 	})
 
+	Context("without audit setting", func() {
+		BeforeEach(func() {
+			t.objs = append(t.objs, t.NewCryostat().Object)
+		})
+
+		It("should enable audit logging by default", func() {
+			result := t.getCryostat()
+			Expect(result.Spec.EnableAudit).ToNot(BeNil())
+			Expect(*result.Spec.EnableAudit).To(BeTrue())
+		})
+	})
+
+	Context("with audit disabled", func() {
+		BeforeEach(func() {
+			auditDisabled := false
+			cr := t.NewCryostat()
+			cr.Spec.EnableAudit = &auditDisabled
+			t.objs = append(t.objs, cr.Object)
+		})
+
+		It("should preserve the user setting", func() {
+			result := t.getCryostat()
+			Expect(result.Spec.EnableAudit).ToNot(BeNil())
+			Expect(*result.Spec.EnableAudit).To(BeFalse())
+		})
+	})
+
+	Context("updating an existing Cryostat with unset audit setting", func() {
+		BeforeEach(func() {
+			auditEnabled := true
+			cr := t.NewCryostat()
+			cr.Spec.EnableAudit = &auditEnabled
+			t.objs = append(t.objs, cr.Object)
+		})
+
+		It("should not re-default audit logging", func() {
+			cr := t.getCryostat()
+			cr.Spec.EnableAudit = nil
+			err := t.client.Update(context.Background(), cr)
+			Expect(err).ToNot(HaveOccurred())
+
+			result := t.getCryostat()
+			Expect(result.Spec.EnableAudit).To(BeNil())
+		})
+	})
+
 })
 
 func (t *defaulterTestInput) getCryostatInstance() *model.CryostatInstance {
+	return t.ConvertNamespacedToModel(t.getCryostat())
+}
+
+func (t *defaulterTestInput) getCryostat() *operatorv1beta2.Cryostat {
 	cr := &operatorv1beta2.Cryostat{}
 	err := t.client.Get(context.Background(), types.NamespacedName{Name: t.Name, Namespace: t.Namespace}, cr)
 	Expect(err).ToNot(HaveOccurred())
-	return t.ConvertNamespacedToModel(cr)
+	return cr
 }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #1257

## Description of the change:
Adds an `enableAudit` boolean property to the Cryostat CR spec that configures the `CRYOSTAT_AUDIT_ENABLED` environment variable on the Cryostat container. New CRs default to `true` via the defaulting webhook; existing CRs created before this field was introduced are left unchanged to preserve upgrade safety.

## Motivation for the change:
Audit logging enables Cryostat to retain historical information about lost target JVMs and their Kubernetes lineages, which is valuable for correlating with other observability signals after unexpected shutdowns. Users should be able to opt in or out through the CR rather than requiring manual env var configuration.

## How to manually test:
1. Deploy the operator and create a new Cryostat custom resource without setting `enableAudit`. Verify the defaulter sets it to `true` and `CRYOSTAT_AUDIT_ENABLED=true` appears in the core container env.
2. Create a custom resource with `enableAudit: false`, `CRYOSTAT_AUDIT_ENABLED=false` should appear.
3. Create a custom resource that omits `enableAudit` on an existing (pre-upgrade) instance. The env var should not exist.