### PR TITLE
fix(discovery): only set config env vars if discovery enabled

### DIFF
--- a/internal/controller/common/resource_definitions/resource_definitions.go
+++ b/internal/controller/common/resource_definitions/resource_definitions.go
@@ -1965,24 +1965,29 @@ func newK8SDiscoveryEnvForCoreContainer(cr *model.CryostatInstance) []corev1.Env
 			k8sDiscoveryPortNumbers = ""
 		}
 	}
-	return []corev1.EnvVar{
+	vars := []corev1.EnvVar{
 		{
 			Name:  "CRYOSTAT_DISCOVERY_KUBERNETES_ENABLED",
 			Value: fmt.Sprintf("%t", k8sDiscoveryEnabled),
 		},
-		{
-			Name:  "CRYOSTAT_DISCOVERY_KUBERNETES_NAMESPACES",
-			Value: strings.Join(cr.TargetNamespaces, ","),
-		},
-		{
-			Name:  "CRYOSTAT_DISCOVERY_KUBERNETES_PORT_NAMES",
-			Value: k8sDiscoveryPortNames,
-		},
-		{
-			Name:  "CRYOSTAT_DISCOVERY_KUBERNETES_PORT_NUMBERS",
-			Value: k8sDiscoveryPortNumbers,
-		},
 	}
+	if k8sDiscoveryEnabled {
+		vars = append(vars,
+			corev1.EnvVar{
+				Name:  "CRYOSTAT_DISCOVERY_KUBERNETES_NAMESPACES",
+				Value: strings.Join(cr.TargetNamespaces, ","),
+			},
+			corev1.EnvVar{
+				Name:  "CRYOSTAT_DISCOVERY_KUBERNETES_PORT_NAMES",
+				Value: k8sDiscoveryPortNames,
+			},
+			corev1.EnvVar{
+				Name:  "CRYOSTAT_DISCOVERY_KUBERNETES_PORT_NUMBERS",
+				Value: k8sDiscoveryPortNumbers,
+			},
+		)
+	}
+	return vars
 }
 
 func newGrafanaEnvForCoreContainer(specs *ServiceSpecs) []corev1.EnvVar {

--- a/internal/controller/reconciler_test.go
+++ b/internal/controller/reconciler_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -2704,6 +2705,111 @@ func (c *controllerTest) commonTests() {
 				})
 				It("should update the target namespaces in Status", func() {
 					t.expectTargetNamespaces()
+				})
+			})
+
+			Context("when changing target namespaces", func() {
+				var originalDeployment *appsv1.Deployment
+				var updatedDeployment *appsv1.Deployment
+
+				BeforeEach(func() {
+					t.TargetNamespaces = targetNamespaces
+				})
+
+				JustBeforeEach(func() {
+					// Get the deployment after initial reconciliation
+					originalDeployment = &appsv1.Deployment{}
+					err := t.Client.Get(context.Background(), types.NamespacedName{Name: t.Name, Namespace: t.Namespace}, originalDeployment)
+					Expect(err).ToNot(HaveOccurred())
+
+					// Update target namespaces to add a new one
+					newTargetNS := "multi-test-three"
+					t.objs = append(t.objs, t.NewOtherNamespace(newTargetNS))
+					err = t.Client.Create(context.Background(), t.NewOtherNamespace(newTargetNS))
+					Expect(err).ToNot(HaveOccurred())
+
+					t.TargetNamespaces = append(targetNamespaces, newTargetNS)
+					cr := t.getCryostatInstance()
+					cr.Spec.TargetNamespaces = t.TargetNamespaces
+					t.updateCryostatInstance(cr)
+
+					// Reconcile again
+					t.reconcileCryostatFully()
+
+					// Get the deployment after update
+					updatedDeployment = &appsv1.Deployment{}
+					err = t.Client.Get(context.Background(), types.NamespacedName{Name: t.Name, Namespace: t.Namespace}, updatedDeployment)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				Context("with built-in discovery disabled", func() {
+					BeforeEach(func() {
+						t.objs = append(t.objs, t.NewCryostatWithBuiltInDiscoveryDisabled().Object)
+					})
+
+					It("should NOT modify the Deployment spec", func() {
+						Expect(originalDeployment.Spec).To(Equal(updatedDeployment.Spec),
+							"Deployment spec should not change when built-in discovery is disabled")
+					})
+
+					It("should NOT include discovery namespace env vars", func() {
+						deployment := &appsv1.Deployment{}
+						err := t.Client.Get(context.Background(), types.NamespacedName{Name: t.Name, Namespace: t.Namespace}, deployment)
+						Expect(err).ToNot(HaveOccurred())
+
+						coreContainer := &deployment.Spec.Template.Spec.Containers[0]
+						for _, env := range coreContainer.Env {
+							Expect(env.Name).ToNot(Equal("CRYOSTAT_DISCOVERY_KUBERNETES_NAMESPACES"),
+								"CRYOSTAT_DISCOVERY_KUBERNETES_NAMESPACES should not be present when built-in discovery is disabled")
+						}
+					})
+
+					It("should update RBAC for the new namespace", func() {
+						t.expectRBAC()
+					})
+
+					It("should update the target namespaces in Status", func() {
+						t.expectTargetNamespaces()
+					})
+				})
+
+				Context("with built-in discovery enabled (default)", func() {
+					BeforeEach(func() {
+						t.objs = append(t.objs, t.NewCryostat().Object)
+					})
+
+					It("should modify the Deployment spec", func() {
+						Expect(originalDeployment.Spec).ToNot(Equal(updatedDeployment.Spec),
+							"Deployment spec should change when built-in discovery is enabled")
+					})
+
+					It("should include updated discovery namespace env vars", func() {
+						deployment := &appsv1.Deployment{}
+						err := t.Client.Get(context.Background(), types.NamespacedName{Name: t.Name, Namespace: t.Namespace}, deployment)
+						Expect(err).ToNot(HaveOccurred())
+
+						coreContainer := &deployment.Spec.Template.Spec.Containers[0]
+						var foundNamespacesEnv bool
+						for _, env := range coreContainer.Env {
+							if env.Name == "CRYOSTAT_DISCOVERY_KUBERNETES_NAMESPACES" {
+								foundNamespacesEnv = true
+								expectedValue := strings.Join(t.TargetNamespaces, ",")
+								Expect(env.Value).To(Equal(expectedValue),
+									"CRYOSTAT_DISCOVERY_KUBERNETES_NAMESPACES should contain all target namespaces")
+								break
+							}
+						}
+						Expect(foundNamespacesEnv).To(BeTrue(),
+							"CRYOSTAT_DISCOVERY_KUBERNETES_NAMESPACES should be present when built-in discovery is enabled")
+					})
+
+					It("should update RBAC for the new namespace", func() {
+						t.expectRBAC()
+					})
+
+					It("should update the target namespaces in Status", func() {
+						t.expectTargetNamespaces()
+					})
 				})
 			})
 		})

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -2817,10 +2817,6 @@ func (r *TestResources) NewCoreEnvironmentVariables(reportsUrl string, ingress b
 			Value: "10",
 		},
 		{
-			Name:  "CRYOSTAT_DISCOVERY_KUBERNETES_NAMESPACES",
-			Value: strings.Join(r.TargetNamespaces, ","),
-		},
-		{
 			Name:  "GRAFANA_DATASOURCE_URL",
 			Value: "http://127.0.0.1:8989",
 		},
