### PR TITLE
feat(console-plugin): uninstall plugin when upgrading Cryostat on unsupported OCP version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BUNDLE_VERSION ?= $(IMAGE_VERSION)
 DEFAULT_NAMESPACE ?= quay.io/cryostat
 
 # Minimum OpenShift version for Console Plugin support
-export MIN_OPENSHIFT_VERSION ?= 4.15.0
+export MIN_OPENSHIFT_VERSION ?= 4.19.0
 IMAGE_NAMESPACE ?= $(DEFAULT_NAMESPACE)
 OPERATOR_NAME ?= cryostat-operator
 OPERATOR_SDK_VERSION ?= v1.31.0

--- a/Makefile
+++ b/Makefile
@@ -376,6 +376,7 @@ manifests: controller-gen ## Generate manifests e.g. CRD, RBAC, etc.
 	$(CONTROLLER_GEN) rbac:roleName=role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	envsubst < hack/image_tag_patch.yaml.in > config/default/image_tag_patch.yaml
 	envsubst < hack/image_pull_patch.yaml.in > config/default/image_pull_patch.yaml
+	envsubst < hack/openshift_version_patch.yaml.in > config/default/openshift_version_patch.yaml
 	envsubst < hack/plugin_image_pull_patch.yaml.in > config/openshift/plugin_image_pull_patch.yaml
 	envsubst < hack/insights_patch.yaml.in > config/overlays/insights/insights_patch.yaml
 	envsubst < hack/insights_image_pull_patch.yaml.in > config/insights/insights_image_pull_patch.yaml

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ export OPERATOR_VERSION ?= 4.2.0-dev
 IMAGE_VERSION ?= $(OPERATOR_VERSION)
 BUNDLE_VERSION ?= $(IMAGE_VERSION)
 DEFAULT_NAMESPACE ?= quay.io/cryostat
+
+# Minimum OpenShift version for Console Plugin support
+export MIN_OPENSHIFT_VERSION ?= 4.15.0
 IMAGE_NAMESPACE ?= $(DEFAULT_NAMESPACE)
 OPERATOR_NAME ?= cryostat-operator
 OPERATOR_SDK_VERSION ?= v1.31.0

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,9 @@ IMAGE_VERSION ?= $(OPERATOR_VERSION)
 BUNDLE_VERSION ?= $(IMAGE_VERSION)
 DEFAULT_NAMESPACE ?= quay.io/cryostat
 
-# Minimum OpenShift version for Console Plugin support
+# Minimum and Maximum OpenShift versions for Console Plugin support
 export MIN_OPENSHIFT_VERSION ?= 4.19.0
+export MAX_OPENSHIFT_VERSION ?= 99.99.0
 IMAGE_NAMESPACE ?= $(DEFAULT_NAMESPACE)
 OPERATOR_NAME ?= cryostat-operator
 OPERATOR_SDK_VERSION ?= v1.31.0

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -33,6 +33,7 @@ commonLabels:
 patchesStrategicMerge:
 - image_tag_patch.yaml
 - image_pull_patch.yaml
+- openshift_version_patch.yaml
 - manager_webhook_patch.yaml
 - webhookcainjection_patch.yaml
 - webhook_object_selector_patch.yaml

--- a/config/default/openshift_version_patch.yaml
+++ b/config/default/openshift_version_patch.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: MIN_OPENSHIFT_VERSION
+          value: "4.19.0"
+        - name: MAX_OPENSHIFT_VERSION
+          value: "99.99.0"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -49,8 +49,6 @@ spec:
         env:
         - name: WATCH_NAMESPACE
           value: ""
-        - name: MIN_OPENSHIFT_VERSION
-          value: "4.19.0"
         resources:
           limits:
             cpu: 1000m

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,7 +50,7 @@ spec:
         - name: WATCH_NAMESPACE
           value: ""
         - name: MIN_OPENSHIFT_VERSION
-          value: "4.15.0"
+          value: "4.19.0"
         resources:
           limits:
             cpu: 1000m

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -49,6 +49,8 @@ spec:
         env:
         - name: WATCH_NAMESPACE
           value: ""
