### PR TITLE
ci(status): use forked set-commit-status action

### DIFF
--- a/.github/workflows/test-ci-reusable.yml
+++ b/.github/workflows/test-ci-reusable.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Run controller tests
       run: make test-envtest
     - name: Set latest commit status as ${{ job.status }}
-      uses: myrotvorets/set-commit-status-action@0eae800fc349cbcab86e3252bfb2a79cf327d0c0 # master
+      uses: daltonbr/set-commit-status-action@6e8342da330a0fe2a5b25fb8da947cedb27372f2 # v3.0.0
       if: always()
       with:
         sha: ${{ inputs.sha }}

--- a/.github/workflows/test-ci-reusable.yml
+++ b/.github/workflows/test-ci-reusable.yml
@@ -153,7 +153,7 @@ jobs:
         BUNDLE_IMG="${{ steps.push-bundle-to-ghcr.outputs.registry-path }}" \
         make test-scorecard
     - name: Set latest commit status as ${{ job.status }}
-      uses: myrotvorets/set-commit-status-action@0eae800fc349cbcab86e3252bfb2a79cf327d0c0 # master
+      uses: daltonbr/set-commit-status-action@6e8342da330a0fe2a5b25fb8da947cedb27372f2 # v3.0.0
       if: always()
       with:
         sha: ${{ inputs.sha }}


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

See #1342

## Description of the change:
The set-commit-status action has not tagged a release in a couple of years and is using outdated dependencies and depending on a deprecated Node version which GitHub will stop supporting.

This fork addresses those issues in the meantime and allows us to pin to a release hash instead of the original action's `master`: https://github.com/daltonbr/set-commit-status-action/releases/tag/v3.0.0
