### PR TITLE
chore(autoconfig): remove credential API paths from Agent proxy allowlist

### DIFF
--- a/internal/controller/configmaps.go
+++ b/internal/controller/configmaps.go
@@ -303,6 +303,7 @@ func (r *Reconciler) reconcileAgentProxyConfig(ctx context.Context, cr *model.Cr
 			"/health",
 			"/api/v4/discovery",
 			"/api/v4.2/discovery",
+			"/api/v4.3/discovery",
 			"/api/beta/diagnostics",
 			"/api/beta/recordings",
 			"/api/beta/targets",

--- a/internal/controller/configmaps.go
+++ b/internal/controller/configmaps.go
@@ -301,11 +301,9 @@ func (r *Reconciler) reconcileAgentProxyConfig(ctx context.Context, cr *model.Cr
 		CryostatPort:  constants.CryostatHTTPContainerPort,
 		AllowedPathPrefixes: []string{
 			"/health",
-			"/api/v4/credentials",
 			"/api/v4/discovery",
 			"/api/v4.2/discovery",
 			"/api/beta/diagnostics",
-			"/api/beta/discovery",
 			"/api/beta/recordings",
 			"/api/beta/targets",
 		},

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -5339,6 +5339,14 @@ http {
 			proxy_pass http://127.0.0.1:8181$request_uri;
 		}
 
+		location /api/v4.3/discovery/ {
+			proxy_pass http://127.0.0.1:8181$request_uri;
+		}
+
+		location = /api/v4.3/discovery {
+			proxy_pass http://127.0.0.1:8181$request_uri;
+		}
+
 		location /api/beta/diagnostics/ {
 			proxy_pass http://127.0.0.1:8181$request_uri;
 		}
@@ -5437,6 +5445,14 @@ http {
 		}
 
 		location = /api/v4.2/discovery {
+			proxy_pass http://127.0.0.1:8181$request_uri;
+		}
+
+		location /api/v4.3/discovery/ {
+			proxy_pass http://127.0.0.1:8181$request_uri;
+		}
+
+		location = /api/v4.3/discovery {
 			proxy_pass http://127.0.0.1:8181$request_uri;
 		}
 

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -5323,14 +5323,6 @@ http {
 			proxy_pass http://127.0.0.1:8181$request_uri;
 		}
 
-		location /api/v4/credentials/ {
-			proxy_pass http://127.0.0.1:8181$request_uri;
-		}
-
-		location = /api/v4/credentials {
-			proxy_pass http://127.0.0.1:8181$request_uri;
-		}
-
 		location /api/v4/discovery/ {
 			proxy_pass http://127.0.0.1:8181$request_uri;
 		}
@@ -5352,14 +5344,6 @@ http {
 		}
 
 		location = /api/beta/diagnostics {
-			proxy_pass http://127.0.0.1:8181$request_uri;
-		}
-
-		location /api/beta/discovery/ {
-			proxy_pass http://127.0.0.1:8181$request_uri;
-		}
-
-		location = /api/beta/discovery {
 			proxy_pass http://127.0.0.1:8181$request_uri;
 		}
 
@@ -5440,14 +5424,6 @@ http {
 			proxy_pass http://127.0.0.1:8181$request_uri;
 		}
 
-		location /api/v4/credentials/ {
-			proxy_pass http://127.0.0.1:8181$request_uri;
-		}
-
-		location = /api/v4/credentials {
-			proxy_pass http://127.0.0.1:8181$request_uri;
-		}
-
 		location /api/v4/discovery/ {
 			proxy_pass http://127.0.0.1:8181$request_uri;
 		}
@@ -5469,14 +5445,6 @@ http {
 		}
 
 		location = /api/beta/diagnostics {
-			proxy_pass http://127.0.0.1:8181$request_uri;
-		}
-
-		location /api/beta/discovery/ {
-			proxy_pass http://127.0.0.1:8181$request_uri;
-		}
-
-		location = /api/beta/discovery {
 			proxy_pass http://127.0.0.1:8181$request_uri;
 		}
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to: [cryostatio/cryostat#1494](https://github.com/cryostatio/cryostat/issues/1494)
Depends on: [cryostatio/cryostat#1586](https://github.com/cryostatio/cryostat/pull/1586)
Depends on: [cryostatio/cryostat-agent#909](https://github.com/cryostatio/cryostat-agent/pull/909)

## Description of the change:
This change removes the `/api/v4/credentials` and `/api/beta/discovery` path prefixes from the Agent auth proxy's allowlist and adds the `/api/v4.3/discovery` prefix for the new combined registration endpoint (updating the expected nginx config fixtures accordingly). With the simplified registration flow, the Agent no longer calls the Stored Credentials API or the `/api/beta/discovery/credential_exists` check, so the proxy only needs to expose the discovery, recordings, diagnostics, targets (smart trigger sync), and health paths.

Note on compatibility: Agents older than cryostatio/cryostat-agent#909, which use the legacy multi-step registration flow, will no longer be able to register through the Agent proxy after this change. The legacy Discovery Plugin API itself remains available on the Cryostat server.

## Motivation for the change:
See cryostatio/cryostat#1494. The simplified Agent registration flow combines plugin registration, Stored Credential creation, and publication into a single `POST /api/v4.3/discovery/agents` request, so the `/api/v4.3/discovery` prefix is added to the allowlist. This shrinks the proxy surface exposed to Agent traffic down to exactly the endpoints the Agent uses.

## How to manually test:
1. Deploy this operator build along with a Cryostat image containing cryostatio/cryostat#1586 (ex. `make deploy OPERATOR_IMG=<your build>` with `RELATED_IMAGE_CORE` and `RELATED_IMAGE_AGENT_INIT` pointing at images built from cryostatio/cryostat#1586 and cryostatio/cryostat-agent#909).
2. Create a `Cryostat` CR with a target namespace, and deploy a sample app with Agent injection enabled (`cryostat.io/name` and `cryostat.io/namespace` pod labels) in that namespace.
3. Inspect the generated `<cr-name>-agent-proxy` ConfigMap: the rendered `nginx.conf` should contain no `location` blocks for `/api/v4/credentials` or `/api/beta/discovery`, and should contain `location` blocks for `/api/v4.3/discovery`.
4. Verify the Agent registers and publishes through the proxy (a single `POST /api/v4.3/discovery/agents` in the app logs), the app appears as a target in Cryostat, and JFR harvester uploads to `/api/beta/recordings` continue to work.
5. `make test-envtest` passes with the updated expected nginx configurations.