+        - name: MIN_OPENSHIFT_VERSION
+          value: "4.15.0"
         resources:
           limits:
             cpu: 1000m

--- a/hack/openshift_version_patch.yaml.in
+++ b/hack/openshift_version_patch.yaml.in
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: MIN_OPENSHIFT_VERSION
+          value: "${MIN_OPENSHIFT_VERSION}"
+        - name: MAX_OPENSHIFT_VERSION
+          value: "${MAX_OPENSHIFT_VERSION}"

--- a/internal/console/plugin.go
+++ b/internal/console/plugin.go
@@ -41,18 +41,19 @@ import (
 )
 
 type PluginInstaller struct {
-	Client    client.Client
-	Namespace string
-	Scheme    *runtime.Scheme
-	Log       logr.Logger
+	Client              client.Client
+	Namespace           string
+	Scheme              *runtime.Scheme
+	Log                 logr.Logger
+	MinOpenShiftVersion string
 }
 
 // Verify that *PluginInstaller implements manager.Runnable and manager.LeaderElectionRunnable.
 var _ manager.Runnable = (*PluginInstaller)(nil)
 var _ manager.LeaderElectionRunnable = (*PluginInstaller)(nil)
 
-// Minimum OpenShift version that supports the plugin
-const minOpenShiftVersion = "4.15.0"
+// Default minimum OpenShift version that supports the plugin
+const defaultMinOpenShiftVersion = "4.15.0"
 
 // Maximum OpenShift version that supports the plugin
 const maxOpenShiftVersion = "99.99.0" // Placeholder until needed
