### PR TITLE
test(scorecard): add option to redirect test output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,12 @@ SCORECARD_TEST_ONLY ?= false
 # Output format for operator-sdk scorecard (text, json, xunit); see `operator-sdk scorecard --help`
 SCORECARD_OUTPUT_FORMAT ?= text
 
+# Optional file path to write scorecard results to (in addition to stdout)
+SCORECARD_OUTPUT_FILE ?=
+ifneq ($(SCORECARD_OUTPUT_FILE),)
+SCORECARD_TEE := | tee $(SCORECARD_OUTPUT_FILE)
+endif
+
 ##@ General
 
 .PHONY: all
@@ -222,7 +228,7 @@ ifneq ($(SKIP_TESTS), true)
 	$(call scorecard-setup)
 	$(call scorecard-cleanup) ; \
 	trap cleanup EXIT ; \
-	$(OPERATOR_SDK) scorecard -n $(SCORECARD_NAMESPACE) -s cryostat-scorecard -w 20m $(BUNDLE_IMG) --pod-security=restricted -o $(SCORECARD_OUTPUT_FORMAT) $(SCORECARD_TEST_SELECTOR)
+	$(OPERATOR_SDK) scorecard -n $(SCORECARD_NAMESPACE) -s cryostat-scorecard -w 20m $(BUNDLE_IMG) --pod-security=restricted -o $(SCORECARD_OUTPUT_FORMAT) $(SCORECARD_TEST_SELECTOR) $(SCORECARD_TEE)
 endif
 
 .PHONY: test-scorecard-local
@@ -277,7 +283,7 @@ function cleanup { \
 endef
 
 define scorecard-local
-	SCORECARD_NAMESPACE=$(SCORECARD_NAMESPACE) BUNDLE_DIR=./bundle go run internal/images/custom-scorecard-tests/main.go $${SCORECARD_TEST_SELECTION} | sed 's/\\n/\n/g'
+	SCORECARD_NAMESPACE=$(SCORECARD_NAMESPACE) BUNDLE_DIR=./bundle go run internal/images/custom-scorecard-tests/main.go $${SCORECARD_TEST_SELECTION} | sed 's/\\n/\n/g' $(SCORECARD_TEE)
 endef
 
 ##@ Build


### PR DESCRIPTION
Assisted-by: Claude Opus 4.6

# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #1323 

## Description of the change:
* Adds a `SCORECARD_OUTPUT_FILE` Makefile parameter that when set, sends the `operator-sdk scorecard` output to a file in addition to stdout.

## Motivation for the change:
* Allows for easy separation of the JSON Scorecard results from any other command output.

## How to manually test:
1. Run `make test-scorecard SCORECARD_OUTPUT_FORMAT=json SCORECARD_OUTPUT_FILE=scorecard.json`
2. Test results should still appear on stdout, but also in scorecard.json, which should be a well-formed JSON file.
