### PR TITLE
chore(storage): enhance liveness/readiness probes

### DIFF
--- a/internal/controller/common/resource_definitions/resource_definitions.go
+++ b/internal/controller/common/resource_definitions/resource_definitions.go
@@ -2213,10 +2213,17 @@ func NewStorageContainer(cr *model.CryostatInstance, imageTag string, tls *TLSCo
 		}
 	}
 
-	probeHandler := corev1.ProbeHandler{
+	livenessProbeHandler := corev1.ProbeHandler{
 		HTTPGet: &corev1.HTTPGetAction{
 			Port:   intstr.IntOrString{IntVal: livenessProbePort},
-			Path:   "/status",
+			Path:   "/healthz",
+			Scheme: livenessProbeScheme,
+		},
+	}
+	readinessProbeHandler := corev1.ProbeHandler{
+		HTTPGet: &corev1.HTTPGetAction{
+			Port:   intstr.IntOrString{IntVal: livenessProbePort},
+			Path:   "/readyz",
 			Scheme: livenessProbeScheme,
 		},
 	}
@@ -2231,12 +2238,15 @@ func NewStorageContainer(cr *model.CryostatInstance, imageTag string, tls *TLSCo
 		Args:            args,
 		Ports:           ports,
 		LivenessProbe: &corev1.Probe{
-			ProbeHandler:     probeHandler,
+			ProbeHandler:     livenessProbeHandler,
 			FailureThreshold: 2,
 		},
 		StartupProbe: &corev1.Probe{
-			ProbeHandler:     probeHandler,
+			ProbeHandler:     livenessProbeHandler,
 			FailureThreshold: 13,
+		},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: readinessProbeHandler,
 		},
 		Resources: *NewStorageContainerResource(cr),
 	}

--- a/internal/controller/reconciler_test.go
+++ b/internal/controller/reconciler_test.go
@@ -4512,6 +4512,8 @@ func (t *cryostatTestInput) checkStorageContainer(container *corev1.Container, r
 	Expect(container.EnvFrom).To(BeEmpty())
 	Expect(container.VolumeMounts).To(ConsistOf(t.NewStorageVolumeMounts()))
 	Expect(container.LivenessProbe).To(Equal(t.NewStorageLivenessProbe()))
+	Expect(container.StartupProbe).To(Equal(t.NewStorageStartupProbe()))
+	Expect(container.ReadinessProbe).To(Equal(t.NewStorageReadinessProbe()))
 	Expect(container.SecurityContext).To(Equal(securityContext))
 
 	test.ExpectResourceRequirements(&container.Resources, resources)

--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -3699,11 +3699,48 @@ func (r *TestResources) NewStorageLivenessProbe() *corev1.Probe {
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Port:   intstr.IntOrString{IntVal: port},
-				Path:   "/status",
+				Path:   "/healthz",
 				Scheme: protocol,
 			},
 		},
 		FailureThreshold: 2,
+	}
+}
+
+func (r *TestResources) NewStorageStartupProbe() *corev1.Probe {
+	protocol := corev1.URISchemeHTTP
+	port := int32(8333)
+
+	if r.TLS {
+		protocol = corev1.URISchemeHTTPS
+	}
+	return &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Port:   intstr.IntOrString{IntVal: port},
+				Path:   "/healthz",
+				Scheme: protocol,
+			},
+		},
+		FailureThreshold: 13,
+	}
+}
+
+func (r *TestResources) NewStorageReadinessProbe() *corev1.Probe {
+	protocol := corev1.URISchemeHTTP
+	port := int32(8333)
+
+	if r.TLS {
+		protocol = corev1.URISchemeHTTPS
+	}
+	return &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Port:   intstr.IntOrString{IntVal: port},
+				Path:   "/readyz",
+				Scheme: protocol,
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits): `git commit -S -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Fixes: #1335

## Description of the change:
Uses new SeaweedFS endpoints for liveness and readiness probes.

## Motivation for the change:
This should improve k8s' ability to detect if the storage container is in a good state and ready to accept requests. If it is in a degraded state, the type of degradation should also be more obvious to a user.