@@ -223,8 +224,17 @@ func (r *PluginInstaller) findOwner(ctx context.Context) (*rbacv1.ClusterRoleBin
 }
 
 func (r *PluginInstaller) isOpenShiftCompatible(ctx context.Context) (bool, error) {
+	minVersionStr := r.MinOpenShiftVersion
+	if minVersionStr == "" {
+		minVersionStr = defaultMinOpenShiftVersion
+	}
+
 	// Build a semver.Version from the minimum/maximum version
-	minVersion := semver.MustParse(minOpenShiftVersion)
+	minVersion, err := semver.Parse(minVersionStr)
+	if err != nil {
+		r.Log.Error(err, "Invalid MIN_OPENSHIFT_VERSION, using default", "value", minVersionStr, "default", defaultMinOpenShiftVersion)
+		minVersion = semver.MustParse(defaultMinOpenShiftVersion)
+	}
 	maxVersion := semver.MustParse(maxOpenShiftVersion)
 
 	// Look up the cluster's version

--- a/internal/console/plugin.go
+++ b/internal/console/plugin.go
@@ -53,7 +53,7 @@ var _ manager.Runnable = (*PluginInstaller)(nil)
 var _ manager.LeaderElectionRunnable = (*PluginInstaller)(nil)
 
 // Default minimum OpenShift version that supports the plugin
-const defaultMinOpenShiftVersion = "4.15.0"
+const defaultMinOpenShiftVersion = "4.19.0"
 
 // Maximum OpenShift version that supports the plugin
 const maxOpenShiftVersion = "99.99.0" // Placeholder until needed

--- a/internal/console/plugin.go
+++ b/internal/console/plugin.go
@@ -46,17 +46,18 @@ type PluginInstaller struct {
 	Scheme              *runtime.Scheme
 	Log                 logr.Logger
 	MinOpenShiftVersion string
+	MaxOpenShiftVersion string
 }
 
 // Verify that *PluginInstaller implements manager.Runnable and manager.LeaderElectionRunnable.
 var _ manager.Runnable = (*PluginInstaller)(nil)
 var _ manager.LeaderElectionRunnable = (*PluginInstaller)(nil)
 
-// Default minimum OpenShift version that supports the plugin
-const defaultMinOpenShiftVersion = "4.19.0"
+// Default minimum OpenShift version that supports the plugin (0.0.0 = accept any version if not set)
+const defaultMinOpenShiftVersion = "0.0.0"
 
-// Maximum OpenShift version that supports the plugin
-const maxOpenShiftVersion = "99.99.0" // Placeholder until needed
+// Default maximum OpenShift version that supports the plugin
+const defaultMaxOpenShiftVersion = "99.99.0"
 
 // Start implements manager.Runnable.
 func (r *PluginInstaller) Start(ctx context.Context) error {
@@ -229,13 +230,22 @@ func (r *PluginInstaller) isOpenShiftCompatible(ctx context.Context) (bool, erro
 		minVersionStr = defaultMinOpenShiftVersion
 	}
 
+	maxVersionStr := r.MaxOpenShiftVersion
+	if maxVersionStr == "" {
+		maxVersionStr = defaultMaxOpenShiftVersion
+	}
+
 	// Build a semver.Version from the minimum/maximum version
 	minVersion, err := semver.Parse(minVersionStr)
 	if err != nil {
 		r.Log.Error(err, "Invalid MIN_OPENSHIFT_VERSION, using default", "value", minVersionStr, "default", defaultMinOpenShiftVersion)
 		minVersion = semver.MustParse(defaultMinOpenShiftVersion)
 	}
-	maxVersion := semver.MustParse(maxOpenShiftVersion)
+	maxVersion, err := semver.Parse(maxVersionStr)
+	if err != nil {
+		r.Log.Error(err, "Invalid MAX_OPENSHIFT_VERSION, using default", "value", maxVersionStr, "default", defaultMaxOpenShiftVersion)
+		maxVersion = semver.MustParse(defaultMaxOpenShiftVersion)
+	}
 
 	// Look up the cluster's version
 	version, err := r.getOpenShiftVersion(ctx)

--- a/internal/console/plugin.go
+++ b/internal/console/plugin.go
@@ -28,6 +28,7 @@ import (
 	openshiftoperatorv1 "github.com/openshift/api/operator/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -72,8 +73,8 @@ func (r *PluginInstaller) installConsolePlugin(ctx context.Context) error {
 		return err
 	}
 	if !compat {
-		// Return early if this OpenShift cluster is not compatible
-		return nil
+		// Uninstall plugin if it exists on incompatible cluster
+		return r.uninstallConsolePlugin(ctx)
 	}
 	err = r.createConsolePlugin(ctx)
 	if err != nil {
@@ -262,4 +263,68 @@ func (r *PluginInstaller) getOpenShiftVersion(ctx context.Context) (*semver.Vers
 	// Parse result back into a semver.Version
 	version := semver.MustParse(trimmedVer)
 	return &version, nil
+}
+
+func (r *PluginInstaller) uninstallConsolePlugin(ctx context.Context) error {
+	r.Log.Info("Uninstalling Console Plugin due to incompatible OpenShift version")
+
+	err := r.unregisterConsolePlugin(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = r.deleteConsolePlugin(ctx)
+	if err != nil {
+		return err
+	}
+
+	r.Log.Info("Console Plugin uninstalled successfully")
+	return nil
+}
+
+func (r *PluginInstaller) unregisterConsolePlugin(ctx context.Context) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		console := &openshiftoperatorv1.Console{}
+		err := r.Client.Get(ctx, types.NamespacedName{Name: constants.ConsoleCRName}, console)
+		if err != nil {
+			if kerrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		idx := slices.Index(console.Spec.Plugins, constants.ConsolePluginName)
+		if idx == -1 {
+			return nil
+		}
+
+		console.Spec.Plugins = slices.Delete(console.Spec.Plugins, idx, idx+1)
+
+		err = r.Client.Update(ctx, console)
+		if err != nil {
+			return err
+		}
+
+		r.Log.Info("Console Plugin unregistered from Console", "name", console.Name)
+		return nil
+	})
+}
+
+func (r *PluginInstaller) deleteConsolePlugin(ctx context.Context) error {
+	plugin := &consolev1.ConsolePlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: constants.ConsolePluginName,
+		},
+	}
+
+	err := r.Client.Delete(ctx, plugin)
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	r.Log.Info("ConsolePlugin deleted", "name", plugin.Name)
+	return nil
 }

