### PR TITLE
chore(deps): un-pin image hashes in kustomize

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,5 +22,18 @@
   "major": {
     "dependencyDashboardApproval": true
   },
-  "stopUpdatingLabel": "blocked"
+  "minor": {
+    "dependencyDashboardApproval": true
+  },
+  "stopUpdatingLabel": "blocked",
+  "packageRules": [
+    {
+      "description": "Allow floating tags and disable digest pinning in kustomization image patches",
+      "matchDatasources": ["docker"],
+      "matchFileNames": [
+        "config/*/kustomization.yaml"
+      ],
+      "pinDigests": false
+    }
+  ]
 }

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 images:
 - name: controller
   newName: quay.io/cryostat/cryostat-operator
-  newTag: 4.3.0-dev@sha256:fd8670c29c4de0264e141318e970f9f6f018391d9d10d961561166c4ccea16c9
+  newTag: 4.3.0-dev

--- a/config/openshift/kustomization.yaml
+++ b/config/openshift/kustomization.yaml
@@ -19,4 +19,4 @@ patches:
 images:
 - name: console-plugin
   newName: quay.io/cryostat/cryostat-openshift-console-plugin
-  newTag: latest@sha256:0656a0c3fad2e519aa5a20de52d0a64a7f5abbe084bc08bba003199f99cc3e19
+  newTag: latest


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

See #1354

## Description of the change:
Un-pin component container image tags in default kustomize patches. It's acceptable and desirable to use floating tags here.