@@ -3278,6 +3274,17 @@ func (r *TestResources) NewTargetDiscoveryEnvVars(hasPortConfig bool, builtInDis
 			Value: fmt.Sprintf("%t", !builtInDiscoveryDisabled),
 		},
 	}
+
+	if builtInDiscoveryDisabled {
+		return envs
+	}
+
+	envs = append(envs,
+		corev1.EnvVar{
+			Name:  "CRYOSTAT_DISCOVERY_KUBERNETES_NAMESPACES",
+			Value: strings.Join(r.TargetNamespaces, ","),
+		},
+	)
 
 	if hasPortConfig {
 		envs = append(envs,


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #1339

## Description of the change:
There are multiple `CRYOSTAT_DISCOVERY_KUBERNETES_` environment variables relating to Cryostat's [k8s EndpointSlices Discovery mechanism](https://github.com/cryostatio/cryostat/blob/main/src/main/java/io/cryostat/discovery/KubeEndpointSlicesDiscovery.java): `NAMESPACES` controls the namespaces that Cryostat monitors for compatible application ports, and `PORT_NAMES` and `PORT_NUMBERS` control the filter it applies to determine if a port should be considered compatible. There is also `ENABLED`, which controls whether this mechanism is active at all. If the `ENABLED` environment variable is set to `false` then the mechanism is disabled, so the values of the other configuration environment variables is irrelevant. Therefore, they should only be set if the mechanism is enabled.

The `NAMESPACES` environment variable in particular is interesting because this is backed by the Cryostat Custom Resource's `.spec.targetNamespaces` property. This property is not only used to set the value of this environment variable, but in the Operator's Agent Autoconfig implementation this property is also read so that the Operator can ensure that it does not proceed with autoconfiguration on an application if the application is not located within a namespace that the specified Cryostat instance is configured to monitor. So, this property does still have a use and a meaning even when built-in EndpointSlices discovery is disabled and the user is using Agent Autoconfiguration instead.

## Motivation for the change:
If the user edits a Cryostat Custom Resource and changes the value of `.spec.targetNamespaces`, while also having `.spec.targetDiscoveryOptions.disableBuiltInDiscovery = true`, this carries the user's intent to change the set of namespaces which the Operator should accept Agent Autoconfiguration requests for, and this is the only implied meaning. Prior to this change, the various configuration environment variables would also be updated on the Cryostat Deployment, leading to a re-rollout of a new Cryostat Pod, causing downtime and a service interruption for no good reason.

If `disableBuiltInDiscovery = false` (which is the default if not specified), then the `.spec.targetNamespaces` also affects the aforementioned `CRYOSTAT_DISCOVERY_KUBERNETES_` configuration environment variables and those new values must be read by the EndpointSlices discovery mechanism within Cryostat, so an edited Deployment and a replaced Pod with the new configuration is required.

## How to manually test:
1. Check out and build PR
2. Create namespaces: `cryostat-operator`, `cryostat`, `apps1` and `apps2`
3. Deploy the custom-built Operator to `cryostat-operator`
4. Create a Cryostat CR within `cryostat` with the spec below
5. Within `apps1`, `make sample_app` to deploy a sample application using JMX without the Agent. This should not be discovered by Cryostat.
6. Within `apps2`, `DEPLOY_NAMESPACE=cryostat make sample_app_agent_injected` to deploy an Agent autoconfig application. This should be discovered by Cryostat.
7. Within `apps3`, `DEPLOY_NAMESPACE=cryostat make sample_app_agent_injected` to deploy an Agent autoconfig application. This should *not* be discovered by Cryostat because `apps3` is not in the `targetNamespaces`.
8. Within `apps3`, `make undeploy_sample_app_agent_injected`
9. Edit the Cryostat CR to add `apps3` to the `targetNamespaces`. Watch `cryostat` to ensure that none of the `Pods` are replaced/restarted/etc. - there should be no interruption to Cryostat operation.
10. Within `apps3`, `DEPLOY_NAMESPACE=cryostat make sample_app_agent_injected` again. This should now be discovered.

The initial Cryostat Custom Resource (step 4) should look like:
```yaml
apiVersion: v1
items:
- apiVersion: operator.cryostat.io/v1beta2
  kind: Cryostat
  metadata:
    name: cryostat-sample
    namespace: cryostat
  spec:
    enableCertManager: true
    targetDiscoveryOptions:
      disableBuiltInDiscovery: true
    targetNamespaces:
    - cryostat
    - apps1
    - apps2
```