--- a/internal/console/plugin_test.go
+++ b/internal/console/plugin_test.go
@@ -81,7 +81,8 @@ var _ = Describe("Plugin", func() {
 			Namespace:           t.Namespace,
 			Scheme:              k8sScheme,
 			Log:                 logger,
-			MinOpenShiftVersion: "",
+			MinOpenShiftVersion: "", // Use default in tests
+			MaxOpenShiftVersion: "", // Use default in tests
 		}
 	})
 

--- a/internal/console/plugin_test.go
+++ b/internal/console/plugin_test.go
@@ -77,11 +77,11 @@ var _ = Describe("Plugin", func() {
 		}
 
 		installer = &console.PluginInstaller{
-			Client:              t.client,
-			Namespace:           t.Namespace,
-			Scheme:              k8sScheme,
-			Log:                 logger,
--			// Hardcode test bounds
+			Client:    t.client,
+			Namespace: t.Namespace,
+			Scheme:    k8sScheme,
+			Log:       logger,
+			// Hardcode test bounds
 			MinOpenShiftVersion: "4.19.0",
 			MaxOpenShiftVersion: "99.99.0",
 		}

--- a/internal/console/plugin_test.go
+++ b/internal/console/plugin_test.go
@@ -77,10 +77,11 @@ var _ = Describe("Plugin", func() {
 		}
 
 		installer = &console.PluginInstaller{
-			Client:    t.client,
-			Namespace: t.Namespace,
-			Scheme:    k8sScheme,
-			Log:       logger,
+			Client:              t.client,
+			Namespace:           t.Namespace,
+			Scheme:              k8sScheme,
+			Log:                 logger,
+			MinOpenShiftVersion: "",
 		}
 	})
 

--- a/internal/console/plugin_test.go
+++ b/internal/console/plugin_test.go
@@ -248,6 +248,120 @@ var _ = Describe("Plugin", func() {
 				expectNoChanges()
 			})
 		})
+		Context("uninstalling plugin", func() {
+			Context("with existing plugin on incompatible OpenShift (too old)", func() {
+				BeforeEach(func() {
+					t.objs = append(t.objs, t.NewConsoleExisting(), t.NewConsolePlugin(), t.NewPluginClusterRoleBinding(), t.NewOperatorDeployment(), t.NewClusterVersionOld())
+				})
+				JustBeforeEach(func() {
+					t.updateClusterVersionStatus(t.NewClusterVersionOld())
+					err := installer.Start(context.Background())
+					Expect(err).ToNot(HaveOccurred())
+				})
+				It("should delete ConsolePlugin", func() {
+					plugin := &consolev1.ConsolePlugin{}
+					err := t.client.Get(context.Background(), types.NamespacedName{Name: t.NewConsolePlugin().Name}, plugin)
+					Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				})
+				It("should unregister from Console", func() {
+					console := t.getConsole(t.NewConsole())
+					Expect(console.Spec.Plugins).ToNot(ContainElement("cryostat-plugin"))
+					Expect(console.Spec.Plugins).To(ContainElement("other-plugin"))
+				})
+			})
+			Context("with existing plugin on incompatible OpenShift (too new)", func() {
+				BeforeEach(func() {
+					t.objs = append(t.objs, t.NewConsoleExisting(), t.NewConsolePlugin(), t.NewPluginClusterRoleBinding(), t.NewOperatorDeployment(), t.NewClusterVersionNew())
+				})
+				JustBeforeEach(func() {
+					t.updateClusterVersionStatus(t.NewClusterVersionNew())
+					err := installer.Start(context.Background())
+					Expect(err).ToNot(HaveOccurred())
+				})
+				It("should delete ConsolePlugin", func() {
+					plugin := &consolev1.ConsolePlugin{}
+					err := t.client.Get(context.Background(), types.NamespacedName{Name: t.NewConsolePlugin().Name}, plugin)
+					Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				})
+				It("should unregister from Console", func() {
+					console := t.getConsole(t.NewConsole())
+					Expect(console.Spec.Plugins).ToNot(ContainElement("cryostat-plugin"))
+					Expect(console.Spec.Plugins).To(ContainElement("other-plugin"))
+				})
+			})
+			Context("with no existing plugin on incompatible OpenShift", func() {
+				BeforeEach(func() {
+					t.objs = append(t.objs, t.NewConsole(), t.NewPluginClusterRoleBinding(), t.NewOperatorDeployment(), t.NewClusterVersionOld())
+				})
+				JustBeforeEach(func() {
+					t.updateClusterVersionStatus(t.NewClusterVersionOld())
+					err := installer.Start(context.Background())
+					Expect(err).ToNot(HaveOccurred())
+				})
+				It("should not error when plugin already uninstalled", func() {
+					// Test passes if no error in JustBeforeEach
+				})
+				It("should not create ConsolePlugin", func() {
+					plugin := &consolev1.ConsolePlugin{}
+					err := t.client.Get(context.Background(), types.NamespacedName{Name: t.NewConsolePlugin().Name}, plugin)
+					Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				})
+			})
+			Context("with ConsolePlugin CR but not registered in Console", func() {
+				BeforeEach(func() {
+					t.objs = append(t.objs, t.NewConsole(), t.NewConsolePlugin(), t.NewPluginClusterRoleBinding(), t.NewOperatorDeployment(), t.NewClusterVersionOld())
+				})
+				JustBeforeEach(func() {
+					t.updateClusterVersionStatus(t.NewClusterVersionOld())
+					err := installer.Start(context.Background())
+					Expect(err).ToNot(HaveOccurred())
+				})
+				It("should delete ConsolePlugin", func() {
+					plugin := &consolev1.ConsolePlugin{}
+					err := t.client.Get(context.Background(), types.NamespacedName{Name: t.NewConsolePlugin().Name}, plugin)
+					Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				})
+				It("should not error when plugin not registered", func() {
+					// Test passes if no error in JustBeforeEach
+				})
+			})
+			Context("with plugin registered in Console but no CR", func() {
+				BeforeEach(func() {
+					t.objs = append(t.objs, t.NewConsoleExisting(), t.NewPluginClusterRoleBinding(), t.NewOperatorDeployment(), t.NewClusterVersionOld())
+				})
+				JustBeforeEach(func() {
+					t.updateClusterVersionStatus(t.NewClusterVersionOld())
+					err := installer.Start(context.Background())
+					Expect(err).ToNot(HaveOccurred())
+				})
+				It("should unregister from Console", func() {
+					console := t.getConsole(t.NewConsole())
+					Expect(console.Spec.Plugins).ToNot(ContainElement("cryostat-plugin"))
+					Expect(console.Spec.Plugins).To(ContainElement("other-plugin"))
+				})
+				It("should not error when ConsolePlugin CR missing", func() {
+					// Test passes if no error in JustBeforeEach
+				})
+			})
+			Context("with missing Console CR during uninstall", func() {
+				BeforeEach(func() {
+					t.objs = append(t.objs, t.NewConsolePlugin(), t.NewPluginClusterRoleBinding(), t.NewOperatorDeployment(), t.NewClusterVersionOld())
+				})
+				JustBeforeEach(func() {
+					t.updateClusterVersionStatus(t.NewClusterVersionOld())
+					err := installer.Start(context.Background())
+					Expect(err).ToNot(HaveOccurred())
+				})
+				It("should still delete ConsolePlugin", func() {
+					plugin := &consolev1.ConsolePlugin{}
+					err := t.client.Get(context.Background(), types.NamespacedName{Name: t.NewConsolePlugin().Name}, plugin)
+					Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				})
+				It("should not error when Console CR missing", func() {
+					// Test passes if no error in JustBeforeEach
+				})
+			})
+		})
 	})
 	Context("as runnable", func() {
 		It("should need leader election", func() {

--- a/internal/console/plugin_test.go
+++ b/internal/console/plugin_test.go
@@ -81,8 +81,9 @@ var _ = Describe("Plugin", func() {
 			Namespace:           t.Namespace,
 			Scheme:              k8sScheme,
 			Log:                 logger,
-			MinOpenShiftVersion: "", // Use default in tests
-			MaxOpenShiftVersion: "", // Use default in tests
+-			// Hardcode test bounds
+			MinOpenShiftVersion: "4.19.0",
+			MaxOpenShiftVersion: "99.99.0",
 		}
 	})
 

--- a/internal/console/test/resources.go
+++ b/internal/console/test/resources.go
@@ -187,7 +187,7 @@ func (r *PluginTestResources) NewOperatorDeploymentMissingLabels() *appsv1.Deplo
 }
 
 func (r *PluginTestResources) NewClusterVersion() *configv1.ClusterVersion {
-	return r.newClusterVersion("4.17.0-foo+bar")
+	return r.newClusterVersion("4.19.0-foo+bar")
 }
 
 func (r *PluginTestResources) NewClusterVersionOld() *configv1.ClusterVersion {

--- a/internal/main.go
+++ b/internal/main.go
@@ -193,12 +193,14 @@ func main() {
 			os.Exit(1)
 		}
 		minOpenShiftVersion := os.Getenv("MIN_OPENSHIFT_VERSION")
+		maxOpenShiftVersion := os.Getenv("MAX_OPENSHIFT_VERSION")
 		installer := &console.PluginInstaller{
 			Client:              mgr.GetClient(),
 			Namespace:           namespace,
 			Scheme:              mgr.GetScheme(),
 			Log:                 setupLog,
 			MinOpenShiftVersion: minOpenShiftVersion,
+			MaxOpenShiftVersion: maxOpenShiftVersion,
 		}
 		err := installer.SetupWithManager(mgr)
 		if err != nil {

--- a/internal/main.go
+++ b/internal/main.go
@@ -192,11 +192,13 @@ func main() {
 			setupLog.Error(err, "could not determine operator's namespace")
 			os.Exit(1)
 		}
+		minOpenShiftVersion := os.Getenv("MIN_OPENSHIFT_VERSION")
 		installer := &console.PluginInstaller{
-			Client:    mgr.GetClient(),
-			Namespace: namespace,
-			Scheme:    mgr.GetScheme(),
-			Log:       setupLog,
+			Client:              mgr.GetClient(),
+			Namespace:           namespace,
+			Scheme:              mgr.GetScheme(),
+			Log:                 setupLog,
+			MinOpenShiftVersion: minOpenShiftVersion,
 		}
 		err := installer.SetupWithManager(mgr)
 		if err != nil {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #1259

## Description of the change:
1. Enhances the OpenShift Console Plugin installation check to additionally check if the current cluster version is *below* the minimum supported version. Previously the logic was a simple one-way "if version >= minimum, install plugin." Now there is an "else, uninstall plugin" branch. This covers the case where Cryostat/cryostat-web/cryostat-openshift-console-plugin are upgraded in a way that increases the required Console version compared to the previous Cryostat version. If a Cryostat installation on a given OpenShift cluster is upgraded and the cluster itself is not upgraded, then it's possible that some features will no longer be available and should be disabled/removed.
2. Sets the minimum OpenShift version to 4.19 - see https://github.com/openshift/console/blob/main/frontend/packages/console-dynamic-plugin-sdk/README.md#patternfly, https://github.com/cryostatio/cryostat-web/pull/2137, https://github.com/cryostatio/cryostat-openshift-console-plugin/pull/833, https://github.com/cryostatio/cryostat-openshift-console-plugin/issues/128, and https://github.com/openshift/console/pull/16056 
3. Refactors the OpenShift version value from a hardcoded constant in the source code to an environment variable which can be set at build time. This helps consolidate all the versions to be updated into the Makefile.
4. According to https://access.redhat.com/product-life-cycles?product=OpenShift%20Container%20Platform%204 , OpenShift 4.19 is currently in Maintenance support. 4.20 and 4.21 are the current fully supported versions but 4.22, the first version which will ship exclusively supporting Patternfly 6, will be coming soon.

## How to manually test:
1. *Insert steps here...*
2. *...*
